### PR TITLE
login, logout, auth commands - oauth vs api key auth

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -8,7 +8,7 @@ This quickstart guide will help you create, deploy, and run your first app on Ke
 
 - `brew` for the Kernel CLI
 - `npm` or `pnpm` to generate a sample Kernel app
-- A [Kernel account](/reference/api-keys)
+- A [Kernel account and authentication setup](/reference/api-keys)
 
 > **Note:** You can also deploy and invoke apps using the [Kernel MCP server](/mcp) from AI assistants (Cursor, Goose, Claude, etc.).
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -8,7 +8,7 @@ This quickstart guide will help you create, deploy, and run your first app on Ke
 
 - `brew` for the Kernel CLI
 - `npm` or `pnpm` to generate a sample Kernel app
-- A [Kernel account](/reference/api-keys) with an API key
+- A [Kernel account](/reference/api-keys)
 
 > **Note:** You can also deploy and invoke apps using the [Kernel MCP server](/mcp) from AI assistants (Cursor, Goose, Claude, etc.).
 
@@ -37,13 +37,27 @@ Verify the installation exists:
 which kernel
 ```
 
-## 3. Set your Kernel API key
+## 3. Authenticate with Kernel
 
-Configure your environment with your Kernel API key:
+### Option A: OAuth Login (Recommended)
+
+The easiest way to authenticate is using OAuth:
+
+```bash
+kernel login
+```
+
+This will open your browser to complete the authentication flow. Your credentials will be securely stored and automatically refreshed.
+
+### Option B: API Key
+
+Alternatively, you can use an API key for authentication:
 
 ```bash
 export KERNEL_API_KEY=<YOUR_API_KEY>
 ```
+
+You can create an API key from the [Kernel dashboard](https://dashboard.onkernel.com).
 
 ## 4. Deploy the sample app on Kernel
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -39,8 +39,6 @@ which kernel
 
 ## 3. Authenticate with Kernel
 
-### Option A: OAuth Login (Recommended)
-
 The easiest way to authenticate is using OAuth:
 
 ```bash
@@ -49,8 +47,7 @@ kernel login
 
 This will open your browser to complete the authentication flow. Your credentials will be securely stored and automatically refreshed.
 
