### PR TITLE
fix(auth): define page before use in overview example

### DIFF
--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -74,23 +74,36 @@ if state.status == "AUTHENTICATED":
 
 <CodeGroup>
 ```typescript TypeScript
-const browser = await kernel.browsers.create({
+import { chromium } from 'playwright';
+
+const kernelBrowser = await kernel.browsers.create({
   profile: { name: 'netflix-user-123' },
   stealth: true,
 });
+
+const browser = await chromium.connectOverCDP(kernelBrowser.cdp_ws_url);
+const context = browser.contexts()[0];
+const page = context.pages()[0];
 
 // Navigate to the site—you're already logged in
 await page.goto('https://netflix.com');
 ```
 
 ```python Python
-browser = await kernel.browsers.create(
+from playwright.async_api import async_playwright
+
+kernel_browser = await kernel.browsers.create(
     profile={"name": "netflix-user-123"},
     stealth=True,
 )
 
-# Navigate to the site—you're already logged in
-await page.goto("https://netflix.com")
+async with async_playwright() as playwright:
+    browser = await playwright.chromium.connect_over_cdp(kernel_browser.cdp_ws_url)
+    context = browser.contexts[0]
+    page = context.pages[0]
+
+    # Navigate to the site—you're already logged in
+    await page.goto("https://netflix.com")
 ```
 </CodeGroup>
 

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -24,11 +24,11 @@ const auth = await kernel.auth.connections.create({
 ```
 
 ```python Python
-from kernel import AsyncKernel
+from kernel import Kernel
 
-kernel = AsyncKernel()
+kernel = Kernel()
 
-auth = await kernel.auth.connections.create(
+auth = kernel.auth.connections.create(
     domain="netflix.com",
     profile_name="netflix-user-123",
 )
@@ -60,16 +60,18 @@ if (state.status === 'AUTHENTICATED') {
 ```
 
 ```python Python
-login = await kernel.auth.connections.login(auth.id)
+import time
+
+login = kernel.auth.connections.login(auth.id)
 
 # Send user to login page
 print(f"Login URL: {login.hosted_url}")
 
 # Poll until complete
-state = await kernel.auth.connections.retrieve(auth.id)
+state = kernel.auth.connections.retrieve(auth.id)
 while state.flow_status == "IN_PROGRESS":
-    await asyncio.sleep(2)
-    state = await kernel.auth.connections.retrieve(auth.id)
+    time.sleep(2)
+    state = kernel.auth.connections.retrieve(auth.id)
 
 if state.status == "AUTHENTICATED":
     print("Authenticated!")
@@ -100,7 +102,7 @@ await page.goto('https://netflix.com');
 ```python Python
 from playwright.async_api import async_playwright
 
-kernel_browser = await kernel.browsers.create(
+kernel_browser = kernel.browsers.create(
     profile={"name": "netflix-user-123"},
     stealth=True,
 )

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -13,6 +13,10 @@ Managed Auth creates and maintains authenticated browser sessions for your AI ag
 
 <CodeGroup>
 ```typescript TypeScript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
 const auth = await kernel.auth.connections.create({
   domain: 'netflix.com',
   profile_name: 'netflix-user-123',
@@ -20,6 +24,10 @@ const auth = await kernel.auth.connections.create({
 ```
 
 ```python Python
+from kernel import AsyncKernel
+
+kernel = AsyncKernel()
+
 auth = await kernel.auth.connections.create(
     domain="netflix.com",
     profile_name="netflix-user-123",


### PR DESCRIPTION
## Summary

The Step 3 (\"Use the Profile\") code snippet in `auth/overview.mdx` calls `page.goto(...)` but never defines `page`. Copy-pasting the snippet produces an immediate `NameError` (Python) / `ReferenceError` (TypeScript).

## Fix

Mirror the canonical CDP connection pattern used in `browsers/create-a-browser.mdx`:

- Rename the Kernel browser handle to `kernelBrowser` / `kernel_browser` so it does not collide with the Playwright `Browser` object.
- Connect to the Kernel browser over CDP via Playwright.
- Grab the first context and page, then call `page.goto(...)`.

The snippet is now runnable as-is (assuming `playwright` is installed and the surrounding async context).

## Test plan

- [ ] Render `auth/overview.mdx` locally and confirm the Step 3 code block looks correct in both TypeScript and Python tabs.
- [ ] Copy-paste each snippet into a fresh file and confirm no `NameError`/`ReferenceError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust example code, with no production logic or API behavior changes.
> 
> **Overview**
> Fixes `auth/overview.mdx` examples so they run as-copied.
> 
> Updates the TypeScript and Python snippets to properly initialize the `Kernel` client, and changes the “Use the Profile” step to connect to the Kernel-launched browser via Playwright CDP (`connectOverCDP`/`connect_over_cdp`) and derive `context`/`page` before calling `page.goto()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1dc86c2e829749f5b656fba5fd5ec31bf5e343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->