### PR TITLE
Update Book Demo href to new Calendly form

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -34,7 +34,7 @@
       },
       {
         "label": "Book a demo",
-        "href": "https://calendly.com/d/cwr7-xxq-m45"
+        "href": "https://calendly.com/d/cs5d-5vx-qp3"
       }
     ]
   },


### PR DESCRIPTION
## Description

Please provide an explanation of the changes you've made:

Updated the href to the new Calendly form for Danny.

## Implementation Checklist

- [N/A] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [N/A] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [YES] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [YES] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

<img width="1658" height="1075" alt="Screenshot 2025-08-19 at 3 58 52 PM" src="https://github.com/user-attachments/assets/35b76de7-25cf-45dc-9e8e-d28320bb2baf" />


## Related Issue

N/A

## Additional Notes

N/A

---

<!-- mesa-description-start -->
## TL;DR
Updated the "Book a demo" link in the documentation to point to a new Calendly booking form.

## Why we made these changes
To ensure users are directed to the correct and current Calendly booking form for demos.

## What changed?
- **docs.json**: The `href` for the 'Book a demo' link was updated with a new Calendly URL.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->