### PR TITLE
Add browser use guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
           {
             "group": "Integrations",
             "pages": [
+              "integrations/browser-use",
               "integrations/valtown",
               "integrations/vercel"
             ]

--- a/integrations/browser-use.mdx
+++ b/integrations/browser-use.mdx
@@ -1,0 +1,103 @@
+---
+title: "Browser Use"
+---
+
+[Browser Use](https://github.com/browser-use/browser-use) is the AI browser agent that empowers anyone to automate repetitive online tasks, no code required. By integrating with Kernel, you can run Browser Use Agents and automations with cloud-hosted browsers.
+
+## Adding Kernel to existing Browser Use implementations
+
+If you already have a Browser Use implementation, you can easily switch to using Kernel's cloud browsers by updating your Browser definition.
+
+### 1. Install the Kernel SDK
+
+```bash
+pip install onkernel
+```
+
+### 2. Initialize Kernel and create a browser
+
+Import the libraries and create a cloud browser session:
+
+```python
+from onkernel import Kernel
+from browser_use import Browser, Agent
+
+# Initialize Kernel client
+kernel = Kernel(api_key="your-api-key")
+
+# Create a Kernel browser session
+kernel_browser = kernel.browsers.create()
+```
+
+### 3. Update your Browser definition
+
+Replace your existing Browser initialization to use Kernel's CDP URL and display settings:
+
+```python
+# Update your Browser definition to use Kernel's CDP URL
+browser = Browser(
+    cdp_url=kernel_browser.cdp_ws_url,
+    headless=False,
+    window_size={'width': 1024, 'height': 786},
+    viewport={'width': 1024, 'height': 786},
+    device_scale_factor=1.0
+)
+```
+
+### 4. Create and run your agent
+
+Use your existing Agent setup with the Kernel-powered browser:
+
+```python
+# Use with your existing Agent setup
+agent = Agent(
+    task="Your automation task",
+    llm=your_llm_instance,
+    browser_session=browser
+)
+
+# Run your automation
+result = agent.run()
+
+# Clean up
+kernel.browsers.delete_by_id(kernel_browser.session_id)
+```
+
+<Info>
+If you're using Browser Use versions `< 0.7.9`, you may need to use a [custom resize class](https://github.com/onkernel/create-kernel-app/blob/main/templates/python/browser-use/session.py) to correct viewport sizing for the browser session. Here's how to use it:
+
+```python
+agent = Agent(
+    task="Your automation task",
+    llm=your_llm_instance,
+    browser_session=BrowserSessionCustomResize(cdp_url=kernel_browser.cdp_ws_url)
+)
+```
+</Info>
+
+## Quick setup with our Browser Use example app
+
+Alternatively, you can use our Kernel app template that includes a pre-configured Browser Use integration:
+
+```bash
+npx @onkernel/create-kernel-app my-browser-use-app
+```
+
+Choose Python as the programming language and then select `browser-use` as the template.
+
+Then follow the [Quickstart guide](/quickstart/) to deploy and run your Browser Use automation on Kernel's infrastructure.
+
+## Benefits of using Kernel with Browser Use
+
+- **No local browser management**: Run automations without installing or maintaining browsers locally
+- **Scalability**: Launch multiple browser sessions in parallel
+- **Stealth mode**: Built-in anti-detection features for web scraping
+- **Session persistence**: Maintain browser state across automation runs
+- **Live view**: Debug your automations with real-time browser viewing
+
+## Next steps
+
+- Check out [live view](/browsers/live-view) for debugging your automations
+- Learn about [stealth mode](/browsers/stealth) for avoiding detection
+- Learn how to properly [terminate browser sessions](/browsers/termination)
+- Learn how to [deploy](/apps/deploy) your Browser Use app to Kernel

--- a/snippets/openapi/delete-browsers-id.mdx
+++ b/snippets/openapi/delete-browsers-id.mdx
@@ -17,7 +17,7 @@ client = Kernel(
     api_key="My API Key",
 )
 client.browsers.delete_by_id(
-    "id",
+    "htzv5orfit78e1m2biiifpbv",
 )
 ```
 </CodeGroup>

--- a/snippets/openapi/delete-proxies-id.mdx
+++ b/snippets/openapi/delete-proxies-id.mdx
@@ -6,9 +6,7 @@ const client = new Kernel({
   apiKey: 'My API Key',
 });
 
-const invocation = await client.invocations.retrieve('rr33xuugxj9h0bkf1rdt2bet');
-
-console.log(invocation.id);
+await client.proxies.delete('id');
 ```
 
 
@@ -18,9 +16,8 @@ from kernel import Kernel
 client = Kernel(
     api_key="My API Key",
 )
-invocation = client.invocations.retrieve(
-    "rr33xuugxj9h0bkf1rdt2bet",
+client.proxies.delete(
+    "id",
 )
-print(invocation.id)
 ```
 </CodeGroup>

--- a/snippets/openapi/get-browsers-id.mdx
+++ b/snippets/openapi/get-browsers-id.mdx
@@ -19,7 +19,7 @@ client = Kernel(
     api_key="My API Key",
 )
 browser = client.browsers.retrieve(
-    "id",
+    "htzv5orfit78e1m2biiifpbv",
 )
 print(browser.session_id)
 ```

--- a/snippets/openapi/get-proxies-id.mdx
+++ b/snippets/openapi/get-proxies-id.mdx
@@ -6,9 +6,9 @@ const client = new Kernel({
   apiKey: 'My API Key',
 });
 
-const invocation = await client.invocations.retrieve('rr33xuugxj9h0bkf1rdt2bet');
+const proxy = await client.proxies.retrieve('id');
 
-console.log(invocation.id);
+console.log(proxy.id);
 ```
 
 
@@ -18,9 +18,9 @@ from kernel import Kernel
 client = Kernel(
     api_key="My API Key",
 )
-invocation = client.invocations.retrieve(
-    "rr33xuugxj9h0bkf1rdt2bet",
+proxy = client.proxies.retrieve(
+    "id",
 )
-print(invocation.id)
+print(proxy.id)
 ```
 </CodeGroup>

--- a/snippets/openapi/get-proxies.mdx
+++ b/snippets/openapi/get-proxies.mdx
@@ -6,9 +6,9 @@ const client = new Kernel({
   apiKey: 'My API Key',
 });
 
-const invocation = await client.invocations.retrieve('rr33xuugxj9h0bkf1rdt2bet');
+const proxies = await client.proxies.list();
 
-console.log(invocation.id);
+console.log(proxies);
 ```
 
 
@@ -18,9 +18,7 @@ from kernel import Kernel
 client = Kernel(
     api_key="My API Key",
 )
-invocation = client.invocations.retrieve(
-    "rr33xuugxj9h0bkf1rdt2bet",
-)
-print(invocation.id)
+proxies = client.proxies.list()
+print(proxies)
 ```
 </CodeGroup>

--- a/snippets/openapi/post-proxies.mdx
+++ b/snippets/openapi/post-proxies.mdx
@@ -6,9 +6,9 @@ const client = new Kernel({
   apiKey: 'My API Key',
 });
 
-const invocation = await client.invocations.retrieve('rr33xuugxj9h0bkf1rdt2bet');
+const proxy = await client.proxies.create({ type: 'datacenter' });
 
-console.log(invocation.id);
+console.log(proxy.id);
 ```
 
 
@@ -18,9 +18,9 @@ from kernel import Kernel
 client = Kernel(
     api_key="My API Key",
 )
-invocation = client.invocations.retrieve(
-    "rr33xuugxj9h0bkf1rdt2bet",
+proxy = client.proxies.create(
+    type="datacenter",
 )
-print(invocation.id)
+print(proxy.id)
 ```
 </CodeGroup>


### PR DESCRIPTION
Added browser user integration guide to docs. It includes a guide for integrating into an existing browser use implementation as well as starting from scratch with our app template.

## Implementation Checklist

- [n/a] If updating our sample apps, update the info in our [Quickstart](../quickstart.mdx)
- [n/a] If updating our CLI, update the info in our [CLI](../reference/cli.mdx)


## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof
<img width="820" height="752" alt="Screenshot 2025-09-24 at 3 15 51 PM" src="https://github.com/user-attachments/assets/dd9ad053-cf18-420b-aa1b-369148ed2c81" />