### PR TITLE
Add Tzafon integration guide to computer use section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -172,6 +172,7 @@
                   "integrations/computer-use/gemini",
                   "integrations/computer-use/openagi",
                   "integrations/computer-use/openai",
+                  "integrations/computer-use/tzafon",
                   "integrations/computer-use/yutori"
                 ]
               },

--- a/integrations/computer-use/tzafon.mdx
+++ b/integrations/computer-use/tzafon.mdx
@@ -2,7 +2,7 @@
 title: "Tzafon"
 ---
 
-[Northstar CUA Fast](https://docs.lightcone.ai/) is Tzafon's vision language model trained with reinforcement learning for computer use tasks. It implements a CUA (computer use agent) loop that predicts browser actions from screenshots, enabling AI agents to interact with web interfaces.
+[Northstar CUA Fast](https://www.tzafon.ai/) is Tzafon's vision language model trained with reinforcement learning for computer use tasks. It implements a CUA (computer use agent) loop that predicts browser actions from screenshots, enabling AI agents to interact with web interfaces.
 
 The model is accessed via Tzafon's [Lightcone](https://docs.lightcone.ai/) API platform. By integrating Tzafon with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure using Kernel's Computer Controls API, eliminating the need for local browser management and enabling scalable, reliable AI agents.
 

--- a/integrations/computer-use/tzafon.mdx
+++ b/integrations/computer-use/tzafon.mdx
@@ -1,0 +1,36 @@
+---
+title: "Tzafon"
+---
+
+[Northstar CUA Fast](https://docs.lightcone.ai/) is Tzafon's vision language model trained with reinforcement learning for computer use tasks. It implements a CUA (computer use agent) loop that predicts browser actions from screenshots, enabling AI agents to interact with web interfaces.
+
+The model is accessed via Tzafon's [Lightcone](https://docs.lightcone.ai/) API platform. By integrating Tzafon with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure using Kernel's Computer Controls API, eliminating the need for local browser management and enabling scalable, reliable AI agents.
+
+## Quick setup with our Tzafon example app
+
+Get started quickly with our Kernel app template that includes a pre-configured Tzafon Northstar CUA Fast integration:
+
+```bash
+kernel create --name my-tzafon-app --template tzafon
+```
+
+Choose `TypeScript` or `Python` as the programming language.
+
+Then follow the [Quickstart guide](/quickstart/) to deploy and run your Tzafon automation on Kernel's infrastructure.
+
+## Benefits of using Kernel with Tzafon Northstar CUA Fast
+
+- **No local browser management**: Run Northstar CUA Fast automations without installing or maintaining browsers locally
+- **Scalability**: Launch multiple browser sessions in parallel for concurrent AI agents
+- **Stealth mode**: Built-in anti-detection features for reliable web interactions
+- **Session state**: Maintain browser state across runs via [Profiles](/auth/profiles)
+- **Live view**: Debug your Tzafon agents with real-time browser viewing
+- **Cloud infrastructure**: Run computationally intensive AI agents without local resource constraints
+
+## Next steps
+
+- Check out [live view](/browsers/live-view) for debugging your automations
+- Learn about [stealth mode](/browsers/bot-detection/stealth) for avoiding detection
+- Learn how to properly [terminate browser sessions](/browsers/termination)
+- Learn how to [deploy](/apps/deploy) your Tzafon app to Kernel
+- Read the [Lightcone API documentation](https://docs.lightcone.ai/) for model details

--- a/integrations/computer-use/tzafon.mdx
+++ b/integrations/computer-use/tzafon.mdx
@@ -2,7 +2,7 @@
 title: "Tzafon"
 ---
 
-[Northstar CUA Fast](https://www.tzafon.ai/) is Tzafon's vision language model trained with reinforcement learning for computer use tasks. It implements a CUA (computer use agent) loop that predicts browser actions from screenshots, enabling AI agents to interact with web interfaces.
+Northstar CUA Fast is [Tzafon's](https://www.tzafon.ai/) vision language model trained with reinforcement learning for computer use tasks. It implements a CUA (computer use agent) loop that predicts browser actions from screenshots, enabling AI agents to interact with web interfaces.
 
 The model is accessed via Tzafon's [Lightcone](https://docs.lightcone.ai/) API platform. By integrating Tzafon with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure using Kernel's Computer Controls API, eliminating the need for local browser management and enabling scalable, reliable AI agents.
 


### PR DESCRIPTION
Adds a new Tzafon (Northstar CUA Fast) integration guide page under the computer use section of integration guides, following the same structure as other CUA provider pages.

## Changes
- New file: `integrations/computer-use/tzafon.mdx`
- Updated `docs.json` navigation to include Tzafon in the Computer Use group (alphabetically between OpenAI and Yutori)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new integration page and a navigation entry; no runtime code paths are affected.
> 
> **Overview**
> Adds a new `integrations/computer-use/tzafon.mdx` guide documenting how to use Tzafon (Northstar CUA Fast via Lightcone) with Kernel, including a `kernel create --template tzafon` quick setup and links to related Kernel features.
> 
> Updates `docs.json` navigation to include the new Tzafon page under **Integrations → Computer Use**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9f6866636729e20b90a491d5c7983defa9d1347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->