### PR TITLE
Mason/cli docs organization

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -126,7 +126,10 @@
         "tab": "CLI",
         "icon": "terminal",
         "pages": [
-          "reference/cli"
+          "reference/cli",
+          "reference/cli/auth",
+          "reference/cli/browsers",
+          "reference/cli/apps"
         ]
       }
     ]

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -6,8 +6,6 @@ The Kernel CLI helps you access and manage your Kernel resources.
 
 ## Installation
 
-Install the Kernel CLI using your favorite package manager:
-
 ```bash
 # Using brew
 brew install onkernel/tap/kernel
@@ -19,94 +17,44 @@ pnpm install -g @onkernel/cli
 npm install -g @onkernel/cli
 ```
 
-## Authentication
-
-The Kernel CLI supports two authentication methods:
-
-### OAuth 2.0 (Recommended)
-
-The preferred method is OAuth 2.0 with PKCE, which provides secure browser-based authentication:
-
-```bash
-kernel login
-```
-
-This opens your browser to complete the OAuth flow. Your tokens are securely stored in your system keychain (macOS/Windows) or a local file (Linux).
-
-### API Key
-
-You can also authenticate using an API key:
-
-```bash
-export KERNEL_API_KEY=<API_KEY>
-```
-
-## Verifying installation
-After installation, verify that Kernel CLI was installed correctly:
+Verify installation:
 
 ```bash
 which kernel
+kernel --version
+```
+
+<Columns cols={2}>
+  <Card icon="key" title="Authentication" href="/reference/cli/auth">
+    Login, logout, and check auth status.
+  </Card>
+  <Card icon="browsers" title="Browsers" href="/reference/cli/browsers">
+    Create, view, and manage Kernel browsers.
+  </Card>
+  <Card icon="rocket" title="Apps" href="/reference/cli/apps">
+    Deploy apps, invoke actions, and stream logs.
+  </Card>
+</Columns>
+
+## Quick Start
+
+```bash
+# 1) Login
+kernel login
+
+# 2) Deploy your app
+kernel deploy index.ts
+
+# 3) Invoke your app
+kernel invoke my-app action-name --payload '{"key":"value"}'
 ```
 
 ## Global Flags
 
-| Flag | Description |
-|------|-------------|
-| `--version`, `-v` | Print the CLI version |
-| `--no-color` | Disable color output |
-| `--log-level <level>` | Set the log level (trace, debug, info, warn, error, fatal, print) |
+- `--version`, `-v` - Print the CLI version
+- `--no-color` - Disable color output
+- `--log-level <level>` - Set the log level (trace, debug, info, warn, error, fatal, print)
 
