### PR TITLE
docs: document residential proxy IP rotation behavior

### DIFF
--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -15,6 +15,10 @@ Kernel supports four types of proxies:
 
 Datacenter has the fastest speed, while residential is least detectable. ISP is a balance between the two options, with less-flexible geotargeting. Kernel recommends to use the first option in the list that works for your use case.
 
+<Info>
+Datacenter and ISP proxies provide a **stable exit IP** that stays consistent across all connections. Residential proxies use **rotating exit IPs** that may change per connection — see [Residential Proxies](/proxies/residential#ip-rotation-behavior) for details.
+</Info>
+
 ## Create a proxy
 
 Create a proxy configuration from the types above that can be reused across browser sessions:

--- a/proxies/residential.mdx
+++ b/proxies/residential.mdx
@@ -18,13 +18,6 @@ Residential proxies assign a new exit IP for each new TCP connection. In practic
 
 This behavior is inherent to residential proxy networks, where traffic is routed through real consumer devices that come online and offline dynamically.
 
-| Feature | Residential | ISP |
-| --- | --- | --- |
-| IP stability | Rotating — changes per connection | Static — consistent across all connections |
-| IP authenticity | Real consumer devices | ISP-assigned IPs hosted in data centers |
-| Best for | Web scraping, data collection, avoiding rate limits | Session-based workflows, account management, login flows |
-| Geo-targeting | Country, state, city, ZIP, ASN | Country |
-
 ## Configuration
 
 Create a residential proxy with a target country:

--- a/proxies/residential.mdx
+++ b/proxies/residential.mdx
@@ -4,6 +4,27 @@ title: "Residential Proxies"
 
 Residential proxies route traffic through real residential IP addresses. They support advanced targeting options including city, state, and operating system.
 
+<Warning>
+Residential proxies use **rotating exit IPs** — each new connection may route through a different residential IP address within your targeted region. This means different browser tabs or requests to different websites within the same session can show different public IPs. If you need a consistent IP address across all connections, use an [ISP proxy](/proxies/isp) instead.
+</Warning>
+
+## IP Rotation Behavior
+
+Residential proxies assign a new exit IP for each new TCP connection. In practice:
+
+- **Same website across tabs**: Tabs connecting to the same domain typically share a TCP connection (via HTTP connection pooling), so they usually see the same IP.
+- **Different websites across tabs**: Tabs connecting to different domains open separate connections, so they will likely exit through different residential IPs.
+- **Reconnections**: If a connection is closed and re-established (e.g., after a timeout or page idle), the new connection may get a different exit IP.
+
+This behavior is inherent to residential proxy networks, where traffic is routed through real consumer devices that come online and offline dynamically.
+
+| Feature | Residential | ISP |
+| --- | --- | --- |
+| IP stability | Rotating — changes per connection | Static — consistent across all connections |
+| IP authenticity | Real consumer devices | ISP-assigned IPs hosted in data centers |
+| Best for | Web scraping, data collection, avoiding rate limits | Session-based workflows, account management, login flows |
+| Geo-targeting | Country, state, city, ZIP, ASN | Country |
+
 ## Configuration
 
 Create a residential proxy with a target country:

--- a/proxies/residential.mdx
+++ b/proxies/residential.mdx
@@ -4,9 +4,9 @@ title: "Residential Proxies"
 
 Residential proxies route traffic through real residential IP addresses. They support advanced targeting options including city, state, and operating system.
 
-<Warning>
-Residential proxies use **rotating exit IPs** — each new connection may route through a different residential IP address within your targeted region. This means different browser tabs or requests to different websites within the same session can show different public IPs. If you need a consistent IP address across all connections, use an [ISP proxy](/proxies/isp) instead.
-</Warning>
+<Info>
+Residential proxies use **rotating exit IPs** — each new connection may route through a different residential IP address within your targeted region. This is because residential traffic is routed through real consumer devices that may go offline at any time, so the network assigns a new available exit node per connection. This means different browser tabs or requests to different websites within the same session can show different public IPs. If you need a consistent IP address across all connections, use an [ISP proxy](/proxies/isp) instead.
+</Info>
 
 ## IP Rotation Behavior
 


### PR DESCRIPTION
## Summary
- Adds a prominent warning to the residential proxies page explaining that exit IPs rotate per connection
- Adds an "IP Rotation Behavior" section with practical details (same-site tabs share IPs via connection pooling, different-site tabs get different IPs, reconnections may rotate)
- Adds a residential vs ISP comparison table to help users pick the right proxy type
- Adds an Info callout to the proxies overview page linking to the new section

## Context
A customer reported seeing different IP addresses across browser tabs when using a residential proxy. Investigation confirmed this is expected behavior — residential proxies use rotating sessions by default (per Byteful/PingProxy docs). Our docs didn't mention this at all, leading to confusion.

## Test plan
- [ ] Verify Mintlify preview renders the Warning, Info, and table correctly
- [ ] Confirm internal links to `/proxies/isp` and `/proxies/residential#ip-rotation-behavior` resolve

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only changes; the main risk is minor confusion from incorrect wording or broken internal anchors/links.
> 
> **Overview**
> Adds an `Info` callout on `proxies/overview.mdx` clarifying that **datacenter/ISP proxies have stable exit IPs** while **residential proxies rotate IPs per connection**, with a deep link to the relevant section.
> 
> Expands `proxies/residential.mdx` with a prominent `Info` warning and a new **IP Rotation Behavior** section explaining per-TCP-connection rotation and common tab/reconnection scenarios, plus guidance to use `ISP` proxies when a consistent IP is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37108ff238c6ab76d01b181c6689553ea161e4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->