### PR TITLE
Per invocation log docs

### DIFF
--- a/apps/logs.mdx
+++ b/apps/logs.mdx
@@ -37,5 +37,5 @@ If you don't specify `--follow`, the logs will print to the terminal until 3 sec
 
 You can get logs for a specific invocation by adding:
 ```
--i --invocation    Show logs for a specific invocation/run of the app.
+-i --invocation <invocation id>    Show logs for a specific invocation of the app.
 ```

--- a/apps/logs.mdx
+++ b/apps/logs.mdx
@@ -34,3 +34,8 @@ kernel logs <app_name> --follow
 ```
 
 If you don't specify `--follow`, the logs will print to the terminal until 3 seconds of inactivity and then stops.
+
+You can get logs for a specific invocation by adding:
+```
+-i --invocation    Show logs for a specific invocation/run of the app.
+```


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Adds documentation for the new per-invocation logging feature, which allows users to view logs for a specific run of their application.

## Why we made these changes

Currently, users can only view global application logs, which makes it difficult to debug issues tied to a single invocation. This change introduces documentation for a feature that provides isolated log streams for each invocation, simplifying the debugging process.

## What changed?

- Updated `apps/logs.mdx` to document retrieving logs for a specific run using the `-i` or `--invocation` flag.

## Validation

- [ ] The new documentation page renders correctly.
- [ ] The code examples provided for the API/CLI are accurate and easy to follow.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->