-## Authentication Commands
-
-| Command | Description |
-|---------|-------------|
-| `kernel login [--force]` | Initiates OAuth 2.0 authentication flow via browser. Use `--force` to re-authenticate when already logged in |
-| `kernel logout` | Clears stored authentication tokens and logs out |
-| `kernel auth` | Displays current authentication status, user details, and token expiry. Use `--log-level debug` for detailed information including user ID and storage method |
-
-## Browser Management Commands
-
-| Command | Description |
-|---------|-------------|
-| `kernel browsers list` | List running or persistent browsers |
-| `kernel browsers create` | Create a new browser session |
-| | `--persistence-id <id>` | Unique identifier for browser session persistence. Optional. |
-| | `--stealth` | Launch browser in stealth mode to avoid detection. Optional. |
-| | `--headless` | Launch browser without GUI access. Optional. |
-| `kernel browsers delete` | Delete a browser. Must specify either `--by-persistent-id` or `--by-id` |
-| | `--by-persistent-id <id>` | Delete browser by persistent ID |
-| | `--by-id <id>` | Delete browser by session ID |
-| | `--yes`, `-y` | Skip confirmation prompt |
-| `kernel browsers view` | Get the live view URL for a browser. Must specify either `--by-persistent-id` or `--by-id` |
-| | `--by-persistent-id <id>` | View browser by persistent ID |
-| | `--by-id <id>` | View browser by session ID |
-
-## App Management Commands
-
-| Command | Optional Flags | Description |
-|---------|-------------| -------------|
-| `kernel deploy <entrypoint_file_name>` | - | Deploys an app to Kernel from the current directory. |
-| | `--version <version>` | Specify a version for the app (default: latest). Optional. |
-| | `--force` | Allow overwrite of an existing version with the same name. Optional. |
-| | `--env <ENV_VAR=VAL>`, `-e` | Adds environment variables to the app. Expects the form `ENV_VAR=VAL` delimited by spaces. May be specified multiple times. Optional. |
-| | `--env-file <file>` | Read environment variables from a file (.env format). May be specified multiple times. Optional. |
-| `kernel invoke <app_name> <action_name>` | - | Invokes a specific app action by its name. Generates an Invocation. |
-| | `--version <version>`, `-v` | Specify a version of the app to invoke (default: latest). Optional. |
-| | `--payload <payload_data>`, `-p` | Includes the specified parameters. Expects a stringified JSON object. Optional. |
-| | `--sync`, `-s` | Invoke synchronously (default false). A synchronous invocation opens a long-lived HTTP POST that times out after 60 seconds. Optional. |
-| | `ctrl-c` | Terminates the running invocation in your CLI. Also destroys any associated browsers. |
-| `kernel app list` | - | List deployed application versions. |
-| | `--name <app_name>` | Filter by application name. Optional. |
-| | `--version <version>` | Filter by version label. Optional. |
-| `kernel app history <app_name>` | - | Show deployment history for an application. |
-| `kernel logs <app_name>` | - | Prints the logs for the specified app. |
-| | `--version <version>` | Specify a version of the app (default: latest). Optional. |
-| | `--follow`, `-f` | Follow logs in real-time (stream continuously). Optional. |
-| | `--since <time>`, `-s` | How far back to retrieve logs (e.g., 5m, 1h). Defaults to 5m if not following, 5s if following. Optional. |
-| | `--with-timestamps` | Include timestamps in each log line. Optional. |
-
-## General Commands
-
-| Command | Description |
-|---------|-------------|
-| `kernel help [command]` | Displays help information about Kernel commands |
+<Info>
+Looking for the API? See the [API Reference](/api-reference/invocations/invoke-an-action).
+</Info>

--- a/reference/cli/apps.mdx
+++ b/reference/cli/apps.mdx
@@ -1,0 +1,45 @@
+---
+title: "Apps"
+---
+
+## `kernel deploy <entrypoint_file_name>`
+Deploy an app to Kernel from the current directory.
+
+| Flag | Description |
+|------|-------------|
+| `--version <version>` | Specify a version for the app (default: latest). Optional. |
+| `--force` | Allow overwrite of an existing version with the same name. Optional. |
+| `--env <ENV_VAR=VAL>`, `-e` | Adds environment variables to the app. May be specified multiple times. Optional. |
+| `--env-file <file>` | Read environment variables from a .env file. May be specified multiple times. Optional. |
+
+## `kernel invoke <app_name> <action_name>`
+Invoke a specific app action by its name. Generates an Invocation.
+
+| Flag | Description |
+|------|-------------|
+| `--version <version>`, `-v` | Specify a version of the app to invoke (default: latest). Optional. |
+| `--payload <payload_data>`, `-p` | Stringified JSON object (max 64 KB). Optional. |
+| `--sync`, `-s` | Invoke synchronously (default false). Optional. |
+
+<Info>Synchronous invocations open a long-lived HTTP POST that times out after 60 seconds. Press `ctrl-c` to terminate a running invocation; associated browsers are destroyed.</Info>
+
+## `kernel app list`
+List deployed application versions.
+
+| Flag | Description |
+|------|-------------|
+| `--name <app_name>` | Filter by application name. Optional. |
+| `--version <version>` | Filter by version label. Optional. |
+
+## `kernel app history <app_name>`
+Show deployment history for an application.
+
+## `kernel logs <app_name>`
+Print the logs for the specified app.
+
+| Flag | Description |
+|------|-------------|
+| `--version <version>` | Specify a version of the app (default: latest). Optional. |
+| `--follow`, `-f` | Follow logs in real-time (stream continuously). Optional. |
+| `--since <time>`, `-s` | How far back to retrieve logs (e.g., 5m, 1h). Defaults to 5m if not following, 5s if following. Optional. |
+| `--with-timestamps` | Include timestamps in each log line. Optional. |

