### PR TITLE
Link GPU availability section to pricing page

### DIFF
--- a/browsers/gpu-acceleration.mdx
+++ b/browsers/gpu-acceleration.mdx
@@ -5,7 +5,7 @@ title: GPU Acceleration
 GPU acceleration enables GPU-accelerated rendering in Kernel browsers, providing enhanced performance for graphics-intensive workloads.
 
 <Warning>
-GPU acceleration is only available for headful browsers and does not support [standby mode](/browsers/standby).
+GPU acceleration is only available for headful browsers and does not support [standby mode](/browsers/standby). GPU browsers have [separate pricing](https://kernel.sh/pricing) from headless or headful browsers.
 </Warning>
 
 ## Enable GPU acceleration

--- a/browsers/gpu-acceleration.mdx
+++ b/browsers/gpu-acceleration.mdx
@@ -46,4 +46,4 @@ GPU acceleration is useful for:
 
 ## Availability
 
-GPU acceleration is available on Start-Up and Enterprise plans. Due to limited capacity during the research preview, GPU-enabled browsers may not always be available.
+GPU acceleration is available on [Start-Up and Enterprise plans](https://kernel.sh/pricing). Due to limited capacity during the research preview, GPU-enabled browsers may not always be available.


### PR DESCRIPTION
## Summary

Adds a link to the [pricing page](https://kernel.sh/pricing) from the GPU acceleration docs. The Availability section mentions Start-Up and Enterprise plans but didn't link to pricing — now it does.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds links and clarifies pricing/availability; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `GPU Acceleration` docs to link plan availability to the pricing page and clarifies in the warning callout that GPU-enabled browsers have separate pricing from standard headful/headless browsers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3094deb9612961e10c42f660c3b0d42dcf9e2e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->