### PR TITLE
Update replay code samples

### DIFF
--- a/observability/replays.mdx
+++ b/observability/replays.mdx
@@ -86,6 +86,8 @@ To access all replays for a browser session, you can list and access them via ur
 
 <CodeGroup>
 ```typescript Typescript/Javascript
+import fs from 'fs';
+import { Buffer } from 'buffer';
 // List all replays for the session
 const replays = await kernel.browsers.replays.list(kernelBrowser.session_id);
 
@@ -95,13 +97,21 @@ for (const replay of replays) {
     
     // Download the mp4 file
     const videoData = await kernel.browsers.replays.download(
-        kernelBrowser.session_id, 
-        replay.replay_id
+        replay.replay_id,
+        { id: kernelBrowser.session_id }
     );
+
+    const content = await videoData.blob();
+    const buffer = Buffer.from(await content.arrayBuffer());
+
+    // Save to file
+    const filename = `replay-${replay.replay_id}-${kernelBrowser.session_id}.mp4`;
+    fs.writeFileSync(filename, buffer);
 }
 ```
 
 ```python Python
+import aiofiles
 # List all replays for the session
 replays = client.browsers.replays.list(kernel_browser.session_id)
 
@@ -111,8 +121,18 @@ for replay in replays:
     
     # Download the mp4 file
     video_data = client.browsers.replays.download(
-        kernel_browser.session_id, 
-        replay.replay_id
+        replay_id=replay.replay_id,
+        id=kernel_browser.session_id
     )
+    
+    # Get the content as bytes
+    content = video_data.read()
+    
+    # Save to file using aiofiles
+    filename = f"replay-{replay.replay_id}-{kernel_browser.session_id}.mp4"
+    async with aiofiles.open(filename, 'wb') as f:
+        await f.write(content)
+    
+    print(f"Saved replay to {filename}")
 ```
 </CodeGroup>


### PR DESCRIPTION
## Description

Please provide an explanation of the changes you've made:

[Describe what this PR does and why]

## Implementation Checklist

- [ ] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [ ] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [ ] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [ ] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

[Drag and drop your screenshot/video here or use the following format:]
[![Screenshot description](image-url)]

## Related Issue

Fixes [Github issue link]

[If this corresponds to a fix from another Kernel OSS repo, include this:]

Fixes [Link to other repo]

[Replace with actual issue link, e.g., Fixes https://github.com/username/repo/issues/123]

## Additional Notes

[Any additional context, concerns, or notes for reviewers]

---

<span data-mesa-description="start"></span>
## TL;DR
Updated replay download code samples in the documentation to reflect a new method signature and demonstrate saving video data.

## Why we made these changes
The `replays.download` method signature changed to use keyword arguments, requiring an update to the documentation to provide accurate and functional code examples for users.

## What changed?
- **observability/replays.mdx**: Updated code examples to use the new `replays.download` method with keyword arguments and added demonstrations for saving the downloaded replay video data to a local file in both TypeScript/JavaScript and Python.

## Validation
- `mintlify dev` works locally.
<span data-mesa-description="end"></span>