### PR TITLE
docs: add Cloudflare to Web Bot Auth partners

### DIFF
--- a/browsers/bot-detection/web-bot-auth.mdx
+++ b/browsers/bot-detection/web-bot-auth.mdx
@@ -3,7 +3,7 @@ title: "Web Bot Auth"
 description: "Cryptographically sign browser requests with Web Bot Auth"
 ---
 
-[Web Bot Auth](https://datatracker.ietf.org/doc/html/draft-meunier-web-bot-auth-architecture) is quickly becoming the standard way for agents to establish identity. That's why we've partnered with [Vercel](https://bots.fyi/d/kernel) to support Web Bot Auth on Kernel.
+[Web Bot Auth](https://datatracker.ietf.org/doc/html/draft-meunier-web-bot-auth-architecture) is quickly becoming the standard way for agents to establish identity. That's why we've partnered with [Vercel](https://bots.fyi/d/kernel) and [Cloudflare](https://radar.cloudflare.com/bots/directory/kernel) to support Web Bot Auth on Kernel.
 
 ![Kernel on Vercel's public directory of known bots used across the web](/images/botsfyi.png)
 


### PR DESCRIPTION
## Summary

- Mention Cloudflare alongside Vercel as a Web Bot Auth partner
- Link to the Kernel entry on Cloudflare's bot directory: https://radar.cloudflare.com/bots/directory/kernel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding a partner mention and link; no runtime or API behavior is affected.
> 
> **Overview**
> Adds Cloudflare to the `Web Bot Auth` documentation as an additional partner directory alongside Vercel, including a link to Kernel’s Cloudflare bot directory entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3439e7e06e35127667bad069818880cc55423cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->