### PR TITLE
Add April 24 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,14 +12,14 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="April 24" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Kernel is now a [Cloudflare Web Bot Auth partner](https://www.kernel.sh/blog/cloudflare) — Kernel browsers can [cryptographically identify themselves](/browsers/bot-detection/web-bot-auth) to Cloudflare-protected sites, so site owners can explicitly allow Kernel traffic instead of blocking it as generic bot traffic.
-- Anti-detection protections are now on by default for all Kernel browsers. [Stealth mode](/browsers/bot-detection/stealth) now specifically adds the managed residential proxy and CAPTCHA solver (both opt-out), and non-stealth browsers fully support [custom proxies](/proxies/custom).
-- Revamped the [managed auth hosted login page](/auth/hosted-ui): all available sign-in options (password fields, SSO providers, MFA, alternate sign-in methods) now render together on a single page, so end users can pick the path they want instead of being funneled through one at a time.
+- Kernel is now a [Cloudflare Web Bot Auth partner](https://www.kernel.sh/blog/cloudflare). Kernel browsers can [cryptographically identify themselves](/browsers/bot-detection/web-bot-auth) to Cloudflare-protected sites, so Kernel traffic isn't blocked.
+- Anti-detection features are now on by default for all Kernel browsers. [Stealth mode](/browsers/bot-detection/stealth) now specifically adds the managed residential proxy and CAPTCHA solver (both opt-out), and non-stealth browsers fully support [custom proxies](/proxies/custom).
+- Revamped the [managed auth hosted login page](/auth/hosted-ui): all available sign-in options (password fields, SSO providers, MFA, alternate sign-in methods) now render together on a single page, so end users can pick the path they want, instead of being funneled through one at a time.
 - [Managed auth connections](/auth/overview) now automatically re-authenticate expired sessions during health checks when credentials are available, reducing the need for manual reauth.
-- Managed auth input fields now display contextual helper text when the site surfaces hints like "Enter the phone ending in ***-**92", reducing user confusion on multi-step logins.
+- Managed auth input fields now display contextual helper text when the site surfaces hints, reducing user confusion on multi-step logins.
 - The "Save credentials after login" option is now automatically disabled when [1Password](/integrations/1password) is selected as the [credential source](/auth/credentials), since those credentials are already managed externally.
 - Kernel now supports WebSocket connections through its API, enabling `process attach` and other long-lived streaming workflows.
-- Exceeding invocation concurrency limits now returns a 429 response immediately, giving clients faster and more actionable feedback.
+- Exceeding invocation concurrency limits now returns a 429 response immediately, for faster and more actionable feedback.
 - Fixed [browser extension](/browsers/extensions) uploads via the [SDK](https://github.com/kernel/kernel-node-sdk) and [CLI](https://github.com/kernel/cli).
 
 ## Documentation updates

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -20,12 +20,10 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - The "Save credentials after login" option is now automatically disabled when [1Password](/integrations/1password) is selected as the [credential source](/auth/credentials), since those credentials are already managed externally.
 - Kernel now supports WebSocket connections through its API, enabling `process attach` and other long-lived streaming workflows.
 - Exceeding invocation concurrency limits now returns a 429 response immediately, for faster and more actionable feedback.
-- Fixed [browser extension](/browsers/extensions) uploads via the [SDK](https://github.com/kernel/kernel-node-sdk) and [CLI](https://github.com/kernel/cli).
 
 ## Documentation updates
 
 - Rewrote the [stealth mode](/browsers/bot-detection/stealth) and [bot detection overview](/browsers/bot-detection/overview) pages to clarify the new anti-detection defaults, and added a "Bring your own proxy" section to the [proxies overview](/proxies/overview).
-- Added a Stagehand + Gemini quick start to the [Val Town](/integrations/valtown) integration guide.
 </Update>
 
 <Update label="April 17" tags={["Product", "Docs"]}>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,25 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="April 24" tags={["Product", "Docs"]}>
+## Product updates
+
+- Kernel is now a [Cloudflare Web Bot Auth partner](https://www.kernel.sh/blog/cloudflare) — Kernel browsers can [cryptographically identify themselves](/browsers/bot-detection/web-bot-auth) to Cloudflare-protected sites, so site owners can explicitly allow Kernel traffic instead of blocking it as generic bot traffic.
+- Anti-detection protections are now on by default for all Kernel browsers. [Stealth mode](/browsers/bot-detection/stealth) now specifically adds the managed residential proxy and CAPTCHA solver (both opt-out), and non-stealth browsers fully support [custom proxies](/proxies/custom).
+- Revamped the [managed auth hosted login page](/auth/hosted-ui): all available sign-in options (password fields, SSO providers, MFA, alternate sign-in methods) now render together on a single page, so end users can pick the path they want instead of being funneled through one at a time.
+- [Managed auth connections](/auth/overview) now automatically re-authenticate expired sessions during health checks when credentials are available, reducing the need for manual reauth.
+- Managed auth input fields now display contextual helper text when the site surfaces hints like "Enter the phone ending in ***-**92", reducing user confusion on multi-step logins.
+- The "Save credentials after login" option is now automatically disabled when [1Password](/integrations/1password) is selected as the [credential source](/auth/credentials), since those credentials are already managed externally.
+- Kernel now supports WebSocket connections through its API, enabling `process attach` and other long-lived streaming workflows.
+- Exceeding invocation concurrency limits now returns a 429 response immediately, giving clients faster and more actionable feedback.
+- Fixed [browser extension](/browsers/extensions) uploads via the [SDK](https://github.com/kernel/kernel-node-sdk) and [CLI](https://github.com/kernel/cli).
+
+## Documentation updates
+
+- Rewrote the [stealth mode](/browsers/bot-detection/stealth) and [bot detection overview](/browsers/bot-detection/overview) pages to clarify the new anti-detection defaults, and added a "Bring your own proxy" section to the [proxies overview](/proxies/overview).
+- Added a Stagehand + Gemini quick start to the [Val Town](/integrations/valtown) integration guide.
+</Update>
+
 <Update label="April 17" tags={["Product", "Docs"]}>
 ## Product updates
 


### PR DESCRIPTION
## Summary

Adds this week's changelog entry covering product updates and documentation updates since April 17.

### Highlights

- Cloudflare Web Bot Auth partnership
- Anti-detection protections on by default for all browsers
- Major managed auth hosted UI overhaul
- Auto-reauth on health checks
- WebSocket support in the API (enables `process attach`)
- Immediate 429s on invocation concurrency limits

## Test plan

- [ ] Verify the April 24 entry renders correctly in the docs preview
- [ ] All internal links resolve (stealth, web-bot-auth, hosted-ui, auth overview, 1password, credentials, extensions, bot-detection overview, proxies overview, valtown, custom proxies)
- [ ] External links (blog post, SDK, CLI repos) open correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a new changelog section; minimal risk beyond potential formatting or link issues.
> 
> **Overview**
> Adds a new **April 24** entry to `changelog.mdx`, summarizing recent product updates (Cloudflare Web Bot Auth partnership, anti-detection defaults/stealth behavior, managed auth hosted UI changes and auto-reauth, WebSocket API support, immediate 429s for concurrency limits) and related documentation rewrites/updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151f7228f5f71b3966fe758046e554e781906f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->