--- a/reference/cli/auth.mdx
+++ b/reference/cli/auth.mdx
@@ -1,0 +1,20 @@
+---
+title: "Authentication"
+---
+
+## `kernel login`
+Login via OAuth 2.0 (PKCE) using your browser. Credentials are stored securely and refreshed automatically.
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Force re-authentication even if already logged in |
+
+## `kernel logout`
+Clear stored authentication tokens and log out.
+
+## `kernel auth`
+Show current authentication status and token expiry.
+
+| Flag | Description |
+|------|-------------|
+| `--log-level debug` | Set the log level to debug for detailed info including user ID, org ID, and storage method. |

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -1,0 +1,277 @@
+---
+title: "Browsers"
+---
+
+## Core
+
+### `kernel browsers list`
+List running or persistent browsers.
+
+### `kernel browsers create`
+Create a new browser session.
+
+| Flag | Description |
+|------|-------------|
+| `--persistence-id <id>` | Unique identifier for browser session persistence. Optional. |
+| `--stealth` | Launch browser in stealth mode to avoid detection. Optional. |
+| `--headless` | Launch browser without GUI access. Optional. |
+
+### `kernel browsers delete`
+Delete a browser. Must specify either `--by-persistent-id` or `--by-id`.
+
+| Flag | Description |
+|------|-------------|
+| `--by-persistent-id <id>` | Delete browser by persistent ID |
+| `--by-id <id>` | Delete browser by session ID |
+| `--yes`, `-y` | Skip confirmation prompt |
+
+### `kernel browsers view`
+Get the live view URL for a browser. Must specify either `--by-persistent-id` or `--by-id`.
+
+| Flag | Description |
+|------|-------------|
+| `--by-persistent-id <id>` | View browser by persistent ID |
+| `--by-id <id>` | View browser by session ID |
+
+## Logs
+
+### `kernel browsers logs stream`
+Stream browser logs.
+
+| Flag | Description |
+|------|-------------|
+| `--source <source>` | Log source: `path` or `supervisor`. Required. |
+| `--follow` | Follow the log stream (default: true). Optional. |
+| `--path <path>` | File path when `--source=path`. Optional. |
+| `--supervisor-process <name>` | Supervisor process name when `--source=supervisor` (e.g., `chromium`). Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+## Replays
+
+### `kernel browsers replays list`
+List replays for a browser.
+
+| Flag | Description |
+|------|-------------|
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers replays start`
+Start a replay recording.
+
+| Flag | Description |
+|------|-------------|
+| `--framerate <fps>` | Recording framerate (fps). Optional. |
+| `--max-duration <seconds>` | Maximum duration in seconds. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers replays stop`
+Stop a replay recording.
+
+| Flag | Description |
+|------|-------------|
+| `--replay-id <id>` | Replay ID to stop. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers replays download`
+Download a replay video.
+
+| Flag | Description |
+|------|-------------|
+| `--replay-id <id>` | Replay ID to download. Required. |
+| `-o, --output <path>` | Output file path. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+## Process Control
+
+### `kernel browsers process exec`
+Execute a command synchronously in the browser VM.
+
+| Flag | Description |
+|------|-------------|
+| `--command <cmd>` | Command to execute. Optional; if omitted, trailing args are executed via `/bin/bash -c`. |
+| `--args <args>` | Command arguments. Optional. |
+| `--cwd <path>` | Working directory. Optional. |
+| `--timeout <seconds>` | Timeout in seconds. Optional. |
+| `--as-user <user>` | Run as user. Optional. |
+| `--as-root` | Run as root. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers process spawn`
+Execute a command asynchronously in the browser VM.
+
+| Flag | Description |
+|------|-------------|
+| `--command <cmd>` | Command to execute. Optional; if omitted, trailing args are executed via `/bin/bash -c`. |
+| `--args <args>` | Command arguments. Optional. |
+| `--cwd <path>` | Working directory. Optional. |
+| `--timeout <seconds>` | Timeout in seconds. Optional. |
+| `--as-user <user>` | Run as user. Optional. |
+| `--as-root` | Run as root. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers process kill`
+Send a signal to a process.
+
+| Flag | Description |
+|------|-------------|
+| `--process-id <id>` | Target process ID. Required. |
+| `--signal <signal>` | Signal to send: `TERM`, `KILL`, `INT`, `HUP` (default: `TERM`). Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers process status`
+Get process status.
+
+| Flag | Description |
+|------|-------------|
+| `--process-id <id>` | Target process ID. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers process stdin`
+Write to process stdin (base64 data).
+
+| Flag | Description |
+|------|-------------|
+| `--process-id <id>` | Target process ID. Required. |
+| `--data-b64 <data>` | Base64-encoded data to write to stdin. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers process stdout-stream`
+Stream process stdout/stderr.
+
+| Flag | Description |
+|------|-------------|
+| `--process-id <id>` | Target process ID. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+## Filesystem
+
+### `kernel browsers fs new-directory`
+Create a new directory.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute directory path to create. Required. |
+| `--mode <mode>` | Directory mode (octal string). Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs delete-directory`
+Delete a directory.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute directory path to delete. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs delete-file`
+Delete a file.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute file path to delete. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs download-dir-zip`
+Download a directory as a zip file.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute directory path to download. Required. |
+| `-o, --output <path>` | Output zip file path. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs file-info`
+Get file or directory info.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute file or directory path. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs list-files`
+List files in a directory.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute directory path. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs move`
+Move or rename a file or directory.
+
+| Flag | Description |
+|------|-------------|
+| `--src <path>` | Absolute source path. Required. |
+| `--dest <path>` | Absolute destination path. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs read-file`
+Read a file.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute file path. Required. |
+| `-o, --output <path>` | Output file path. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs set-permissions`
+Set file permissions or ownership.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Absolute path. Required. |
+| `--mode <mode>` | File mode bits (octal string). Required. |
+| `--owner <user>` | New owner username or UID. Optional. |
+| `--group <group>` | New group name or GID. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs upload`
+Upload one or more files.
+
+| Flag | Description |
+|------|-------------|
+| `--file <local:remote>` | Mapping local:remote (repeatable). Optional. |
+| `--dest-dir <path>` | Destination directory for uploads. Optional. |
+| `--paths <paths>` | Local file paths to upload. Optional. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs upload-zip`
+Upload a zip and extract it.
+
+| Flag | Description |
+|------|-------------|
+| `--zip <path>` | Local zip file path. Required. |
+| `--dest-dir <path>` | Destination directory to extract to. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |
+
+### `kernel browsers fs write-file`
+Write a file from local data.
+
+| Flag | Description |
+|------|-------------|
+| `--path <path>` | Destination absolute file path. Required. |
+| `--mode <mode>` | File mode (octal string). Optional. |
+| `--source <path>` | Local source file path. Required. |
+| `--by-persistent-id <id>` | Target browser by persistent ID. Optional. |
+| `--by-id <id>` | Target browser by session ID. Optional. |

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -3,78 +3,32 @@ title: "MCP Server"
 description: "Access Kernel's cloud-based browsers via MCP"
 ---
 
