### PR TITLE
move mcp and cli doc up in IA

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,6 +42,7 @@
     "tabs": [
       {
         "tab": "Guides",
+        "icon": "book-open",
         "groups": [
           {
             "group": "Get Started",
@@ -74,13 +75,6 @@
               "apps/stop",
               "apps/status",
               "apps/logs"
-            ]
-          },
-          {
-            "group": "API",
-            "pages": [
-              "reference/cli",
-              "reference/mcp-server"
             ]
           },
           {
@@ -117,7 +111,22 @@
       },
       {
         "tab": "API Reference",
+        "icon": "code",
         "openapi": "https://app.stainless.com/api/spec/documented/kernel/openapi.documented.yml"
+      },
+      {
+        "tab": "MCP",
+        "icon": "code-fork",
+        "pages": [
+          "reference/mcp-server"
+        ]
+      },
+      {
+        "tab": "CLI",
+        "icon": "terminal",
+        "pages": [
+          "reference/cli"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Description

Saw this IA on vapi's docs and thought they were nice:
<img width="1093" height="365" alt="Screenshot 2025-08-18 at 12 10 08 PM" src="https://github.com/user-attachments/assets/ba4bcb85-e6d3-4837-99ad-014a322ae9c0" />
<img width="1318" height="312" alt="Screenshot 2025-08-18 at 12 10 13 PM" src="https://github.com/user-attachments/assets/e340117a-f3b1-4ea0-8011-d7c6953a16d9" />

---

<!-- mesa-description-start -->
## TL;DR
Reorganized the documentation navigation by promoting 'CLI' and 'MCP Server' to top-level tabs and adding icons to key sections.

## Why we made these changes
To improve the discoverability of important documentation sections like CLI and MCP Server, and enhance the overall user experience of the navigation, inspired by a more intuitive information architecture.

## What changed?
- **docs.json**: Restructured the documentation's `docs.json` file to:
    - Remove the 'API' section from the 'Guides' group.
    - Elevate 'CLI' and 'MCP Server' documentation to their own top-level navigation tabs ('CLI' and 'MCP').
    - Add icons to the 'Guides' and 'API Reference' tabs for better visual clarity.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->