### PR TITLE
Add April 17 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,24 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="April 17" tags={["Product", "Docs"]}>
+## Product updates
+
+- Managed auth now scrolls to find and click submit buttons that are below the initial viewport.
+- Added a [Tzafon](https://www.tzafon.ai/) Northstar computer use template to the [CLI](https://github.com/kernel/cli) for building Northstar-based browser agents.
+- Browser search now matches by pool name in addition to session ID, profile, and proxy.
+- Added an enterprise option to remove the Kernel logo from the live view loading screen, useful when embedding live views in customer-facing products.
+- Eliminated live view scrollbar flickering on mobile viewports.
+- Fixed Safari clipboard paste issues in live view iframes.
+
+## Documentation updates
+
+- Added a new [Tzafon Northstar](/integrations/computer-use/tzafon) integration guide.
+- Updated the [bot anti-detection](/browsers/bot-detection) page to document smooth Bezier curve mouse movements, and renamed the Chrome policy configuration page in the nav for clarity.
+- Added documentation for [smooth typing with typo injection](/browsers/computer-controls) — new `smooth` and `typo_chance` parameters for human-like `typeText` behavior.
+- Updated DPA subprocessor list URLs to point to the new trust center at `trust.kernel.sh`.
+</Update>
+
 <Update label="April 10" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -15,7 +15,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Managed auth now scrolls to find and click submit buttons that are below the initial viewport.
 - Added a [Tzafon](https://www.tzafon.ai/) Northstar computer use template to the [CLI](https://github.com/kernel/cli) for building Northstar-based browser agents.
 - Browser search now matches by pool name in addition to session ID, profile, and proxy.
-- Added an enterprise option to remove the Kernel logo from the live view loading screen, useful when embedding live views in customer-facing products.
+- Added an [enterprise option](/info/pricing) to remove the Kernel logo from the live view loading screen.
 - Eliminated live view scrollbar flickering on mobile viewports.
 - Fixed Safari clipboard paste issues in live view iframes.
 


### PR DESCRIPTION
Adds the April 17 changelog entry with Product and Docs tags.

**Product updates:**
- Managed auth viewport scrolling for submit buttons
- Tzafon Northstar CLI template
- Browser search by pool name
- Enterprise live view logo removal option
- Mobile viewport scrollbar fix
- Safari clipboard paste fix

**Documentation updates:**
- Tzafon Northstar integration guide
- Bot anti-detection Bezier mouse movement docs
- Smooth typing with typo injection docs
- DPA subprocessor list URL update to trust.kernel.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new changelog entry; minimal risk beyond potential copy/link accuracy.
> 
> **Overview**
> Adds a new `April 17` entry to `changelog.mdx` tagged `Product` and `Docs`, documenting recent managed auth, live view, browser search, and CLI template updates.
> 
> Also includes doc callouts for a new Tzafon Northstar integration guide, updates to bot anti-detection and smooth typing docs/parameters, and moves DPA subprocessor links to `trust.kernel.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c40194c6b9981f87176a3e559beecaafce39d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->