-Our Model Context Protocol (MCP) server gives any compatible AI model or agent a single, secure endpoint for launching Chromium browsers, injecting context, evaluating JavaScript, and streaming DOM snapshots from Kernel's cloud platform.
-
-## First Time? Start Here!
-
-Ready to try Kernel but don't have a browser automation yet? Perfect! Here's how to get started:
-
-### Step 1: Install Kernel MCP Server
-
-Install the Kernel MCP server to your favorite MCP client using the [setup instructions](#setup-instructions) below.
-
-### Step 2: Ask Your AI Assistant for Help
-
-Once connected, simply ask in your MCP client chat:
-
-```
-"How do I get a Kernel sample app set up locally?"
-```
-
-Your AI assistant will use the `search_docs` tool to get you the latest quickstart instructions and guide you through setting up your first Kernel app!
-
-### Step 3: Deploy & Test with MCP Tools
-
-After you have a sample app locally, ask your assistant:
-
-```
-"Deploy my sample app to Kernel"
-```
-
-Then test it:
-
-```
-"Run my app and get the title from onkernel.com"
-```
-
-## Available Tools
-The server provides these tools for AI assistants:
-
-### Browser Automation
-- `create_browser` - Launch a new browser session
-- `get_browser` - Get browser session information
-- `delete_browser` - Terminate a browser session
-- `list_browsers` - List active browser sessions
-
-### App Management
-- `deploy_app` - Deploy TypeScript or Python apps to Kernel
-- `list_apps` - List apps in your Kernel organization
-- `invoke_action` - Execute actions in Kernel apps
-- `get_deployment` - Get deployment status and logs
-- `list_deployments` - List all deployments
-- `get_invocation` - Get action invocation details
-
-### Documentation & Search
-- `search_docs` - Search Kernel platform documentation and guides
+Our Model Context Protocol (MCP) server lets any compatible AI model or agent launch Chromium browsers, inject context, evaluate JavaScript, and stream DOM snapshots from Kernel's cloud platform — via a single secure endpoint.
 
 ## Setup Instructions
 
-Add the Kernel MCP server to your favorite MCP-compatible client using `https://mcp.onkernel.com/mcp`.
+### General (Transports)
 
-## Claude
+- Streamable HTTP (recommended): `https://mcp.onkernel.com/mcp`
+- stdio via `mcp-remote` (for clients without remote MCP support): `npx -y mcp-remote https://mcp.onkernel.com/mcp`
 
-### Team & Enterprise (Claude.ai)
+Use the streamable HTTP endpoint where supported for increased reliability. If your client does not support remote MCP, use `mcp-remote` over stdio.
 
-1. Navigate to **Settings** in the sidebar (web or desktop).
-2. Scroll to **Integrations** and click **Add more**.
-3. Fill in:
-   - **Integration name:** `Kernel`
-   - **Integration URL:** `https://mcp.onkernel.com/mcp`
-4. Start a chat, enable **Tools**, and finish auth.
+Kernel's server is a centrally hosted, authenticated remote MCP using OAuth 2.1 with dynamic client registration.
 
-### Free & Pro (Claude desktop)
+## Connect in your client
 
-Open `~/Library/Application Support/Claude/claude_desktop_config.json` and add:
+### Claude
+
+#### Team & Enterprise (Claude.ai)
+
+1. Go to **Settings → Integrations → Add more**.
+2. Enter: **Integration name:** `Kernel`, **Integration URL:** `https://mcp.onkernel.com/mcp`.
+3. Start a chat, enable **Tools**, complete auth.
+
+#### Free & Pro (Claude desktop)
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` and restart Claude:
 
 ```json
 {
@@ -89,24 +43,27 @@ Open `~/Library/Application Support/Claude/claude_desktop_config.json` and add:
 
 Restart the Claude desktop app.
 
-### Claude Code CLI
+#### Claude Code CLI
 
 ```bash
 claude mcp add --transport http kernel https://mcp.onkernel.com/mcp
-# then, inside the REPL:
-/mcp   # to run through auth
+# Then in the REPL run once to authenticate:
+/mcp
 ```
 
-## Cursor
+### Cursor
 
-Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=eyJ1cmwiOiJodHRwczovL21jcC5vbmtlcm5lbC5jb20vbWNwIn0%3D) to install Kernel on Cursor in one click.
+Install with one click or configure manually.
 
-### Manual Setup
+### One-click install
 
-1. Press **⌘/Ctrl Shift J** to open settings.
-2. Click **Tools & Integrations**.
-3. Click **New MCP server**.
-4. Add the following configuration:
+Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=eyJ1cmwiOiJodHRwczovL21jcC5vbmtlcm5lbC5jb20vbWNwIn0%3D).
+
+### Manual setup
+
+1. Press **⌘/Ctrl Shift J**.
+2. Go to **Tools & Integrations → New MCP server**.
+3. Add this configuration:
 
 ```json
 {
@@ -118,9 +75,9 @@ Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=e
 }
 ```
 
