### PR TITLE
Update `list_apps` description in MCP documentation to clarify it ref…

### DIFF
--- a/mcp.mdx
+++ b/mcp.mdx
@@ -18,7 +18,7 @@ The server provides these tools for AI assistants:
 
 ### Kernel Apps
   - `deploy_app` - Deploy TypeScript or Python apps to Kernel
-  - `list_apps` - List apps in your Kernel workspace
+  - `list_apps` - List apps in your Kernel organization
   - `invoke_action` - Execute actions in Kernel apps
   - `get_deployment` - Get deployment status and logs
   - `list_deployments` - List all deployments


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Corrected a typo in the MCP documentation for the `list_apps` tool, clarifying its scope.

## Why we made these changes
To improve the accuracy and clarity of the MCP documentation, ensuring users understand that `list_apps` operates within an 'organization' rather than a 'workspace'.

## What changed?
- `mcp.mdx`: Updated the description for the `list_apps` tool to specify it lists Kernel apps within an 'organization' instead of a 'workspace'.

## Validation
- Visual inspection of the updated documentation.
<span data-mesa-description="end"></span>