### PR TITLE
Clarify stealth mode: anti-detection is the platform default

### DIFF
--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -25,10 +25,10 @@ These systems are heuristic and probabilistic — small mismatches can still tri
 
 ## Kernel Features That Help
 ### Anti-detection defaults
-Every Kernel browser launches with our anti-detection chrome configuration applied. You don't have to enable anything to get this baseline.
+Every Kernel browser launches with anti-detection chrome configuration applied. No setup required.
 
 ### [Stealth Mode](/browsers/bot-detection/stealth)
-On top of the defaults, stealth mode adds two managed services: a default residential proxy and an automatic CAPTCHA solver. Both can be opted out so you can BYO proxy and/or CAPTCHA tooling without losing the anti-detection baseline.
+On top of the defaults, stealth mode adds a default residential proxy and an automatic CAPTCHA solver. Both are opt-out so you can BYO proxy and/or CAPTCHA tooling.
 
 ### [Configurable Proxies](/proxies/overview)
 Bring your own proxy network or use Kernel's managed pool (selectable down to ZIP-code level). If needed, use the same IP to reduce detection and allow for regional testing or QA.

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -24,8 +24,11 @@ Most detection systems look for inconsistencies between how a real user's browse
 These systems are heuristic and probabilistic — small mismatches can still trigger blocks. The goal isn't to “beat” detection but rather emulate the real-world conditions of a normal browser session.
 
 ## Kernel Features That Help
+### Anti-detection defaults
+Every Kernel browser launches with our anti-detection chrome configuration applied. You don't have to enable anything to get this baseline.
+
 ### [Stealth Mode](/browsers/bot-detection/stealth)
-A basic configuration that launches Kernel's browser through a residential proxy and integrates a Google [reCAPTCHA solver](https://www.google.com/recaptcha/api2/demo).
+On top of the defaults, stealth mode adds two managed services: a default residential proxy and an automatic CAPTCHA solver. Both can be opted out so you can BYO proxy and/or CAPTCHA tooling without losing the anti-detection baseline.
 
 ### [Configurable Proxies](/proxies/overview)
 Bring your own proxy network or use Kernel's managed pool (selectable down to ZIP-code level). If needed, use the same IP to reduce detection and allow for regional testing or QA.

--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -2,14 +2,14 @@
 title: "Stealth Mode"
 ---
 
-All Kernel browsers ship with our anti-detection optimizations applied by default. Chrome launches with a hardened configuration tuned to look like a normal browser — you don't need to enable stealth mode to get this baseline.
+All Kernel browsers ship with anti-detection optimizations by default — you don't need stealth mode for this baseline.
 
-Enabling `stealth` mode adds two managed services on top of the defaults:
+Enabling `stealth` mode adds two managed services on top:
 
-1. **Default residential proxy** — traffic egresses through Kernel's recommended residential proxy pool.
-2. **Automatic CAPTCHA solver** — an extension is loaded into the browser to solve [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo), Cloudflare challenges, and similar tests automatically.
+1. **Default residential proxy** — traffic routes through Kernel's residential proxy pool.
+2. **Automatic CAPTCHA solver** — solves [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo), Cloudflare challenges, and similar tests automatically.
 