-5. Save and the server will be available.
+4. Save. The server will appear in Tools.
 
-## Goose
+### Goose
 
 Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP) to install Kernel on Goose in one click.
 
@@ -150,7 +107,7 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
    - **Timeout**: `300`
    - **Description**: `Access Kernel's cloud-based browsers via MCP`
 
-## Visual Studio Code
+### Visual Studio Code
 
 ```json
 {
@@ -169,13 +126,13 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
    ```bash
    npx -y mcp-remote https://mcp.onkernel.com/mcp
    ```
-4. Name the server **Kernel** and press Enter.
+4. Name the server **Kernel** → Enter.
 5. Activate via **MCP: List Servers → Kernel → Start Server**.
 
-## Windsurf
+### Windsurf
 
 1. Press **⌘/Ctrl ,** to open settings.
-2. Navigate **Cascade → MCP servers** → **Add custom server**.
+2. Go to **Cascade → MCP servers → Add custom server**.
 3. Paste:
 
 ```json
@@ -189,7 +146,7 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
 }
 ```
 
-## Zed
+### Zed
 
 Open `settings.json` and add:
 
@@ -208,7 +165,7 @@ Open `settings.json` and add:
 }
 ```
 
-## Others
+### Others
 
 Many other MCP-capable tools accept:
 
