### PR TITLE
docs: Reorder introduction before quickstart

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -47,8 +47,8 @@
           {
             "group": "Get Started",
             "pages": [
-              "quickstart",
-              "introduction"
+              "introduction",
+              "quickstart"
             ]
           },
           {


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Moved the "Introduction" page before "Quickstart" in the docs sidebar.

## Why we made these changes

To provide a more logical flow for new users. The introduction gives important context that should be read before the quickstart guide.

## What changed?

- Updated `docs.json` to reorder the navigation, placing `introduction.mdx` before `quickstart.mdx`.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->