### PR TITLE
feat(docs): auto-generate OpenAPI code snippets

### DIFF
--- a/.github/scripts/code_samples.config.json
+++ b/.github/scripts/code_samples.config.json
@@ -1,0 +1,7 @@
+{
+	"variants": {
+		"post /invocations": [
+			{ "name": "async", "overrides": { "async": true } }
+		]
+	}
+}

--- a/.github/scripts/generate_code_samples.ts
+++ b/.github/scripts/generate_code_samples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { readdir, readFile, writeFile } from "fs/promises";
+import { readdir, readFile, writeFile, mkdir, unlink } from "fs/promises";
 import path from "path";
 import yaml from "js-yaml"; // for YAML support
 
@@ -8,10 +8,226 @@ const OPENAPI_URL =
   "https://app.stainless.com/api/spec/documented/kernel/openapi.documented.yml";
 
 const TARGET_DIRS = ["browsers", "apps"]; // adjust as needed
+const SNIPPETS_ROOT = path.resolve("snippets/openapi");
+
+// Only emit code samples for these languages (normalized): e.g., ["typescript", "python"]
+const TARGET_LANGUAGES = ["typescript", "python"] as const;
+type SupportedLanguage = (typeof TARGET_LANGUAGES)[number] | "javascript" | "go";
+
+function normalizeLang(input: string): SupportedLanguage {
+  const lc = (input || "").toLowerCase();
+  if (lc === "ts" || lc === "typescript") return "typescript";
+  if (lc === "py" || lc === "python") return "python";
+  if (lc === "js" || lc === "javascript" || lc === "node" || lc === "node.js" || lc === "nodejs") return "javascript";
+  if (lc === "go" || lc === "golang") return "go";
+  return lc as SupportedLanguage;
+}
+
+function renderFenceInfo(lang: SupportedLanguage, rawLang: string): string {
+  if (lang === "typescript" || lang === "javascript") return "typescript index.ts";
+  if (lang === "python") return "python main.py";
+  return `${lang} ${toTitleCase(rawLang)}`;
+}
+
+function renderValueForLanguage(lang: SupportedLanguage, value: unknown): string {
+  const type = typeof value;
+  if (type === "boolean") {
+    const b = value as boolean;
+    return lang === "python" ? (b ? "True" : "False") : b ? "true" : "false";
+  }
+  if (type === "number") return String(value);
+  if (type === "string") {
+    // Use double quotes across both for simplicity
+    return JSON.stringify(value);
+  }
+  // Fallback to JSON for objects/arrays; Python will be JSON-like which is acceptable for docs
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function injectParamsIntoObjectLiteral(
+  lang: SupportedLanguage,
+  objectLiteral: string,
+  params: Record<string, unknown>
+): string {
+  let updated = objectLiteral;
+  for (const [key, val] of Object.entries(params)) {
+    const valueStr = renderValueForLanguage(lang, val);
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Try to replace existing key first (handles both quoted and unquoted keys)
+    const keyPatterns = [
+      new RegExp(`(([,\{\n\r\t\s])${escapedKey}\\s*:\\s*)([^,\n}]+)`, "m"), // JS/TS style key: value
+      new RegExp(`(([,\{\n\r\t\s])\"${escapedKey}\"\\s*:\\s*)([^,\n}]+)`, "m"), // JSON/Python style "key": value
+    ];
+    let replaced = false;
+    for (const pattern of keyPatterns) {
+      if (pattern.test(updated)) {
+        updated = updated.replace(pattern, `$1${valueStr}`);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      // Insert after the first opening brace
+      if (lang === "python") {
+        const insertion = `"${key}": ${valueStr}, `;
+        updated = updated.replace(/\{\s*/, (m) => m + insertion);
+      } else {
+        const isMultiline = /\{\s*\n/.test(updated);
+        const indentMatch = updated.match(/\{\s*\n([ \t]*)/);
+        const indent = indentMatch?.[1] ?? "";
+        const insertion = isMultiline
+          ? `${indent}${key}: ${valueStr},\n${indent}`
+          : `${key}: ${valueStr}, `;
+        if (isMultiline) {
+          // Normalize to a single newline after '{' then insert our line
+          updated = updated.replace(/\{\s*/, '{\n');
+          updated = updated.replace(/\{\n/, `{\n${insertion}`);
+        } else {
+          updated = updated.replace(/\{\s*/, (m) => m + insertion);
+        }
+      }
+    }
+  }
+  return updated;
+}
+
+function injectParamsIntoPythonArgs(
+  argList: string,
+  params: Record<string, unknown>
+): string {
+  let updated = argList;
+  // Ensure trailing comma handling is clean; if arguments are on multiple lines, add newline before inserted kwarg
+  for (const [key, val] of Object.entries(params)) {
+    const valueStr = renderValueForLanguage("python", val);
+    const pattern = new RegExp(`(\\b${key}\\s*=)\\s*([^,\n)]+)`, "m");
+    if (pattern.test(updated)) {
+      updated = updated.replace(pattern, `$1 ${valueStr}`);
+    } else {
+      const trimmed = updated.trim();
+      if (trimmed.length === 0) {
+        updated = `${key}=${valueStr}`;
+      } else {
+        const isMultiline = /\n/.test(updated);
+        const hasTrailingComma = /,\s*$/.test(updated);
+        if (isMultiline) {
+          const firstArgIndentMatch = updated.match(/^([ \t]+)[A-Za-z_]/m);
+          const lastLineIndentMatch = updated.match(/\n([ \t]*)[^\n]*$/);
+          const indent = firstArgIndentMatch?.[1] ?? lastLineIndentMatch?.[1] ?? "    ";
+          const prefix = updated.replace(/\s*$/, "");
+          const commaPrefix = hasTrailingComma ? prefix : `${prefix},`;
+          updated = `${commaPrefix}\n${indent}${key}=${valueStr},`;
+        } else {
+          const sep = hasTrailingComma ? " " : ", ";
+          updated = `${updated.replace(/\s*$/, "")}${sep}${key}=${valueStr}`;
+        }
+      }
+    }
+  }
+  return updated;
+}
+
+function applyOverridesToSource(
+  lang: SupportedLanguage,
+  src: string,
+  overrides?: Record<string, unknown>
+): string {
+  if (!overrides || Object.keys(overrides).length === 0) return src;
+  // Heuristic: find the first object literal in a create(...) call and inject params
+  const createCall = /(invocations\.(create|new)\()([\s\S]*?)(\))/m;
+  const match = src.match(createCall);
+  if (!match) return src;
+  const before = src.slice(0, match.index ?? 0);
+  const after = src.slice((match.index ?? 0) + match[0].length);
+  const inside = match[3] ?? "";
+  const objectMatch = inside.match(/\{[\s\S]*?\}/m);
+  if (objectMatch) {
+    const objBefore = inside.slice(0, objectMatch.index!);
+    const obj = objectMatch[0];
+    const objAfter = inside.slice((objectMatch.index || 0) + objectMatch[0].length);
+    const injected = injectParamsIntoObjectLiteral(lang, obj, overrides);
+    const newInside = objBefore + injected + objAfter;
+    return before + match[1] + newInside + match[4] + after;
+  }
+  if (lang === "python") {
+    const injectedArgs = injectParamsIntoPythonArgs(inside, overrides);
+    const needsNewlineBeforeParen = /\n/.test(injectedArgs) && !/\n\s*$/.test(injectedArgs);
+    const joiner = needsNewlineBeforeParen ? "\n" : "";
+    return before + match[1] + injectedArgs + joiner + match[4] + after;
+  }
+  return src;
+}
+
+function parseOverridesString(raw: string): Record<string, unknown> | undefined {
+  const trim = raw.trim();
+  // Strip one layer of surrounding braces if present
+  let inner = trim;
+  if (inner.startsWith("{") && inner.endsWith("}")) {
+    inner = inner.slice(1, -1).trim();
+  }
+  // If wrapped as {{ ... }}, strip outer again
+  if (inner.startsWith("{") && inner.endsWith("}")) {
+    inner = inner.slice(1, -1).trim();
+  }
+  // Rebuild as JSON object string; heuristically quote keys
+  let jsonish = `{ ${inner} }`;
+  // Quote unquoted keys (simple heuristic)
+  jsonish = jsonish.replace(/([,{\s])([A-Za-z_][A-Za-z0-9_]*)\s*:/g, '$1"$2":');
+  // Normalize single quotes to double quotes
+  jsonish = jsonish.replace(/'([^']*)'/g, '"$1"');
+  try {
+    return JSON.parse(jsonish);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractOverridesFromAttributes(attrs: string | undefined): Record<string, unknown> | undefined {
+  if (!attrs) return undefined;
+  const idx = attrs.indexOf("overrides=");
+  if (idx === -1) return undefined;
+  // Find first '{' after 'overrides='
+  const start = attrs.indexOf('{', idx);
+  if (start === -1) return undefined;
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < attrs.length; i++) {
+    const ch = attrs[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return undefined;
+  const raw = attrs.slice(start, end + 1);
+  return parseOverridesString(raw);
+}
 
 function toTitleCase(input: string): string {
   if (!input) return "";
   return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
+}
+
+type VariantConfig = { name: string; overrides?: Record<string, unknown> };
+type CodeSamplesConfig = {
+  variants?: Record<string, VariantConfig[]>; // key: "method /path" lowercased
+};
+
+async function readConfig(): Promise<CodeSamplesConfig> {
+  const configPath = path.resolve(".github/scripts/code_samples.config.json");
+  try {
+    const text = await readFile(configPath, "utf8");
+    return JSON.parse(text) as CodeSamplesConfig;
+  } catch {
+    return {};
+  }
 }
 
 async function fetchOpenAPISpec() {
@@ -46,7 +262,8 @@ async function getMdxFiles(dir: string): Promise<string[]> {
 function extractCodeSamples(
   spec: any,
   endpoint: string,
-  method?: string
+  method?: string,
+  overrides?: Record<string, unknown>
 ): string {
   const pathItem = spec.paths?.[endpoint];
   if (!pathItem) return `⚠️ No spec found for ${endpoint}`;
@@ -60,18 +277,19 @@ function extractCodeSamples(
     if (op?.["x-codeSamples"]) {
       for (const sample of op["x-codeSamples"]) {
         const rawLang = typeof sample.lang === "string" ? sample.lang : "";
-        const lang = rawLang.toLowerCase();
+        const normalized = normalizeLang(rawLang);
+        const allowedNormalized = ["typescript", "javascript", "python"] as const;
+        if (!(allowedNormalized as readonly string[]).includes(normalized)) continue;
+        const displayLang: "typescript" | "python" =
+          normalized === "python" ? "python" : "typescript";
 
-        let fenceInfo: string;
-        if (["typescript", "ts", "javascript", "js"].includes(lang)) {
-          fenceInfo = "typescript Typescript";
-        } else if (rawLang) {
-          fenceInfo = `${lang} ${toTitleCase(rawLang)}`;
-        } else {
-          fenceInfo = "";
-        }
-
-        blocks.push(`\n\`\`\`${fenceInfo}\n${sample.source.trim()}\n\`\`\`\n`);
+        const fenceInfo = renderFenceInfo(displayLang, rawLang);
+        const transformedSource = applyOverridesToSource(
+          displayLang,
+          String(sample.source ?? "").trim(),
+          overrides
+        );
+        blocks.push(`\n\`\`\`${fenceInfo}\n${transformedSource}\n\`\`\`\n`);
       }
     }
   }
@@ -83,28 +301,109 @@ function extractCodeSamples(
       } ${endpoint}`;
 }
 
+function slugifyEndpoint(method: string, endpoint: string): string {
+  const m = (method || "").toLowerCase().replace(/[^a-z]/g, "");
+  let ep = endpoint.replace(/^\//, "");
+  // Unwrap path params like {id} -> id
+  ep = ep.replace(/\{([^}]+)\}/g, "$1");
+  // Sanitize and normalize
+  ep = ep
+    .replace(/[^a-zA-Z0-9\-/_]/g, "-")
+    .replace(/[\/]/g, "-")
+    .replace(/--+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${m}-${ep}`.toLowerCase();
+}
+
+async function writeSnippetFile(filePath: string, blocks: string) {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const content = `<CodeGroup dropdown>\n${blocks.trim()}\n</CodeGroup>\n`;
+  await writeFile(filePath, content, "utf8");
+}
+
+async function generateSnippets(spec: any) {
+  const config = await readConfig();
+  const paths = spec.paths || {};
+  for (const endpoint of Object.keys(paths)) {
+    const pathItem = paths[endpoint];
+    for (const method of Object.keys(pathItem)) {
+      const key = `${method.toLowerCase()} ${endpoint}`.toLowerCase();
+      const baseBlocks = extractCodeSamples(spec, endpoint, method).trim();
+      if (!baseBlocks.startsWith("⚠️ ")) {
+        const baseSlug = slugifyEndpoint(method, endpoint);
+        const baseFile = path.join(SNIPPETS_ROOT, `${baseSlug}.mdx`);
+        await writeSnippetFile(baseFile, baseBlocks);
+        console.log(`🧩 Wrote snippet: ${path.relative(process.cwd(), baseFile)}`);
+      }
+      const variants = config.variants?.[key] || [];
+      for (const variant of variants) {
+        const vBlocks = extractCodeSamples(spec, endpoint, method, variant.overrides).trim();
+        if (!vBlocks.startsWith("⚠️ ")) {
+          const vSlug = `${slugifyEndpoint(method, endpoint)}-${variant.name}`;
+          const vFile = path.join(SNIPPETS_ROOT, `${vSlug}.mdx`);
+          await writeSnippetFile(vFile, vBlocks);
+          console.log(`🧩 Wrote snippet: ${path.relative(process.cwd(), vFile)}`);
+        }
+      }
+    }
+  }
+}
+
+async function cleanupOldSnippets() {
+  try {
+    const entries = await readdir(SNIPPETS_ROOT, { withFileTypes: true });
+    const stale = entries
+      .filter((e) => e.isFile())
+      .map((e) => e.name)
+      .filter((name) => name.endsWith("-.mdx"));
+    for (const name of stale) {
+      const full = path.join(SNIPPETS_ROOT, name);
+      await unlink(full);
+      console.log(`🧹 Removed stale snippet: ${path.relative(process.cwd(), full)}`);
+    }
+  } catch {
+    // ignore if folder doesn't exist yet
+  }
+}
+
 async function processFile(file: string, spec: any) {
   let content = await readFile(file, "utf8");
 
   // Matches {{ get /path }} or {{ post /path }} or {{ /path }}
   const mustacheRegex =
-    /\{\{\s*(?:(get|post|put|delete|patch|options|head)\s+)?(\/[^\s}]+)\s*\}\}/gi;
+    /\{\{\s*(?:(get|post|put|delete|patch|options|head)\s+)?(\/[^\s}]+)(?:\s+(\{[\s\S]*?\}))?\s*\}\}/gi;
 
   // Matches <OpenAPICodeGroup>get /path</OpenAPICodeGroup>
   // or <OpenAPICodeGroup>/path</OpenAPICodeGroup>
   const tagRegex =
-    /<OpenAPICodeGroup>\s*(?:(get|post|put|delete|patch|options|head)\s+)?(\/[^\s<]+)\s*<\/OpenAPICodeGroup>/gi;
+    /<OpenAPICodeGroup([^>]*)>\s*(?:(get|post|put|delete|patch|options|head)\s+)?(\/[^\s<]+)(?:\s+(\{[\s\S]*?\}))?\s*<\/OpenAPICodeGroup>/gi;
 
   let changed = false;
-  content = content.replace(mustacheRegex, (_, method, endpoint) => {
+  content = content.replace(mustacheRegex, (_, method, endpoint, jsonOverrides) => {
     changed = true;
-    return extractCodeSamples(spec, endpoint, method);
+    let overrides: Record<string, unknown> | undefined = undefined;
+    if (jsonOverrides) {
+      try {
+        overrides = JSON.parse(jsonOverrides);
+      } catch {
+        console.warn(`Failed to parse overrides JSON in ${file} for ${endpoint}`);
+      }
+    }
+    return extractCodeSamples(spec, endpoint, method, overrides);
   });
 
-  content = content.replace(tagRegex, (_, method, endpoint) => {
+  content = content.replace(tagRegex, (_, attrs, method, endpoint, jsonOverrides) => {
     changed = true;
-    const blocks = extractCodeSamples(spec, endpoint, method).trim();
-    return `<CodeGroup>\n${blocks}\n</CodeGroup>`;
+    let overrides: Record<string, unknown> | undefined = undefined;
+    const attrOverrides = extractOverridesFromAttributes(attrs);
+    if (attrOverrides) overrides = { ...attrOverrides };
+    if (jsonOverrides) {
+      const inline = parseOverridesString(jsonOverrides);
+      if (inline) overrides = { ...(overrides || {}), ...inline };
+    }
+    const blocks = extractCodeSamples(spec, endpoint, method, overrides).trim();
+    return `<CodeGroup dropdown>\n${blocks}\n</CodeGroup>`;
   });
 
   if (changed) {
@@ -115,6 +414,10 @@ async function processFile(file: string, spec: any) {
 
 async function main() {
   const spec = await fetchOpenAPISpec();
+
+  // Always generate snippet files from OpenAPI
+  await cleanupOldSnippets();
+  await generateSnippets(spec);
 
   for (const dir of TARGET_DIRS) {
     const files = await getMdxFiles(dir);

--- a/apps/invoke.mdx
+++ b/apps/invoke.mdx
@@ -2,53 +2,22 @@
 title: "Invoking"
 ---
 
+import SynchronousInvocation from '/snippets/openapi/post-invocations.mdx';
+import AsyncInvocation from '/snippets/openapi/post-invocations-async.mdx';
+
 ## Via API
 
 You can invoke your app by making a `POST` request to Kernel's API. **For automations and agents that take longer than 100 seconds, use [async invocations](/apps/invoke#asynchronous-invocations).**
 
 <Info>Synchronous invocations time out after 100 seconds.</Info>
 
-<OpenAPICodeGroup>post /invocations</OpenAPICodeGroup>
+<SynchronousInvocation />
 
 ### Asynchronous invocations
 
 For long running jobs, use asynchronous invocations to trigger Kernel actions without waiting for the result. You can then poll its [status](/apps/status) for the result.
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
-
-const {
-id,
-status, // status will be QUEUED
-} = await Kernel.invocations.create({
-app_name: app_name,
-action_name: action_name,
-version: "latest",
-async: true,
-});
-
-````
-
-```python Python
-import kernel
-
-result = kernel.invocations.create({
-    "app_name": app_name,
-    "action_name": action_name,
-    "version": "latest",
-    "async": True
-})
-invocation_id, status = (
-    result["id"],
-    result["status"]  # status will be QUEUED
-)
-    result["id"],
-    result["status"] # status will be QUEUED
-)
-````
-
-</CodeGroup>
+<AsyncInvocation />
 
 ## Via CLI
 

--- a/apps/status.mdx
+++ b/apps/status.mdx
@@ -4,39 +4,9 @@ title: "Status"
 
 Once you've [deployed](/apps/deploy) an app and invoked it, you can check its status.
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
+import GetInvocationStatus from '/snippets/openapi/get-invocations-id.mdx';
 
-const {
-    id,
-    app_name,
-    action_name,
-    payload,
-    output,
-    started_at,
-    finished_at,
-    status,
-    status_reason
-} = await Kernel.invocations.get(invocation_id);
-```
-
-```python Python
-import kernel
-
-data = kernel.invocations.get(invocation_id)
-invocation_id = data["id"]
-app_name = data["app_name"]
-action_name = data["action_name"]
-payload = data["payload"]
-output = data["output"]
-started_at = data["started_at"]
-finished_at = data["finished_at"]
-status = data["status"]
-status_reason = data["status_reason"]
-```
-
-</CodeGroup>
+<GetInvocationStatus />
 
 <Info>
   An invocation ends once its code execution finishes.

--- a/apps/stop.mdx
+++ b/apps/stop.mdx
@@ -9,21 +9,11 @@ Terminating an invocation also destroys any browsers associated with it.
 </Info>
 
 ## Via API
-You can also do this by making a `DELETE` request to Kernel's API:
+You can also do this via the API:
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
+import StopInvocation from '/snippets/openapi/patch-invocations-id.mdx';
 
-await Kernel.invocations.delete(invocationId);
-```
-
-```python Python
-import kernel
-
-kernel.invocations.delete(invocation_id)
-```
-</CodeGroup>
+<StopInvocation />
 
 
 ## Via CLI

--- a/browsers/create-a-browser.mdx
+++ b/browsers/create-a-browser.mdx
@@ -8,20 +8,9 @@ Kernel browsers were designed to be lightweight, fast, and efficient for cloud-b
 
 Use our SDK to create a browser:
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
-const kernel = new Kernel();
-const kernelBrowser = await kernel.browsers.create();
-```
+import CreateBrowserSnippet from '/snippets/openapi/post-browsers.mdx';
 
-```Python Python
-import kernel
-client = Kernel()
-kernel_browser = client.browsers.create()
-```
-
-</CodeGroup>
+<CreateBrowserSnippet />
 
 ## 2. Connect to the browser with the Chrome DevTools Protocol
 
@@ -50,16 +39,9 @@ browser = playwright.chromium.connect_over_cdp(kernel_browser.cdp_ws_url)
 
 When you're finished with the browser, you can delete it:
 
-<CodeGroup>
-```typescript Typescript/Javascript 
-await client.browsers.deleteByID(kernel_browser.session_id);
-```
+import DeleteBrowserSnippet from '/snippets/openapi/delete-browsers-id.mdx';
 
-```Python Python
-client.browsers.delete_by_id(kernel_browser.session_id)
-```
-
-</CodeGroup>
+<DeleteBrowserSnippet />
 
 You can also delete the browser by [specifiying a timeout](/browsers/termination#timeouts-for-non-persisted-browsers) when you create the browser.
 ## Full example

--- a/browsers/live-view.mdx
+++ b/browsers/live-view.mdx
@@ -6,22 +6,9 @@ Humans-in-the-loop can access the live view of Kernel browsers in real-time to r
 
 To access the live view, visit the `browser_live_view_url` provided when you create a Kernel browser:
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
-const kernel = new Kernel();
-const kernelBrowser = await kernel.browsers.create();
-console.log(kernelBrowser.browser_live_view_url);
-```
+import CreateBrowserForLiveView from '/snippets/openapi/post-browsers.mdx';
 
-```python Python
-import kernel
-client = Kernel()
-kernel_browser = client.browsers.create()
-print(kernel_browser.browser_live_view_url)
-```
-
-</CodeGroup>
+<CreateBrowserForLiveView />
 
 ## Query parameters
 

--- a/browsers/termination.mdx
+++ b/browsers/termination.mdx
@@ -8,31 +8,9 @@ Kernel browsers should be terminated after you're done with them.
 
 You can delete a browser by making a `DELETE` request to Kernel's API:
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import Kernel from '@onkernel/sdk';
-const kernel = new Kernel();
+import DeleteBrowser from '/snippets/openapi/delete-browsers-id.mdx';
 
-// Delete a persisted browser
-await kernel.browsers.delete({ persistent_id: 'persistent_id' });
-
-// Delete a non-persisted browser
-await kernel.browsers.deleteByID('htzv5orfit78e1m2biiifpbv');
-```
-
-```python Python
-from kernel import Kernel
-client = Kernel()
-
-# Delete a persisted browser
-client.browsers.delete(
-    persistent_id="persistent_id",
-)
-
-# Delete a non-persisted browser
-client.browsers.delete_by_id('htzv5orfit78e1m2biiifpbv')
-```
-</CodeGroup>
+<DeleteBrowser />
 
 ## Timeouts for non-persisted browsers
 
@@ -40,16 +18,6 @@ If you don't manually delete a `non-persisted` browser, deletion will happen aut
 
 You can set a custom timeout of up to 24 hours via the API:
 
-<CodeGroup>
-```typescript Typescript/Javascript
-import { Kernel } from '@onkernel/sdk';
-const kernel = new Kernel();
-const kernelBrowser = await kernel.browsers.create({ timeout_seconds: 300 });
-```
+import CreateBrowserTimeout from '/snippets/openapi/post-browsers.mdx';
 
-```python Python
-import kernel
-client = Kernel()
-kernel_browser = client.browsers.create(timeout_seconds=300)
-```
-</CodeGroup>
+<CreateBrowserTimeout />

--- a/snippets/openapi/delete-browsers-id-fs-watch-watch_id.mdx
+++ b/snippets/openapi/delete-browsers-id-fs-watch-watch_id.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.watch.stop('watch_id', { id: 'id' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.watch.stop(
+    watch_id="watch_id",
+    id="id",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/delete-browsers-id.mdx
+++ b/snippets/openapi/delete-browsers-id.mdx
@@ -1,0 +1,23 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.deleteByID('htzv5orfit78e1m2biiifpbv');
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.delete_by_id(
+    "id",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/delete-browsers.mdx
+++ b/snippets/openapi/delete-browsers.mdx
@@ -1,0 +1,23 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.delete({ persistent_id: 'persistent_id' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.delete(
+    persistent_id="persistent_id",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/delete-invocations-id-browsers.mdx
+++ b/snippets/openapi/delete-invocations-id-browsers.mdx
@@ -1,0 +1,23 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.invocations.deleteBrowsers('id');
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.invocations.delete_browsers(
+    "id",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/get-apps.mdx
+++ b/snippets/openapi/get-apps.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const apps = await client.apps.list();
+
+console.log(apps);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+apps = client.apps.list()
+print(apps)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-fs-file_info.mdx
+++ b/snippets/openapi/get-browsers-id-fs-file_info.mdx
@@ -1,0 +1,27 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.fileInfo('id', { path: '/J!' });
+
+console.log(response.is_dir);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.file_info(
+    id="id",
+    path="/J!",
+)
+print(response.is_dir)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-fs-list_files.mdx
+++ b/snippets/openapi/get-browsers-id-fs-list_files.mdx
@@ -1,0 +1,27 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.listFiles('id', { path: '/J!' });
+
+console.log(response);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.list_files(
+    id="id",
+    path="/J!",
+)
+print(response)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-fs-read_file.mdx
+++ b/snippets/openapi/get-browsers-id-fs-read_file.mdx
@@ -1,0 +1,32 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.readFile('id', { path: '/J!' });
+
+console.log(response);
+
+const content = await response.blob();
+console.log(content);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.read_file(
+    id="id",
+    path="/J!",
+)
+print(response)
+content = response.read()
+print(content)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-fs-watch-watch_id-events.mdx
+++ b/snippets/openapi/get-browsers-id-fs-watch-watch_id-events.mdx
@@ -1,0 +1,27 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.watch.events('watch_id', { id: 'id' });
+
+console.log(response.path);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.watch.events(
+    watch_id="watch_id",
+    id="id",
+)
+print(response.path)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-replays-replay_id.mdx
+++ b/snippets/openapi/get-browsers-id-replays-replay_id.mdx
@@ -1,0 +1,32 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.replays.download('replay_id', { id: 'id' });
+
+console.log(response);
+
+const content = await response.blob();
+console.log(content);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.replays.download(
+    replay_id="replay_id",
+    id="id",
+)
+print(response)
+content = response.read()
+print(content)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-replays.mdx
+++ b/snippets/openapi/get-browsers-id-replays.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const replays = await client.browsers.replays.list('id');
+
+console.log(replays);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+replays = client.browsers.replays.list(
+    "id",
+)
+print(replays)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id.mdx
+++ b/snippets/openapi/get-browsers-id.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const browser = await client.browsers.retrieve('htzv5orfit78e1m2biiifpbv');
+
+console.log(browser.session_id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+browser = client.browsers.retrieve(
+    "id",
+)
+print(browser.session_id)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers.mdx
+++ b/snippets/openapi/get-browsers.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const browsers = await client.browsers.list();
+
+console.log(browsers);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+browsers = client.browsers.list()
+print(browsers)
+```
+</CodeGroup>

--- a/snippets/openapi/get-deployments-id-events.mdx
+++ b/snippets/openapi/get-deployments-id-events.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.deployments.follow('id');
+
+console.log(response);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.deployments.follow(
+    id="id",
+)
+print(response)
+```
+</CodeGroup>

--- a/snippets/openapi/get-deployments-id.mdx
+++ b/snippets/openapi/get-deployments-id.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const deployment = await client.deployments.retrieve('id');
+
+console.log(deployment.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+deployment = client.deployments.retrieve(
+    "id",
+)
+print(deployment.id)
+```
+</CodeGroup>

--- a/snippets/openapi/get-deployments.mdx
+++ b/snippets/openapi/get-deployments.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const deployments = await client.deployments.list();
+
+console.log(deployments);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+deployments = client.deployments.list()
+print(deployments)
+```
+</CodeGroup>

--- a/snippets/openapi/get-invocations-id-events.mdx
+++ b/snippets/openapi/get-invocations-id-events.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.invocations.follow('id');
+
+console.log(response);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.invocations.follow(
+    "id",
+)
+print(response)
+```
+</CodeGroup>

--- a/snippets/openapi/get-invocations-id.mdx
+++ b/snippets/openapi/get-invocations-id.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const invocation = await client.invocations.retrieve('rr33xuugxj9h0bkf1rdt2bet');
+
+console.log(invocation.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+invocation = client.invocations.retrieve(
+    "id",
+)
+print(invocation.id)
+```
+</CodeGroup>

--- a/snippets/openapi/patch-invocations-id.mdx
+++ b/snippets/openapi/patch-invocations-id.mdx
@@ -1,0 +1,27 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const invocation = await client.invocations.update('id', { status: 'succeeded' });
+
+console.log(invocation.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+invocation = client.invocations.update(
+    id="id",
+    status="succeeded",
+)
+print(invocation.id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-fs-watch.mdx
+++ b/snippets/openapi/post-browsers-id-fs-watch.mdx
@@ -1,0 +1,27 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.watch.start('id', { path: 'path' });
+
+console.log(response.watch_id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.watch.start(
+    id="id",
+    path="path",
+)
+print(response.watch_id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-replays-replay_id-stop.mdx
+++ b/snippets/openapi/post-browsers-id-replays-replay_id-stop.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.replays.stop('replay_id', { id: 'id' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.replays.stop(
+    replay_id="replay_id",
+    id="id",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-replays.mdx
+++ b/snippets/openapi/post-browsers-id-replays.mdx
@@ -1,0 +1,26 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.replays.start('id');
+
+console.log(response.replay_id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.replays.start(
+    id="id",
+)
+print(response.replay_id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers.mdx
+++ b/snippets/openapi/post-browsers.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const browser = await client.browsers.create();
+
+console.log(browser.session_id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+browser = client.browsers.create()
+print(browser.session_id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-deployments.mdx
+++ b/snippets/openapi/post-deployments.mdx
@@ -1,0 +1,30 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const deployment = await client.deployments.create({
+  entrypoint_rel_path: 'src/app.py',
+  file: fs.createReadStream('path/to/file'),
+});
+
+console.log(deployment.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+deployment = client.deployments.create(
+    entrypoint_rel_path="src/app.py",
+    file=b"raw file contents",
+)
+print(deployment.id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-invocations-async.mdx
+++ b/snippets/openapi/post-invocations-async.mdx
@@ -1,0 +1,34 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const invocation = await client.invocations.create({
+  async: true,
+  action_name: 'analyze',
+  app_name: 'my-app',
+  version: '1.0.0',
+});
+
+console.log(invocation.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+invocation = client.invocations.create(
+    action_name="analyze",
+    app_name="my-app",
+    version="1.0.0",
+    async=True,
+)
+print(invocation.id)
+```
+</CodeGroup>

--- a/snippets/openapi/post-invocations.mdx
+++ b/snippets/openapi/post-invocations.mdx
@@ -1,0 +1,32 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const invocation = await client.invocations.create({
+  action_name: 'analyze',
+  app_name: 'my-app',
+  version: '1.0.0',
+});
+
+console.log(invocation.id);
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+invocation = client.invocations.create(
+    action_name="analyze",
+    app_name="my-app",
+    version="1.0.0",
+)
+print(invocation.id)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-create_directory.mdx
+++ b/snippets/openapi/put-browsers-id-fs-create_directory.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.createDirectory('id', { path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.create_directory(
+    id="id",
+    path="/J!",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-delete_directory.mdx
+++ b/snippets/openapi/put-browsers-id-fs-delete_directory.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.deleteDirectory('id', { path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.delete_directory(
+    id="id",
+    path="/J!",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-delete_file.mdx
+++ b/snippets/openapi/put-browsers-id-fs-delete_file.mdx
@@ -1,0 +1,24 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.deleteFile('id', { path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.delete_file(
+    id="id",
+    path="/J!",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-move.mdx
+++ b/snippets/openapi/put-browsers-id-fs-move.mdx
@@ -1,0 +1,25 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.move('id', { dest_path: '/J!', src_path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.move(
+    id="id",
+    dest_path="/J!",
+    src_path="/J!",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-set_file_permissions.mdx
+++ b/snippets/openapi/put-browsers-id-fs-set_file_permissions.mdx
@@ -1,0 +1,25 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.setFilePermissions('id', { mode: '0611', path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.set_file_permissions(
+    id="id",
+    mode="0611",
+    path="/J!",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/put-browsers-id-fs-write_file.mdx
+++ b/snippets/openapi/put-browsers-id-fs-write_file.mdx
@@ -1,0 +1,25 @@
+<CodeGroup dropdown>
+```typescript index.ts
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.writeFile('id', fs.createReadStream('path/to/file'), { path: '/J!' });
+```
+
+
+```python main.py
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.write_file(
+    id="id",
+    contents=b"raw file contents",
+    path="/J!",
+)
+```
+</CodeGroup>


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR
Auto-generated reusable OpenAPI code snippets to streamline API documentation across the codebase.

## Why we made these changes
To enhance documentation consistency, reduce manual effort, and improve maintainability by replacing hardcoded code examples with dynamically generated ones from OpenAPI specifications.

## What changed?
- **New Code Sample Generation System:**
    - Introduced `.github/scripts/code_samples.config.json` for configuring code sample variants (e.g., async invocations).
    - Significantly updated `.github/scripts/generate_code_samples.ts` to create standalone MDX snippet files for each OpenAPI endpoint/method, supporting configuration-driven parameter overrides, and cleaning up old snippets.
- **Documentation Refactoring:**
    - Refactored existing MDX documentation files (e.g., `apps/*.mdx`, `browsers/*.mdx`) to replace manual code examples with imported, auto-generated MDX snippet components (e.g., `<SynchronousInvocation />`).
- **Generated Snippet Files:**
    - Numerous new or updated `snippets/openapi/*.mdx` files were generated, providing consistent TypeScript and Python examples for various API endpoints and operations.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->