### PR TITLE
Kernel SDK Installation Instructions

### DIFF
--- a/apps/develop.mdx
+++ b/apps/develop.mdx
@@ -19,7 +19,19 @@ An `Invocation` is a single execution of an action. Invocations can be triggered
 
 ## Getting started: create an app
 
-First, install the Kernel SDK and create an app.
+First, install the Kernel SDK for your language:
+
+<CodeGroup>
+```bash TypeScript/JavaScript
+npm install @onkernel/sdk
+```
+
+```bash Python
+pip install kernel
+```
+</CodeGroup>
+
+Then create an app:
 
 <CodeGroup>
 ```typescript Typescript/Javascript

--- a/apps/develop.mdx
+++ b/apps/develop.mdx
@@ -22,7 +22,7 @@ An `Invocation` is a single execution of an action. Invocations can be triggered
 First, install the Kernel SDK for your language:
 
 <CodeGroup>
-```bash TypeScript/JavaScript
+```bash Typescript/Javascript
 npm install @onkernel/sdk
 ```
 

--- a/browsers/create-a-browser.mdx
+++ b/browsers/create-a-browser.mdx
@@ -9,6 +9,12 @@ Kernel browsers were designed to be lightweight, fast, and efficient for cloud-b
 
 ## 1. Create a Kernel browser
 
+<Info>
+First, install the Kernel SDK:
+- JavaScript/TypeScript: `npm install @onkernel/sdk`
+- Python: `pip install kernel`
+</Info>
+
 Use our SDK to create a browser:
 
 <CreateBrowserSnippet />

--- a/browsers/create-a-browser.mdx
+++ b/browsers/create-a-browser.mdx
@@ -11,7 +11,7 @@ Kernel browsers were designed to be lightweight, fast, and efficient for cloud-b
 
 <Info>
 First, install the Kernel SDK:
-- JavaScript/TypeScript: `npm install @onkernel/sdk`
+- TypeScript/JavaScript: `npm install @onkernel/sdk`
 - Python: `pip install kernel`
 </Info>
 

--- a/browsers/create-a-browser.mdx
+++ b/browsers/create-a-browser.mdx
@@ -11,7 +11,7 @@ Kernel browsers were designed to be lightweight, fast, and efficient for cloud-b
 
 <Info>
 First, install the Kernel SDK:
-- TypeScript/JavaScript: `npm install @onkernel/sdk`
+- Typescript/Javascript: `npm install @onkernel/sdk`
 - Python: `pip install kernel`
 </Info>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,7 +9,7 @@ Kernel is a developer platform that provides Crazy Fast Browser Infrastructure f
 
 <Info>
 To use the Kernel SDK, install it first:
-- JavaScript/TypeScript: `npm install @onkernel/sdk`  
+- TypeScript/JavaScript: `npm install @onkernel/sdk`  
 - Python: `pip install kernel`
 </Info>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,7 +9,7 @@ Kernel is a developer platform that provides Crazy Fast Browser Infrastructure f
 
 <Info>
 To use the Kernel SDK, install it first:
-- TypeScript/JavaScript: `npm install @onkernel/sdk`  
+- Typescript/Javascript: `npm install @onkernel/sdk`  
 - Python: `pip install kernel`
 </Info>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,6 +7,12 @@ Kernel is a developer platform that provides Crazy Fast Browser Infrastructure f
 
 ## kernel.browsers.create()
 
+<Info>
+To use the Kernel SDK, install it first:
+- JavaScript/TypeScript: `npm install @onkernel/sdk`  
+- Python: `pip install kernel`
+</Info>
+
 If you are already familiar with browser vendors, you can immediately start using our browsers with `kernel.browsers.create()`. We return a CDP url that you can connect any Playwright or Puppeteer automation to.
 
 <CodeGroup>


### PR DESCRIPTION
## Description

Added instructions for installing the Kernel SDK in a project (TypeScript + Python). Locations determined by key entry points into docs.

## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof

<img width="732" height="157" alt="Screenshot 2025-09-03 at 3 41 23 PM" src="https://github.com/user-attachments/assets/537b3ecf-db19-4af5-ac03-55f8a89fbd72" />

---

<!-- mesa-description-start -->
## TL;DR

Added installation instructions for the Python and TypeScript Kernel SDKs to key entry points in the docs.

## Why we made these changes

To provide clear, accessible instructions for getting started with the Kernel SDK, ensuring users can correctly set up their projects for both Python and TypeScript.

## What changed?

- **`introduction.mdx`**: Added a new installation guide with commands for both `npm` and `pip`.
- **`apps/develop.mdx`**: Updated existing instructions to use language-specific tabs for TypeScript and Python installation.
- **`browsers/create-a-browser.mdx`**: Added an info block directing users to install the SDK with language-specific commands.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->