### PR TITLE
Add docs for Cancelling invocation

### DIFF
--- a/apps/stop.mdx
+++ b/apps/stop.mdx
@@ -9,7 +9,38 @@ Terminating an invocation also destroys any browsers associated with it.
 </Info>
 
 ## Via API
-Stopping an invocation via the API is not available yet, but it's coming very soon.
+You can stop an invocation by setting its status to `failed`. This will cancel the invocation and mark it as terminated.
+
+<CodeGroup>
+
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+const invocation = await client.invocations.update('invocation_id', {
+  status: 'failed',
+  output: JSON.stringify({ error: 'Invocation cancelled by user' })
+});
+```
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+
+invocation = client.invocations.update(
+    id="invocation_id",
+    status='failed',
+    output='{"error":"Invocation cancelled by user"}'
+)
+```
+
+</CodeGroup>
 
 ## Via CLI
 Use `ctrl-c` in the terminal tab where you launched the invocation.


### PR DESCRIPTION
## Description

Please provide an explanation of the changes you've made:

This PR adds documentation for stopping/cancelling invocations via the API. Previously, the docs stated that stopping invocations via API was "coming very soon". This update provides clear examples showing how to stop an invocation by setting its status to `failed`, with code examples in both TypeScript/JavaScript and Python.

## Implementation Checklist

- [ ] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [ ] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)

## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Docs
- [ ] Link to a PR in our [docs repo](https://github.com/onkernel/docs) documenting your change (if applicable)
*This PR is already in the docs repo*

## Visual Proof

Please provide a screenshot or video demonstrating that your changes work locally:

The updated documentation shows:
- Clear explanation that invocations can be stopped by setting status to `failed`
- TypeScript/JavaScript example with proper SDK usage
- Python example with proper SDK usage
- Both examples include error output to indicate cancellation

## Related Issue

Fixes [Github issue link]

[If this corresponds to a fix from another Kernel OSS repo, include this:]

*No specific issue linked - this was a documentation improvement based on the Go client example provided*

## Additional Notes

- Verified the SDK schemas are correct by installing both `@onkernel/sdk` (npm) and `kernel` (pip) packages and testing the method signatures
- The examples follow the same pattern as other API documentation in the codebase
- Maintained consistency with the existing documentation style using `<CodeGroup>` for multi-language examples

---

<!-- mesa-description-start -->
## TL;DR

Added documentation for cancelling an API invocation by setting its status to `failed`.

## Why we made these changes

The previous documentation for this feature was a "coming soon" placeholder. This PR adds the official guide and code examples so users can cancel in-progress invocations via the API.

## What changed?

- Updated `apps/invoke.mdx` to replace the placeholder with a guide on cancelling invocations.
- Added code examples in a `<CodeGroup>` for both TypeScript/JavaScript and Python, demonstrating how to patch the invocation's status.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->