-Both are designed to be opt-out so you can bring your own infrastructure where it makes sense — see [Bring your own proxy or CAPTCHA solver](#bring-your-own-proxy-or-captcha-solver) below.
+Both are opt-out so you can [bring your own](#bring-your-own-proxy-or-captcha-solver) where it makes sense.
 
 To turn on stealth mode, set its flag when instantiating Kernel browsers:
 
@@ -37,11 +37,11 @@ kernel_browser = kernel.browsers.create(
 
 ## Bring your own proxy or CAPTCHA solver
 
-Because anti-detection is the platform default, you don't have to choose between Kernel's anti-detection layer and your own networking or CAPTCHA tooling. Common patterns:
+Anti-detection is the platform default, so you can freely mix in your own networking or CAPTCHA tooling. Common patterns:
 
-- **BYO proxy, keep CAPTCHA solver** — launch a stealth browser, attach your own [proxy](/proxies/overview) via `proxy_id`, and the residential default is replaced while the CAPTCHA solver stays loaded.
-- **BYO proxy, no CAPTCHA solver** — launch a non-stealth browser with your own `proxy_id`. You still get the full anti-detection chrome configuration, just without the managed proxy and CAPTCHA extension.
-- **Disable the default proxy at runtime** — for stealth browsers already running, set [`disable_default_proxy`](/proxies/overview#disable-default-proxy-on-stealth-browsers) to route directly without losing the CAPTCHA solver.
+- **BYO proxy, keep CAPTCHA solver** — launch a stealth browser with your own [proxy](/proxies/overview) via `proxy_id`. Replaces the residential default; CAPTCHA solver stays loaded.
+- **BYO proxy, no CAPTCHA solver** — launch a non-stealth browser with your own `proxy_id`. Full anti-detection config, no managed proxy or CAPTCHA extension.
+- **Disable the default proxy at runtime** — on a running stealth browser, set [`disable_default_proxy`](/proxies/overview#disable-default-proxy-on-stealth-browsers) to route directly while keeping the CAPTCHA solver.
 
 If you're looking for proxy-level configuration with Kernel browsers, see [Proxies](/proxies/overview).
 

--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -2,7 +2,14 @@
 title: "Stealth Mode"
 ---
 
-Kernel browsers can be configured to `stealth` mode, which automatically adds our recommended proxy to your browser instances. It also adds a `reCAPTCHA solver` to the browser, so it automatically solves [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo) on your behalf.
+All Kernel browsers ship with our anti-detection optimizations applied by default. Chrome launches with a hardened configuration tuned to look like a normal browser — you don't need to enable stealth mode to get this baseline.
+
+Enabling `stealth` mode adds two managed services on top of the defaults:
+
+1. **Default residential proxy** — traffic egresses through Kernel's recommended residential proxy pool.
+2. **Automatic CAPTCHA solver** — an extension is loaded into the browser to solve [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo), Cloudflare challenges, and similar tests automatically.
+
+Both are designed to be opt-out so you can bring your own infrastructure where it makes sense — see [Bring your own proxy or CAPTCHA solver](#bring-your-own-proxy-or-captcha-solver) below.
 
 To turn on stealth mode, set its flag when instantiating Kernel browsers:
 
@@ -28,7 +35,15 @@ kernel_browser = kernel.browsers.create(
 ```
 </CodeGroup>
 
-If you're looking for proxy-level configuration with Kernel browsers, see [Proxies](/proxies/overview). To disable the default proxy on a running stealth browser, see [Disable default proxy](/proxies/overview#disable-default-proxy-on-stealth-browsers).
+## Bring your own proxy or CAPTCHA solver
+
+Because anti-detection is the platform default, you don't have to choose between Kernel's anti-detection layer and your own networking or CAPTCHA tooling. Common patterns:
+
+- **BYO proxy, keep CAPTCHA solver** — launch a stealth browser, attach your own [proxy](/proxies/overview) via `proxy_id`, and the residential default is replaced while the CAPTCHA solver stays loaded.
+- **BYO proxy, no CAPTCHA solver** — launch a non-stealth browser with your own `proxy_id`. You still get the full anti-detection chrome configuration, just without the managed proxy and CAPTCHA extension.
+- **Disable the default proxy at runtime** — for stealth browsers already running, set [`disable_default_proxy`](/proxies/overview#disable-default-proxy-on-stealth-browsers) to route directly without losing the CAPTCHA solver.
+
+If you're looking for proxy-level configuration with Kernel browsers, see [Proxies](/proxies/overview).
 
 ## CAPTCHA Handling Behavior
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,11 +12,11 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="April 19" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Anti-detection chrome configuration is now applied to **every** Kernel browser by default. Previously this hardened flag set was only applied to stealth browsers. Stealth mode now exclusively manages the default residential proxy and CAPTCHA solver — both of which remain opt-out so you can [bring your own](/browsers/bot-detection/stealth#bring-your-own-proxy-or-captcha-solver) proxy or CAPTCHA tooling without losing the anti-detection baseline.
+- Anti-detection chrome configuration is now applied to **every** Kernel browser by default — previously only stealth browsers. Stealth mode now exclusively manages the default residential proxy and CAPTCHA solver, both of which remain [opt-out](/browsers/bot-detection/stealth#bring-your-own-proxy-or-captcha-solver).
 
 ## Documentation updates
 
-- Rewrote the [Stealth Mode](/browsers/bot-detection/stealth) page to clarify that anti-detection is the platform default and to document the BYO proxy / BYO CAPTCHA patterns as first-class flows.
+- Rewrote the [Stealth Mode](/browsers/bot-detection/stealth) page to clarify anti-detection defaults and document BYO proxy / CAPTCHA patterns.
 - Added a [Bring your own proxy](/proxies/overview#bring-your-own-proxy) section to the proxies overview.
 </Update>
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,17 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="April 19" tags={["Product", "Docs"]}>
+## Product updates
+
+- Anti-detection chrome configuration is now applied to **every** Kernel browser by default. Previously this hardened flag set was only applied to stealth browsers. Stealth mode now exclusively manages the default residential proxy and CAPTCHA solver — both of which remain opt-out so you can [bring your own](/browsers/bot-detection/stealth#bring-your-own-proxy-or-captcha-solver) proxy or CAPTCHA tooling without losing the anti-detection baseline.
+
+## Documentation updates
+
+- Rewrote the [Stealth Mode](/browsers/bot-detection/stealth) page to clarify that anti-detection is the platform default and to document the BYO proxy / BYO CAPTCHA patterns as first-class flows.
+- Added a [Bring your own proxy](/proxies/overview#bring-your-own-proxy) section to the proxies overview.
+</Update>
+
 <Update label="April 17" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -253,7 +253,7 @@ If you swap the proxy on a browser acquired from a pool, the browser will be res
 
 ### Bring your own proxy
 
-You can attach a custom `proxy_id` to any browser — stealth or non-stealth — and Kernel's anti-detection chrome configuration still applies. If you want full anti-detection without Kernel's managed residential proxy or CAPTCHA solver, launch a non-stealth browser with your own `proxy_id`:
+Attach a custom `proxy_id` to any browser — stealth or non-stealth — and Kernel's anti-detection config still applies. For full anti-detection without the managed proxy or CAPTCHA solver, launch a non-stealth browser with your own `proxy_id`:
 
 <CodeGroup>
 ```typescript Typescript/Javascript

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -251,6 +251,26 @@ The update is synchronous — when the call returns, the proxy swap is fully app
 If you swap the proxy on a browser acquired from a pool, the browser will be reset back to the pool's default proxy configuration when it is released. Releasing the browser will be delayed by the swap duration (~2-3 seconds) while the proxy is restored to the pool default.
 </Info>
 
+### Bring your own proxy
+
+You can attach a custom `proxy_id` to any browser — stealth or non-stealth — and Kernel's anti-detection chrome configuration still applies. If you want full anti-detection without Kernel's managed residential proxy or CAPTCHA solver, launch a non-stealth browser with your own `proxy_id`:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const browser = await kernel.browsers.create({
+  stealth: false,
+  proxy_id: myProxy.id,
+});
+```
+
+```python Python
+browser = kernel.browsers.create(
+    stealth=False,
+    proxy_id=my_proxy.id,
+)
+```
+</CodeGroup>
+
 ### Disable default proxy on stealth browsers
 
 [Stealth browsers](/browsers/bot-detection/stealth) are automatically assigned a proxy. To disable this on a running stealth browser and route traffic directly, set `disable_default_proxy` to `true`:


### PR DESCRIPTION
## Summary

Updates the docs to reflect that anti-detection optimizations are applied to every Kernel browser by default. Stealth mode is now scoped to two managed services on top of that baseline — the default residential proxy and the automatic CAPTCHA solver — both of which remain opt-out.

This makes BYO-proxy / BYO-CAPTCHA a first-class story: customers can keep their own networking and CAPTCHA tooling without losing the anti-detection baseline.

### Changes

- **`browsers/bot-detection/stealth.mdx`** — rewrote the intro and added a *Bring your own proxy or CAPTCHA solver* section documenting the common BYO patterns.
- **`browsers/bot-detection/overview.mdx`** — added an *Anti-detection defaults* section above the Stealth Mode blurb and tightened the Stealth Mode description.
- **`proxies/overview.mdx`** — added a *Bring your own proxy* section showing how to pair a custom `proxy_id` with a non-stealth browser.
- **`changelog.mdx`** — April 19 entry covering the platform change and the doc updates.

## Test plan

- [ ] Mintlify preview renders all four pages without layout regressions.
- [ ] Anchor links in the rewritten stealth page resolve (`#bring-your-own-proxy-or-captcha-solver`, `#disable-default-proxy-on-stealth-browsers`).
- [ ] Changelog entry shows up correctly above the April 17 entry.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify existing behavior around anti-detection defaults, stealth mode services, and proxy/CAPTCHA configuration patterns.
> 
> **Overview**
> Clarifies in the bot-detection docs that **anti-detection Chrome configuration now applies to all Kernel browsers by default**, and reframes `stealth` mode as *only* adding the managed residential proxy and automatic CAPTCHA solver (both opt-out).
> 
> Updates the Stealth Mode and Proxies docs to document common **BYO proxy / BYO CAPTCHA** setups (including using `proxy_id` with non-stealth browsers and linking to `disable_default_proxy`), and adds an April 19 `changelog.mdx` entry capturing these product/docs changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4289122abe9eb8e724c92685578b6f9bc67511d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->