### PR TITLE
Danny/kernel 297 docs mention timeouts for async invocation

### DIFF
--- a/apps/invoke.mdx
+++ b/apps/invoke.mdx
@@ -17,6 +17,8 @@ You can invoke your app by making a `POST` request to Kernel's API or via the CL
 
 For long running jobs, use asynchronous invocations to trigger Kernel actions without waiting for the result. You can then poll its [status](/apps/status) for the result.
 
+<Info>Asynchronous invocations time out after 15 minutes.</Info>
+
 <AsyncInvocation />
 
 ## Via CLI

--- a/reference/cli/apps.mdx
+++ b/reference/cli/apps.mdx
@@ -21,7 +21,7 @@ Invoke a specific app action by its name. Generates an Invocation.
 | `--payload <payload_data>`, `-p` | Stringified JSON object (max 64 KB). Optional. |
 | `--sync`, `-s` | Invoke synchronously (default false). Optional. |
 
-<Info>Synchronous invocations open a long-lived HTTP POST that times out after 60 seconds. Press `ctrl-c` to terminate a running invocation; associated browsers are destroyed.</Info>
+<Info>Synchronous invocations open a long-lived HTTP POST that times out after 60 seconds. Asynchronous invocations time out after 15 minutes. Press `ctrl-c` to terminate a running invocation; associated browsers are destroyed.</Info>
 
 ## `kernel app list`
 List deployed application versions.

--- a/snippets/openapi/get-deployments.mdx
+++ b/snippets/openapi/get-deployments.mdx
@@ -6,9 +6,10 @@ const client = new Kernel({
   apiKey: 'My API Key',
 });
 
-const deployments = await client.deployments.list();
-
-console.log(deployments);
+// Automatically fetches more pages as needed.
+for await (const deploymentListResponse of client.deployments.list()) {
+  console.log(deploymentListResponse.id);
+}
 ```
 
 
@@ -18,7 +19,8 @@ from kernel import Kernel
 client = Kernel(
     api_key="My API Key",
 )
-deployments = client.deployments.list()
-print(deployments)
+page = client.deployments.list()
+page = page.items[0]
+print(page.id)
 ```
 </CodeGroup>


### PR DESCRIPTION
## Description

Added notes to the docs for 15 minute timeouts on async invocations.

## Implementation Checklist

- [N/A] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [N/A] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof

<img width="796" height="262" alt="Screenshot 2025-09-05 at 1 12 07 PM" src="https://github.com/user-attachments/assets/147f3864-b1f1-4dd8-9ee7-f9e3659eca12" />
