### PR TITLE
Updated deployment notes

### DIFF
--- a/apps/deploy.mdx
+++ b/apps/deploy.mdx
@@ -32,6 +32,7 @@ kernel deploy my_app.py --env MY_ENV_VAR=my_value # Can add multiple env vars de
 ## Deployment notes
 
 - The `entrypoint_file_name` is the file name where you [defined](/apps/develop) your app.
+- **The entrypoint file and dependency manifest (`package.json` for JS/TS, `pyproject.toml` for Python) must both be in the root directory of your project.**
 - Include a `.gitignore` file to exclude dependency folders like `node_modules` and `.venv`.
 - Kernel assumes the root directory contains at least this file structure:
 

--- a/reference/cli/apps.mdx
+++ b/reference/cli/apps.mdx
@@ -12,6 +12,10 @@ Deploy an app to Kernel from the current directory.
 | `--env <ENV_VAR=VAL>`, `-e` | Adds environment variables to the app. May be specified multiple times. Optional. |
 | `--env-file <file>` | Read environment variables from a .env file. May be specified multiple times. Optional. |
 
+<Info>
+The entrypoint file and dependency manifest (`package.json` for JS/TS, `pyproject.toml` for Python) must both be in the root directory of your project.
+</Info>
+
 ## `kernel invoke <app_name> <action_name>`
 Invoke a specific app action by its name. Generates an Invocation.
 


### PR DESCRIPTION
Added deployment notes about entrypoint file and dependency manifest to the Deploy CLI section + Deploy guide page.

## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof

<img width="759" height="283" alt="Screenshot 2025-09-10 at 11 30 17 AM" src="https://github.com/user-attachments/assets/23761cbb-6663-4308-a23f-205a7cf036f6" />

<img width="767" height="465" alt="Screenshot 2025-09-10 at 11 30 31 AM" src="https://github.com/user-attachments/assets/8dea70cf-f154-4890-9e86-76ed5a75eb04" />

---

<!-- mesa-description-start -->
## TL;DR

Clarified documentation for deployments, adding notes that an entrypoint file (e.g., `index.js`) and a dependency manifest (e.g., `package.json`) are required.

## Why we made these changes

The previous documentation was unclear about the required file structure for a deployment directory. This led to user confusion and failed deployments. These changes explicitly state the requirements to ensure a smoother developer experience.

## What changed?

- **`apps/deploy.mdx`**: Added a note to the main deployment guide clarifying the file requirements.
- **`reference/cli/apps.mdx`**: Added a similar note to the CLI reference documentation for the `deploy` command.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->