### PR TITLE
docs: Reorder Get Started pages in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -47,8 +47,8 @@
           {
             "group": "Get Started",
             "pages": [
-              "introduction",
-              "quickstart"
+              "quickstart",
+              "introduction"
             ]
           },
           {


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Reordered the 'Get Started' pages in the documentation sidebar.

## Why we made these changes

To improve the user journey by presenting the 'Get Started' topics in a more logical sequence, making the onboarding experience more intuitive for new users.

## What changed?

- Modified `docs.json` to update the sequence of pages under the 'Get Started' section.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->