### PR TITLE
Add `deploy_app` tool to MCP documentation

### DIFF
--- a/mcp.mdx
+++ b/mcp.mdx
@@ -17,9 +17,9 @@ The **Kernel Model Context Protocol (MCP) server** gives any compatible AI model
 The server provides these tools for AI assistants:
 
 ### Kernel Apps
-  - `deploy_application` - Deploy TypeScript or Python applications to Kernel
-  - `list_apps` - List applications in your Kernel workspace
-  - `invoke_action` - Execute actions in Kernel applications
+  - `deploy_app` - Deploy TypeScript or Python apps to Kernel
+  - `list_apps` - List apps in your Kernel workspace
+  - `invoke_action` - Execute actions in Kernel apps
   - `get_deployment` - Get deployment status and logs
   - `list_deployments` - List all deployments
   - `get_invocation` - Get action invocation details

--- a/mcp.mdx
+++ b/mcp.mdx
@@ -17,6 +17,7 @@ The **Kernel Model Context Protocol (MCP) server** gives any compatible AI model
 The server provides these tools for AI assistants:
 
 ### Kernel Apps
+  - `deploy_application` - Deploy TypeScript or Python applications to Kernel
   - `list_apps` - List applications in your Kernel workspace
   - `invoke_action` - Execute actions in Kernel applications
   - `get_deployment` - Get deployment status and logs


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Added documentation for the `deploy_app` tool, enabling deployment of TypeScript or Python applications to Kernel.

## Why we made these changes
To provide users with essential documentation for the new `deploy_app` tool, detailing how to deploy TypeScript or Python applications to Kernel.

## What changed?
- `mcp.mdx`: Updated to include `deploy_app` in the list of Kernel Apps, describing its functionality for deploying TypeScript or Python applications.

## Validation
- [ ] Confirmed `deploy_app` tool documentation is present and accurate in `mcp.mdx`.
- [ ] Verified the documentation correctly describes the tool's function for TypeScript/Python app deployment.
<span data-mesa-description="end"></span>