@@ -218,17 +175,33 @@ Many other MCP-capable tools accept:
 
 Configure these values wherever the tool expects MCP server settings.
 
-## Usage Examples
+## Tools
 
-### Deploy Local Apps to the Cloud
+### Browser Automation
+- `create_browser` - Launch a new browser session
+- `get_browser` - Get browser session information
+- `delete_browser` - Terminate a browser session
+- `list_browsers` - List active browser sessions
 
-```
-Human: I have a Playwright automation script open in my editor. Can you deploy it to Kernel?
-Assistant: I'll read your local files and deploy them to Kernel for you.
-[Uses deploy_app tool to upload your code and create a cloud deployment]
-```
+### App Management
+- `list_apps` - List apps in your Kernel organization
+- `invoke_action` - Execute actions in Kernel apps
+- `get_deployment` - Get deployment status and logs
+- `list_deployments` - List all deployments
+- `get_invocation` - Get action invocation details
 
-### Invoke Apps from Anywhere
+### Documentation & Search
+- `search_docs` - Search Kernel platform documentation and guides
+
+## Troubleshooting
+
+- Clear saved auth and retry: `rm -rf ~/.mcp-auth`
+- Ensure a recent Node.js version when using `npx mcp-remote`
+- If behind strict networks, try stdio via `mcp-remote`, or explicitly set the transport your client supports
+
+## Examples
+
+### Invoke apps from anywhere
 
 ```
 Human: Run my web-scraper app to get data from reddit.com
@@ -236,7 +209,7 @@ Assistant: I'll execute your web-scraper action with reddit.com as the target.
 [Uses invoke_action tool to run your deployed app in the cloud]
 ```
 
-### Create Persistent Browser Sessions
+### Create persistent browser sessions
 
 ```
 Human: Create a stealth browser session that I can reuse for testing login flows

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -20,7 +20,9 @@ Kernel's server is a centrally hosted, authenticated remote MCP using OAuth 2.1 
 
 ### Claude
 
-#### Team & Enterprise (Claude.ai)
+<Info>Our remote MCP server is not compatible with the method Free users of Claude use to add MCP servers.</Info>
+
+#### Pro, Max, Team & Enterprise (Claude.ai and Claude Desktop)
 
 1. Go to **Settings → Connectors → Add custom connector**.
 2. Enter: **Integration name:** `Kernel`, **Integration URL:** `https://mcp.onkernel.com/mcp`, then click **Add**.
@@ -28,23 +30,6 @@ Kernel's server is a centrally hosted, authenticated remote MCP using OAuth 2.1 
 4. In chat, click **Search and tools** and enable the Kernel tools if needed.
 
 <Info>On Claude for Work (Team/Enterprise), only Primary Owners or Owners can enable custom connectors for the org. After it's configured, each user still needs to go to **Settings → Connectors** and click **Connect** to authorize it for their account.</Info>
-
-#### Free & Pro (Claude desktop)
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` and restart Claude:
-
-```json
-{
-  "mcpServers": {
-    "kernel": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.onkernel.com/mcp"]
-    }
-  }
-}
-```
-
-Restart the Claude desktop app.
 
 #### Claude Code CLI
 

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -27,7 +27,7 @@ Kernel's server is a centrally hosted, authenticated remote MCP using OAuth 2.1 
 3. In **Settings → Connectors**, click **Connect** next to `Kernel` to launch OAuth and approve.
 4. In chat, click **Search and tools** and enable the Kernel tools if needed.
 
-> On Claude for Work (Team/Enterprise), only Primary Owners or Owners can enable custom connectors for the org. After it's configured, each user still needs to go to **Settings → Connectors** and click **Connect** to authorize it for their account.
+<Info>On Claude for Work (Team/Enterprise), only Primary Owners or Owners can enable custom connectors for the org. After it's configured, each user still needs to go to **Settings → Connectors** and click **Connect** to authorize it for their account.</Info>
 
 #### Free & Pro (Claude desktop)
 

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -22,9 +22,12 @@ Kernel's server is a centrally hosted, authenticated remote MCP using OAuth 2.1 
 
 #### Team & Enterprise (Claude.ai)
 
-1. Go to **Settings → Integrations → Add more**.
-2. Enter: **Integration name:** `Kernel`, **Integration URL:** `https://mcp.onkernel.com/mcp`.
-3. Start a chat, enable **Tools**, complete auth.
+1. Go to **Settings → Connectors → Add custom connector**.
+2. Enter: **Integration name:** `Kernel`, **Integration URL:** `https://mcp.onkernel.com/mcp`, then click **Add**.
+3. In **Settings → Connectors**, click **Connect** next to `Kernel` to launch OAuth and approve.
+4. In chat, click **Search and tools** and enable the Kernel tools if needed.
+
+> On Claude for Work (Team/Enterprise), only Primary Owners or Owners can enable custom connectors for the org. After it's configured, each user still needs to go to **Settings → Connectors** and click **Connect** to authorize it for their account.
 
 #### Free & Pro (Claude desktop)
 
