### PR TITLE
document additional live view params

### DIFF
--- a/observability/live-view.mdx
+++ b/observability/live-view.mdx
@@ -33,10 +33,12 @@ kernel logs <your-app> --follow
 
 The `browser_live_view_url` supports additional query parameters to customize the live view:
 
-- `w` / `width`: sets the width of the VM's screen in pixels.
-- `h` / `height`: sets the height of the VM's screen in pixels.
-- `fr`: sets the live view frame rate. The default frame rate is 30 FPS.
-- `readOnly`: when set to `true`, the view will be non-interactive.
+- `w` / `width` (num): sets the width of the VM's screen in pixels.
+- `h` / `height` (num): sets the height of the VM's screen in pixels.
+- `fr` (num): sets the live view frame rate. The default frame rate is 30 FPS.
+- `readOnly` (bool): when set to `true`, the view will be non-interactive.
+
+ Example `https://api.onkernel.com/browser/live?w=1024&h=768&fr=60readOnly=false&jwt=` 
 
 ## Browser persistence
 


### PR DESCRIPTION
added these in the release today

also removed the note about live view + stealth... I think this has been fixed with the change to the proxy extension to exclude api.onkernel.com