### PR TITLE
Danny/kernel 364 documentation update async invocations section to use

### DIFF
--- a/apps/invoke.mdx
+++ b/apps/invoke.mdx
@@ -15,7 +15,7 @@ You can invoke your app by making a `POST` request to Kernel's API or via the CL
 
 ### Asynchronous invocations
 
-For long running jobs, use asynchronous invocations to trigger Kernel actions without waiting for the result. You can then poll its [status](/apps/status) for the result.
+For long running jobs, use asynchronous invocations to trigger Kernel actions without waiting for the result. You can then stream real-time [status updates](/apps/status#streaming-status-updates) for the result.
 
 <Info>Asynchronous invocations time out after 15 minutes.</Info>
 

--- a/apps/status.mdx
+++ b/apps/status.mdx
@@ -3,11 +3,54 @@ title: "Status"
 ---
 
 import GetInvocationStatus from '/snippets/openapi/get-invocations-id.mdx';
+import GetInvocationEvents from '/snippets/openapi/get-invocations-id-events.mdx';
 
-Once you've [deployed](/apps/deploy) an app and invoked it, you can check its status.
-
-<GetInvocationStatus />
+Once you've [deployed](/apps/deploy) an app and invoked it, you can monitor its status using streaming for real-time updates or polling for periodic checks.
 
 <Info>
   An invocation ends once its code execution finishes.
 </Info>
+
+## Streaming Status Updates
+
+For real-time status monitoring, use `follow` to [stream invocation events](/api-reference/invocations/stream-invocation-events-via-sse). This provides immediate updates as your invocation progresses and is more efficient than polling.
+
+<GetInvocationEvents />
+
+### Example
+
+Here's an example showing how to handle streaming status updates:
+
+```javascript
+const result = await client.invocations.retrieve(invocation.id);
+
+const follow = await client.invocations.follow(result.id);
+for await (const evt of follow) {
+  if (evt.event === 'invocation_state') {
+    console.log(`Status: ${evt.invocation.status}`);
+
+    if (evt.invocation.status === 'succeeded') {
+      console.log('✅ Invocation completed successfully!');
+      if (evt.invocation.output) {
+        console.log('Result:', JSON.parse(evt.invocation.output));
+      }
+    } else if (evt.invocation.status === 'failed') {
+      console.log('❌ Invocation failed');
+      if (evt.invocation.status_reason) {
+        console.log('Error:', evt.invocation.status_reason);
+      }
+    }
+  } else if (evt.event === 'error') {
+    console.error('🚨 Error:', evt.error.message);
+  }
+}
+
+console.log('✅ Invocation successful!');
+console.log('Invocation result:', JSON.stringify(result, null, 2));
+```
+
+## Polling Status Updates
+
+Alternatively, you can poll the status endpoint using `retrieve` to check the invocation status periodically.
+
+<GetInvocationStatus />

--- a/snippets/openapi/get-invocations-id-events.mdx
+++ b/snippets/openapi/get-invocations-id-events.mdx
@@ -19,7 +19,7 @@ client = Kernel(
     api_key="My API Key",
 )
 response = client.invocations.follow(
-    "id",
+    id="id",
 )
 print(response)
 ```


### PR DESCRIPTION
## Description
Update the documentation to highlight streaming status updates as the recommended method for retrieving the status of an asynchronous invocation.

## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof

<img width="1093" height="854" alt="Screenshot 2025-09-25 at 11 20 36 AM" src="https://github.com/user-attachments/assets/4e8789d4-84e7-453b-8c94-b6d0694b9179" />