### PR TITLE
Danny/kernel 267 docs update mcp docs goose section

### DIFF
--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -122,7 +122,7 @@ Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=e
 
 ## Goose
 
-Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP%20%28mcp-remote%29) to install Kernel on Goose in one click.
+Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP) to install Kernel on Goose in one click.
 
 ### Goose Desktop
 

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -128,13 +128,13 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
 
 1. Click `Extensions` in the sidebar of the Goose Desktop.
 2. Click `Add custom extension`.
-4. On the `Add custom extension` modal, enter:
+3. On the `Add custom extension` modal, enter:
    - **Extension Name**: `Kernel`
    - **Type**: `STDIO`
    - **Description**: `Access Kernel's cloud-based browsers via MCP`
    - **Command**: `npx -y mcp-remote https://mcp.onkernel.com/mcp`
    - **Timeout**: `300`
-5. Click `Save Changes` button.
+4. Click `Save Changes` button.
 
 ### Goose CLI
 

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -122,21 +122,19 @@ Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=e
 
 ## Goose
 
-Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP) to install Kernel on Goose in one click.
+Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP%20%28mcp-remote%29) to install Kernel on Goose in one click.
 
 ### Goose Desktop
 
-1. Click `...` in the top right corner of the Goose Desktop.
-2. Select `Advanced Settings` from the menu.
-3. Under `Extensions`, click `Add custom extension`.
+1. Click `Extensions` in the sidebar of the Goose Desktop.
+2. Click `Add custom extension`.
 4. On the `Add custom extension` modal, enter:
-   - **Type**: `Streaming HTTP`
-   - **ID**: `kernel`
-   - **Name**: `Kernel`
+   - **Extension Name**: `Kernel`
+   - **Type**: `STDIO`
    - **Description**: `Access Kernel's cloud-based browsers via MCP`
-   - **URL**: `https://mcp.onkernel.com/mcp`
+   - **Command**: `npx -y mcp-remote https://mcp.onkernel.com/mcp`
    - **Timeout**: `300`
-5. Click `Add` button.
+5. Click `Save Changes` button.
 
 ### Goose CLI
 
@@ -145,11 +143,12 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
    goose configure
    ```
 2. Select `Add Extension` from the menu.
-3. Choose `Remote Extension (Streaming HTTP)`.
+3. Choose `Command-line Extension`.
 4. Follow the prompts:
    - **Extension name**: `Kernel`
-   - **URL**: `https://mcp.onkernel.com/mcp`
+   - **Command**: `npx -y mcp-remote https://mcp.onkernel.com/mcp`
    - **Timeout**: `300`
+   - **Description**: `Access Kernel's cloud-based browsers via MCP`
 
 ## Visual Studio Code
 


### PR DESCRIPTION
## Description

Please provide an explanation of the changes you've made:

Updated Goose section of MCP server documentation to reflect currently available installation methods.


## Testing

- [YES] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [N/A] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

<img width="1704" height="1196" alt="Screenshot 2025-08-21 at 11 09 08 PM" src="https://github.com/user-attachments/assets/1a4159b0-ad95-48de-b5bd-f92b9ae4fb56" />