### PR TITLE
Danny/kernel 285 docs sidebar headers blend in with normal content titles

### DIFF
--- a/snippets/openapi/get-browsers-id-fs-download_dir_zip.mdx
+++ b/snippets/openapi/get-browsers-id-fs-download_dir_zip.mdx
@@ -1,0 +1,32 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.fs.downloadDirZip('id', { path: '/J!' });
+
+console.log(response);
+
+const content = await response.blob();
+console.log(content);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.fs.download_dir_zip(
+    id="id",
+    path="/J!",
+)
+print(response)
+content = response.read()
+print(content)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-logs-stream.mdx
+++ b/snippets/openapi/get-browsers-id-logs-stream.mdx
@@ -1,0 +1,27 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const logEvent = await client.browsers.logs.stream('id', { source: 'path' });
+
+console.log(logEvent.event);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+log_event = client.browsers.logs.stream(
+    id="id",
+    source="path",
+)
+print(log_event.event)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-process-process_id-status.mdx
+++ b/snippets/openapi/get-browsers-id-process-process_id-status.mdx
@@ -1,0 +1,27 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.status('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e', { id: 'id' });
+
+console.log(response.cpu_pct);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.status(
+    process_id="182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+    id="id",
+)
+print(response.cpu_pct)
+```
+</CodeGroup>

--- a/snippets/openapi/get-browsers-id-process-process_id-stdout-stream.mdx
+++ b/snippets/openapi/get-browsers-id-process-process_id-stdout-stream.mdx
@@ -1,0 +1,29 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.stdoutStream('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e', {
+  id: 'id',
+});
+
+console.log(response.data_b64);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.stdout_stream(
+    process_id="182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+    id="id",
+)
+print(response.data_b64)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-fs-upload.mdx
+++ b/snippets/openapi/post-browsers-id-fs-upload.mdx
@@ -1,0 +1,29 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.upload('id', {
+  files: [{ dest_path: '/J!', file: fs.createReadStream('path/to/file') }],
+});
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.upload(
+    id="id",
+    files=[{
+        "dest_path": "/J!",
+        "file": b"raw file contents",
+    }],
+)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-fs-upload_zip.mdx
+++ b/snippets/openapi/post-browsers-id-fs-upload_zip.mdx
@@ -1,0 +1,25 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+await client.browsers.fs.uploadZip('id', { dest_path: '/J!', zip_file: fs.createReadStream('path/to/file') });
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+client.browsers.fs.upload_zip(
+    id="id",
+    dest_path="/J!",
+    zip_file=b"raw file contents",
+)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-process-exec.mdx
+++ b/snippets/openapi/post-browsers-id-process-exec.mdx
@@ -1,0 +1,27 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.exec('id', { command: 'command' });
+
+console.log(response.duration_ms);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.exec(
+    id="id",
+    command="command",
+)
+print(response.duration_ms)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-process-process_id-kill.mdx
+++ b/snippets/openapi/post-browsers-id-process-process_id-kill.mdx
@@ -1,0 +1,31 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.kill('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e', {
+  id: 'id',
+  signal: 'TERM',
+});
+
+console.log(response.ok);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.kill(
+    process_id="182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+    id="id",
+    signal="TERM",
+)
+print(response.ok)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-process-process_id-stdin.mdx
+++ b/snippets/openapi/post-browsers-id-process-process_id-stdin.mdx
@@ -1,0 +1,31 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.stdin('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e', {
+  id: 'id',
+  data_b64: 'data_b64',
+});
+
+console.log(response.written_bytes);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.stdin(
+    process_id="182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+    id="id",
+    data_b64="data_b64",
+)
+print(response.written_bytes)
+```
+</CodeGroup>

--- a/snippets/openapi/post-browsers-id-process-spawn.mdx
+++ b/snippets/openapi/post-browsers-id-process-spawn.mdx
@@ -1,0 +1,27 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const response = await client.browsers.process.spawn('id', { command: 'command' });
+
+console.log(response.pid);
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+response = client.browsers.process.spawn(
+    id="id",
+    command="command",
+)
+print(response.pid)
+```
+</CodeGroup>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+/* style sidebar titles */
+#navigation-items .sidebar-group-header #sidebar-title{
+  font-weight: bold;
+  font-size: larger;
+}


### PR DESCRIPTION
## Description

Adds style.css file to style the sidebar titles in the docs, so they are larger and stand out more.

## Implementation Checklist

- [N/A] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [N/A] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [N/A] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

<img width="330" height="815" alt="Screenshot 2025-08-28 at 11 20 05 AM" src="https://github.com/user-attachments/assets/5497b56e-90ea-40ad-af11-2d6f951c2643" />

---

<!-- mesa-description-start -->
## TL;DR

Made docs sidebar headers larger and bolder to distinguish them from content links.

## Why we made these changes

The previous styling for sidebar navigation headers was too similar to regular page links, making the documentation's structure difficult to scan. This change improves navigation clarity and readability.

## What changed?

- Added a `style.css` file to introduce custom styles for the documentation.
- Targeted sidebar group headers to increase their font size and weight, making them stand out.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->