### PR TITLE
Update DPA subprocessor list URLs from Delve to Trust Center

### DIFF
--- a/dpa.mdx
+++ b/dpa.mdx
@@ -2,7 +2,7 @@
 title: "Data Processing Agreement"
 ---
 
-Last Modified: November 10, 2025
+Last Modified: April 13, 2026
 
 This Data Processing Addendum (“DPA”) supplements the [Master Services Agreement](/tos) (the “Agreement”) entered into by and between Customer, as identified in the Agreement, (“Customer”) and Kernel Technologies, Inc. (“Kernel”) (together with Customer, the “Parties”). This DPA incorporates the terms of the Agreement. Kernel may update this DPA from time to time, and we will provide reasonable notice of any such updates. Any terms not defined in this DPA shall have the meaning set forth in the Agreement.  
 
@@ -227,7 +227,7 @@ Role (controller/processor): As provided in Section 2 of the DPA.
 | Purpose of the Processing | As described in Exhibit A of the DPA |
 | Duration of Processing and Retention (or the criteria to determine such period) | As described in Exhibit A of the DPA |
 | Frequency of the transfer | As necessary to provide perform all obligations and rights with respect to Personal Data as provided in the Agreement or DPA |
-| Recipients of Personal Data Transferred to the Data Importer | A list of the Company's Authorized Subprocessors is available at https://trust.delve.co/kernel.  |
+| Recipients of Personal Data Transferred to the Data Importer | A list of the Company's Authorized Subprocessors is available at https://trust.kernel.sh/subprocessors.  |
 
 3. **Competent Supervisory Authority**
 
@@ -235,7 +235,7 @@ The supervisory authority shall be the supervisory authority of the Data Exporte
 
 4. **List of Authorized Subprocessors**
 
-A list of the Company's Authorized Subprocessors is available at https://trust.delve.co/kernel.  
+A list of the Company's Authorized Subprocessors is available at https://trust.kernel.sh/subprocessors.  
 
 ## Exhibit C
 


### PR DESCRIPTION
## Summary
- Replaced 2 stale `trust.delve.co/kernel` URLs in the DPA with `trust.kernel.sh/subprocessors` (Exhibit B sections 2 and 4)
- Updated Last Modified date from November 10, 2025 to April 13, 2026

Kernel migrated from Delve to Vanta for compliance management, but the published DPA still pointed customers to the old Delve trust center for the authorized subprocessor list. That URL no longer works.

## Test plan
- [ ] Verify https://trust.kernel.sh/subprocessors loads correctly
- [ ] Confirm the DPA renders properly at kernel.sh/docs/dpa after merge


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits a legal document only, updating referenced URLs and the modification date with no impact on product behavior. Risk is limited to potential broken/incorrect links if the new trust center URL changes.
> 
> **Overview**
> Updates `dpa.mdx` to replace the Authorized Subprocessors list link from `trust.delve.co/kernel` to `https://trust.kernel.sh/subprocessors` in Exhibit B (transfer recipients and subprocessor list sections).
> 
> Also updates the DPA **Last Modified** date to `April 13, 2026`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf5bbb6bdb470dffbef7b0c2563cdf33b487046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->