-### Option B: API Key
-
+<Info>
 Alternatively, you can use an API key for authentication:
 
 ```bash
@@ -58,6 +55,7 @@ export KERNEL_API_KEY=<YOUR_API_KEY>
 ```
 
 You can create an API key from the [Kernel dashboard](https://dashboard.onkernel.com).
+</Info>
 
 ## 4. Deploy the sample app on Kernel
 

--- a/reference/api-keys.mdx
+++ b/reference/api-keys.mdx
@@ -4,11 +4,11 @@ title: "API Keys"
 
 ## Authentication Methods
 
-Kernel supports two authentication methods for the CLI:
+Kernel supports two authentication methods:
 
-### OAuth 2.0 (Recommended)
+### OAuth 2.0 (Recommended for CLI)
 
-The preferred authentication method is OAuth 2.0, which provides secure browser-based authentication with automatic token refresh:
+The preferred authentication method to use the CLI is OAuth 2.0, which provides secure browser-based authentication with automatic token refresh:
 
 ```bash
 kernel login

--- a/reference/api-keys.mdx
+++ b/reference/api-keys.mdx
@@ -1,7 +1,40 @@
 ---
-title: "Creating API Keys"
+title: "API Keys"
 ---
 
-To get started, sign up for a Kernel account and create an API key [here](https://dashboard.onkernel.com/sign-up). Then follow our [quickstart guide](/quickstart) to launch your first web agent or browser automation.
+## Authentication Methods
+
+Kernel supports two authentication methods for the CLI:
+
+### OAuth 2.0 (Recommended)
+
+The preferred authentication method is OAuth 2.0, which provides secure browser-based authentication with automatic token refresh:
+
+```bash
+kernel login
+```
+
+This method stores your credentials securely in your system keychain and handles token refresh automatically.
+
+### API Keys
+
+API keys are an alternative authentication method, particularly useful for programmatic access, CI/CD pipelines, or when OAuth is not suitable:
+
+```bash
+export KERNEL_API_KEY=<YOUR_API_KEY>
+```
+
+## Creating API Keys
+
+To create an API key:
+
+1. Sign up for a Kernel account [here](https://dashboard.onkernel.com/sign-up)
+2. Navigate to your dashboard settings
+3. Generate a new API key
+4. Store it securely and use it in your environment
+
+## Getting Started
+
+Once you have your authentication set up, follow our [quickstart guide](/quickstart) to launch your first web agent or browser automation.
 
 You can find information about pricing on our [website](https://www.onkernel.com/#pricing).

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -19,7 +19,25 @@ pnpm install -g onkernel/cli
 npm install -g onkernel/cli
 ```
 
-Then, set your Kernel API key for deployments
+## Authentication
+
+The Kernel CLI supports two authentication methods:
+
+### OAuth 2.0 (Recommended)
+
+The preferred method is OAuth 2.0 with PKCE, which provides secure browser-based authentication:
+
+```bash
+# Login via browser
+kernel login
+```
+
+This opens your browser to complete the OAuth flow. Your tokens are securely stored in your system keychain (macOS/Windows) or a local file (Linux).
+
+### API Key
+
+You can also authenticate using an API key:
+
 ```bash
 export KERNEL_API_KEY=<API_KEY>
 ```
@@ -31,7 +49,15 @@ After installation, verify that Kernel CLI was installed correctly:
 which kernel
 ```
 
-## Commands
+## Authentication Commands
+
+| Command | Description |
+|---------|-------------|
+| `kernel login [--force] [--device]` | Initiates OAuth 2.0 authentication flow via browser. Use `--force` to re-authenticate when already logged in, `--device` for headless environments (not yet implemented) |
+| `kernel logout` | Clears stored authentication tokens and logs out |
+| `kernel auth [--verbose]` | Displays current authentication status, user details, and token expiry. Use `--verbose` for detailed information including user ID and storage method |
+
+## App Management Commands
 
 | Command | Optional Flags | Description |
 |---------|-------------| -------------|
@@ -44,7 +70,43 @@ which kernel
 | | `--follow` | Follows the logs. Optional. |
 | | `--log-level <log_level>` | Specify the log level to print: trace, debug, info, warn, error, fatal, print. Optional. |
 | | `--no-color` | Disables color output|
-| `kernel browser delete <persistent_browser_id>` | - | Deletes the specified persistent browser |
-| `kernel help [command]` | - | Displays help information about Kernel commands. |
 
-This may not be the full list of available CLI commands. Use `kernel --help` in your command line.
+## Browser Management Commands
+
+| Command | Description |
+|---------|-------------|
+| `kernel browser delete <persistent_browser_id>` | Deletes the specified persistent browser |
+
+## General Commands
+
+| Command | Description |
+|---------|-------------|
+| `kernel help [command]` | Displays help information about Kernel commands |
+
+## Authentication Flow
+
+1. **Login**: Run `kernel login` to authenticate via OAuth 2.0
+   - Opens your browser to complete the authentication
+   - Displays your organization after successful login
+   - If already logged in, shows current status (use `--force` to re-authenticate)
+
+2. **Check Status**: Use `kernel auth` to view your authentication details
+   - Shows authentication method (OAuth vs API Key)
+   - Displays user email and organization
+   - Shows token expiry status and remaining time
+   - Use `--verbose` for additional details like storage method
+
+3. **Secure Storage**: Tokens are stored securely
+   - macOS/Windows: OS Keychain
+   - Linux: Local file (~/.config/kernel/credentials)
+   - Automatic token refresh when needed
+
+4. **Logout**: Use `kernel logout` to clear stored credentials
+   - Shows which organization you're logging out from
+   - Removes all stored authentication tokens
+
+The CLI supports both OAuth and API key authentication, with OAuth being the recommended approach for interactive use.
+
+<Info>
+This may not be the full list of available CLI commands. Use `kernel --help` in your command line for the most up-to-date command reference.
+</Info>

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -13,10 +13,10 @@ Install the Kernel CLI using your favorite package manager:
 brew install onkernel/tap/kernel
 
 # Using pnpm
-pnpm install -g onkernel/cli
+pnpm install -g @onkernel/cli
 
 # Using npm
-npm install -g onkernel/cli
+npm install -g @onkernel/cli
 ```
 
 ## Authentication
@@ -49,6 +49,14 @@ After installation, verify that Kernel CLI was installed correctly:
 which kernel
 ```
 
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version`, `-v` | Print the CLI version |
+| `--no-color` | Disable color output |
+| `--log-level <level>` | Set the log level (trace, debug, info, warn, error, fatal, print) |
+
 ## Authentication Commands
 
 | Command | Description |
@@ -62,51 +70,40 @@ which kernel
 | Command | Optional Flags | Description |
 |---------|-------------| -------------|
 | `kernel deploy <entrypoint_file_name>` | - | Deploys an app to Kernel from the current directory. |
-| | `--env <ENV_VAR=VAL>` | Adds environment variables to the app. Expects the form `ENV_VAR=VAL` delimited by spaces. Optional. |
+| | `--version <version>` | Specify a version for the app (default: latest). Optional. |
+| | `--force` | Allow overwrite of an existing version with the same name. Optional. |
+| | `--env <ENV_VAR=VAL>`, `-e` | Adds environment variables to the app. Expects the form `ENV_VAR=VAL` delimited by spaces. May be specified multiple times. Optional. |
+| | `--env-file <file>` | Read environment variables from a file (.env format). May be specified multiple times. Optional. |
 | `kernel invoke <app_name> <action_name>` | - | Invokes a specific app action by its name. Generates an Invocation. |
-| | `--payload <payload_data>` | Includes the specified parameters. Expects a stringified JSON object. Optional. |
+| | `--version <version>`, `-v` | Specify a version of the app to invoke (default: latest). Optional. |
+| | `--payload <payload_data>`, `-p` | Includes the specified parameters. Expects a stringified JSON object. Optional. |
+| | `--sync`, `-s` | Invoke synchronously (default false). A synchronous invocation opens a long-lived HTTP POST that times out after 60 seconds. Optional. |
 | | `ctrl-c` | Terminates the running invocation in your CLI. Also destroys any associated browsers. |
+| `kernel app list` | - | List deployed application versions. |
+| | `--name <app_name>` | Filter by application name. Optional. |
+| | `--version <version>` | Filter by version label. Optional. |
+| `kernel app history <app_name>` | - | Show deployment history for an application. |
 | `kernel logs <app_name>` | - | Prints the logs for the specified app. |
-| | `--follow` | Follows the logs. Optional. |
-| | `--log-level <log_level>` | Specify the log level to print: trace, debug, info, warn, error, fatal, print. Optional. |
-| | `--no-color` | Disables color output|
+| | `--version <version>` | Specify a version of the app (default: latest). Optional. |
+| | `--follow`, `-f` | Follow logs in real-time (stream continuously). Optional. |
+| | `--since <time>`, `-s` | How far back to retrieve logs (e.g., 5m, 1h). Defaults to 5m if not following, 5s if following. Optional. |
+| | `--with-timestamps` | Include timestamps in each log line. Optional. |
 
 ## Browser Management Commands
 
 | Command | Description |
 |---------|-------------|
-| `kernel browser delete <persistent_browser_id>` | Deletes the specified persistent browser |
+| `kernel browsers list` | List running or persistent browsers |
+| `kernel browsers delete` | Delete a browser. Must specify either `--by-persistent-id` or `--by-id` |
+| | `--by-persistent-id <id>` | Delete browser by persistent ID |
+| | `--by-id <id>` | Delete browser by session ID |
+| | `--yes`, `-y` | Skip confirmation prompt |
+| `kernel browsers view` | Get the live view URL for a browser. Must specify either `--by-persistent-id` or `--by-id` |
+| | `--by-persistent-id <id>` | View browser by persistent ID |
+| | `--by-id <id>` | View browser by session ID |
 
 ## General Commands
 
 | Command | Description |
 |---------|-------------|
 | `kernel help [command]` | Displays help information about Kernel commands |
-
-## Authentication Flow
-
-1. **Login**: Run `kernel login` to authenticate via OAuth 2.0
-   - Opens your browser to complete the authentication
-   - Displays your organization after successful login
-   - If already logged in, shows current status (use `--force` to re-authenticate)
-
-2. **Check Status**: Use `kernel auth` to view your authentication details
-   - Shows authentication method (OAuth vs API Key)
-   - Displays user email and organization
-   - Shows token expiry status and remaining time
-   - Use `--log-level debug` for additional details like storage method
-
-3. **Secure Storage**: Tokens are stored securely
-   - macOS/Windows: OS Keychain
-   - Linux: Local file (~/.config/kernel/credentials)
-   - Automatic token refresh when needed
-
-4. **Logout**: Use `kernel logout` to clear stored credentials
-   - Shows which organization you're logging out from
-   - Removes all stored authentication tokens
-
-The CLI supports both OAuth and API key authentication, with OAuth being the recommended approach for interactive use.
-
-<Info>
-This may not be the full list of available CLI commands. Use `kernel --help` in your command line for the most up-to-date command reference.
-</Info>

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -53,9 +53,9 @@ which kernel
 
 | Command | Description |
 |---------|-------------|
-| `kernel login [--force] [--device]` | Initiates OAuth 2.0 authentication flow via browser. Use `--force` to re-authenticate when already logged in, `--device` for headless environments (not yet implemented) |
+| `kernel login [--force]` | Initiates OAuth 2.0 authentication flow via browser. Use `--force` to re-authenticate when already logged in |
 | `kernel logout` | Clears stored authentication tokens and logs out |
-| `kernel auth [--verbose]` | Displays current authentication status, user details, and token expiry. Use `--verbose` for detailed information including user ID and storage method |
+| `kernel auth` | Displays current authentication status, user details, and token expiry. Use `--log-level debug` for detailed information including user ID and storage method |
 
 ## App Management Commands
 
@@ -94,7 +94,7 @@ which kernel
    - Shows authentication method (OAuth vs API Key)
    - Displays user email and organization
    - Shows token expiry status and remaining time
-   - Use `--verbose` for additional details like storage method
+   - Use `--log-level debug` for additional details like storage method
 
 3. **Secure Storage**: Tokens are stored securely
    - macOS/Windows: OS Keychain


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Updated CLI documentation to introduce new `login`, `logout`, and `auth` commands, prioritizing OAuth-based authentication as the recommended method.

## Why we made these changes
To provide clear, up-to-date documentation for Kernel CLI authentication, guiding users to the new, recommended OAuth flow while still supporting API keys.

## What changed?
- `quickstart.mdx`: Prioritized `kernel login` (OAuth) as the primary authentication method; clarified API key usage.
- `reference/api-keys.mdx`: Renamed, expanded on both OAuth and API key methods, and improved API key creation steps.
- `reference/cli.mdx`: Reorganized CLI docs, added detailed sections for `kernel login`, `logout`, and `auth` commands, including an 'Authentication Flow' guide.

## Validation
- [ ] Verified all new commands (`login`, `logout`, `auth`) are accurately documented.
- [ ] Confirmed OAuth flow is clearly explained and recommended.
- [ ] Ensured API key instructions are correct and accessible.
- [ ] Checked overall clarity and consistency across documentation files.
<span data-mesa-description="end"></span>