### PR TITLE
Danny/kernel 368 magnitude integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -82,6 +82,7 @@
             "group": "Integrations",
             "pages": [
               "integrations/browser-use",
+              "integrations/magnitude",
               "integrations/valtown",
               "integrations/vercel"
             ]

--- a/integrations/browser-use.mdx
+++ b/integrations/browser-use.mdx
@@ -83,7 +83,7 @@ Alternatively, you can use our Kernel app template that includes a pre-configure
 npx @onkernel/create-kernel-app my-browser-use-app
 ```
 
-Choose Python as the programming language and then select `browser-use` as the template.
+Choose `Python` as the programming language and then select `Browser Use` as the template.
 
 Then follow the [Quickstart guide](/quickstart/) to deploy and run your Browser Use automation on Kernel's infrastructure.
 

--- a/integrations/magnitude.mdx
+++ b/integrations/magnitude.mdx
@@ -1,0 +1,102 @@
+---
+title: "Magnitude"
+---
+
+[Magnitude](https://magnitude.run) is an open source AI browser automation framework. It uses vision AI to enable you to control your browser with natural language. By integrating with Kernel, you can run Magnitude agents and automations with cloud-hosted browsers.
+
+## Adding Kernel to existing Magnitude implementations
+
+If you already have a Magnitude implementation, you can easily switch to using Kernel's cloud browsers by updating your browser configuration.
+
+### 1. Install the Kernel SDK
+
+```bash
+npm install @onkernel/sdk
+```
+
+### 2. Initialize Kernel and create a browser
+
+Import the libraries and create a cloud browser session:
+
+```typescript
+import { startBrowserAgent } from "magnitude-core";
+import Kernel from '@onkernel/sdk';
+import z from 'zod';
+
+const client = new Kernel({
+    apiKey: process.env.KERNEL_API_KEY,
+});
+
+const kernelBrowser = await client.browsers.create();
+
+console.log(`Live view url: ${kernelBrowser.browser_live_view_url}`);
+```
+
+### 3. Update your browser configuration
+
+Replace your existing browser setup to use Kernel's CDP URL and display settings:
+
+```typescript
+const agent = await startBrowserAgent({
+    url: 'https://magnitasks.com',
+    narrate: true,
+    browser: {
+        cdp: kernelBrowser.cdp_ws_url,
+        contextOptions: {
+            viewport: { width: 1024, height: 768 }
+        }
+    },
+    virtualScreenDimensions: { width: 1024, height: 768 },
+    llm: {
+        provider: 'anthropic',
+        options: {
+            model: 'claude-sonnet-4-20250514'
+        }
+    }
+});
+```
+
+### 4. Use your agent
+
+Use Magnitude's agent methods with the Kernel-powered browser:
+
+```typescript
+await agent.act([
+    'click on "Tasks" in the sidebar',
+    'click on the first item in the "In Progress" column'
+]);
+
+const assignee = await agent.extract('Extract the task Assignee', z.string());
+
+await agent.stop();
+
+// Clean up the Kernel Browser Session
+await client.browsers.deleteByID(kernelBrowser.session_id);
+```
+
+## Quick setup with our Magnitude example app
+
+Alternatively, you can use our Kernel app template that includes a pre-configured Magnitude integration:
+
+```bash
+npx @onkernel/create-kernel-app my-magnitude-app
+```
+
+Choose `TypeScript` as the programming language and then select `Magnitude` as the template.
+
+Then follow the [Quickstart guide](/quickstart/) to deploy and run your Magnitude automation on Kernel's infrastructure.
+
+## Benefits of using Kernel with Magnitude
+
+- **No local browser management**: Run automations without installing or maintaining browsers locally
+- **Scalability**: Launch multiple browser sessions in parallel
+- **Stealth mode**: Built-in anti-detection features for web scraping
+- **Session persistence**: Maintain browser state across automation runs
+- **Live view**: Debug your automations with real-time browser viewing
+
+## Next steps
+
+- Check out [live view](/browsers/live-view) for debugging your automations
+- Learn about [stealth mode](/browsers/stealth) for avoiding detection
+- Learn how to properly [terminate browser sessions](/browsers/termination)
+- Learn how to [deploy](/apps/deploy) your Magnitude app to Kernel

--- a/snippets/openapi/get-invocations.mdx
+++ b/snippets/openapi/get-invocations.mdx
@@ -1,0 +1,26 @@
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const client = new Kernel({
+  apiKey: 'My API Key',
+});
+
+// Automatically fetches more pages as needed.
+for await (const invocationListResponse of client.invocations.list()) {
+  console.log(invocationListResponse.id);
+}
+```
+
+
+```python Python
+from kernel import Kernel
+
+client = Kernel(
+    api_key="My API Key",
+)
+page = client.invocations.list()
+page = page.items[0]
+print(page.id)
+```
+</CodeGroup>


### PR DESCRIPTION
## Description

Added Magnitude.run integration guide.

## Testing

- [x] `mintlify dev` works (see installation [here](https://mintlify.com/docs/installation#cli))

## Visual Proof

<img width="1304" height="970" alt="Screenshot 2025-09-26 at 3 27 06 PM" src="https://github.com/user-attachments/assets/21a20984-38db-4d98-a227-504e0781df0c" />