@@ -53,13 +56,9 @@ claude mcp add --transport http kernel https://mcp.onkernel.com/mcp
 
 ### Cursor
 
-Install with one click or configure manually.
+Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=eyJ1cmwiOiJodHRwczovL21jcC5vbmtlcm5lbC5jb20vbWNwIn0%3D) to install Kernel on Cursor.
 
-### One-click install
-
-Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=eyJ1cmwiOiJodHRwczovL21jcC5vbmtlcm5lbC5jb20vbWNwIn0%3D).
-
-### Manual setup
+#### Manual setup
 
 1. Press **⌘/Ctrl Shift J**.
 2. Go to **Tools & Integrations → New MCP server**.
@@ -81,7 +80,7 @@ Click [here](cursor://anysphere.cursor-deeplink/mcp/install?name=kernel&config=e
 
 Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fmcp.onkernel.com%2Fmcp&timeout=300&id=kernel&name=Kernel&description=Access%20Kernel%27s%20cloud-based%20browsers%20via%20MCP) to install Kernel on Goose in one click.
 
-### Goose Desktop
+#### Goose Desktop
 
 1. Click `Extensions` in the sidebar of the Goose Desktop.
 2. Click `Add custom extension`.
@@ -93,7 +92,7 @@ Click [here](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=https%3A%2F%2Fm
    - **Timeout**: `300`
 4. Click `Save Changes` button.
 
-### Goose CLI
+#### Goose CLI
 
 1. Run the following command:
    ```bash

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -195,6 +195,7 @@ Configure these values wherever the tool expects MCP server settings.
 
 ## Troubleshooting
 
+- Cursor clean reset: ⌘/Ctrl Shift P → run `Cursor: Clear All MCP Tokens` (resets all MCP servers and auth; re-enable Kernel and re-authenticate).
 - Clear saved auth and retry: `rm -rf ~/.mcp-auth`
 - Ensure a recent Node.js version when using `npx mcp-remote`
 - If behind strict networks, try stdio via `mcp-remote`, or explicitly set the transport your client supports


### PR DESCRIPTION
## Description

Please provide an explanation of the changes you've made:

[Describe what this PR does and why]

## Implementation Checklist

- [ ] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [ ] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [ ] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [ ] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

[Drag and drop your screenshot/video here or use the following format:]
[![Screenshot description](image-url)]

## Related Issue

Fixes [Github issue link]

[If this corresponds to a fix from another Kernel OSS repo, include this:]

Fixes [Link to other repo]

[Replace with actual issue link, e.g., Fixes https://github.com/username/repo/issues/123]

## Additional Notes

[Any additional context, concerns, or notes for reviewers]

---

<!-- mesa-description-start -->
## TL;DR

Reorganized the CLI documentation, splitting the single reference page into multiple, command-specific pages for better navigation and clarity.

## Why we made these changes

The existing CLI documentation was a single, long page, making it difficult for users to quickly find information about specific commands. This restructuring improves the developer experience by organizing commands into logical groups, making the documentation easier to read and reference.

## What changed?

- Decomposed the monolithic `reference/cli.mdx` into smaller, more focused pages.
- Created new pages for each command group under `reference/cli/`:
    - `apps.mdx`
    - `auth.mdx`
    - `browsers.mdx`
- Converted the main `reference/cli.mdx` into a landing page that links to the new documentation sections.
- Restructured the `reference/mcp-server.mdx` documentation for better clarity.
- Updated `docs.json` to reflect the new documentation hierarchy in the side navigation.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->