### PR TITLE
docs: add IP rotation behavior to ISP, datacenter, and stealth pages

### DIFF
--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -77,12 +77,24 @@ Once you have a stable baseline, replicate those conditions in your automations.
 
 ## Choosing a Proxy Type
 
-IP address is one of the strongest signals bot detection systems use. Kernel offers several [proxy types](/proxies/overview), each with different trade-offs for detection avoidance:
+IP address is one of the strongest signals bot detection systems use. Kernel offers several [proxy types](/proxies/overview), each with different trade-offs for detection avoidance.
 
-- **[ISP proxies](/proxies/isp)** use IP addresses assigned by real internet service providers. They provide a stable exit IP for the lifetime of the proxy, making them a good default for most automation workflows — especially login flows, session-based tasks, and sites that track IP consistency. The stealth mode default proxy is an ISP proxy.
+### ISP proxies
 
-- **[Residential proxies](/proxies/residential)** route traffic through real consumer devices. They tend to look more like organic traffic to detection systems, but the exit IP [rotates per connection](/proxies/residential#ip-rotation-behavior) — different tabs or requests to different sites may show different IPs. This can be an advantage for scraping workloads where IP diversity matters, but a disadvantage for session-based workflows where a changing IP may trigger re-authentication or blocks.
+[ISP proxies](/proxies/isp) route traffic through data centers using IP addresses assigned by real internet service providers. They offer datacenter-level speed with better legitimacy than pure datacenter proxies, and every connection in a session exits through the same static IP — making them ideal for login flows and session-based workflows.
 
-- **[Datacenter proxies](/proxies/datacenter)** are the fastest and most cost-effective option, but their IP ranges are well-known to detection systems. Some sites block datacenter IPs outright; others treat them with higher scrutiny.
+Kernel's [stealth mode](/browsers/bot-detection/stealth) uses static ISP proxies that are hosted in data centers but announced on residential ISP networks, so they tend to appear residential by ASN to most of the internet. This matters for IP-reputation-based detection systems: a static IP on a residential ASN looks like a normal ISP customer, which generally achieves better pass rates than rotating residential IPs.
 
-There is no universally "best" proxy type — it depends on the target site's detection approach. We recommend starting with the stealth default (ISP) and switching to residential or datacenter only if your specific use case requires it.
+### Residential proxies
+
+[Residential proxies](/proxies/residential) route traffic through real consumer devices, making them the least detectable proxy type by ASN classification. However, exit IPs [rotate per connection](/proxies/residential#ip-rotation-behavior) since the underlying devices come online and offline dynamically — different tabs hitting different domains will likely show different public IPs.
+
+Some IP-reputation-based detection systems (such as reCAPTCHA) can detect rotating pool traffic patterns and penalize them, regardless of how clean the individual exit IPs are. On the other hand, residential proxies tend to be a stronger choice against fingerprint-heavy vendors where detection focuses on the browser and behavioral layer rather than the network layer. Residential proxies also offer richer geo-targeting (country, state, city, ZIP, ASN) compared to ISP.
+
+### Datacenter proxies
+
+[Datacenter proxies](/proxies/datacenter) are the fastest and most cost-effective option, but their IP ranges are well-known to detection systems. Some sites block datacenter IPs outright; others treat them with higher scrutiny.
+
+### Which to use
+
+Start with ISP — it's the stealth default for good reason. Consider residential if you need fine-grained geo-targeting or your specific target site doesn't rely on IP reputation as its primary detection signal. Use datacenter when speed and cost matter more than detection avoidance.

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -28,7 +28,7 @@ These systems are heuristic and probabilistic — small mismatches can still tri
 Every Kernel browser launches with anti-detection chrome configuration applied. No setup required.
 
 ### [Stealth Mode](/browsers/bot-detection/stealth)
-On top of the defaults, stealth mode adds a default residential proxy and an automatic CAPTCHA solver. Both are opt-out so you can BYO proxy and/or CAPTCHA tooling.
+On top of the defaults, stealth mode adds a default ISP proxy and an automatic CAPTCHA solver. Both are opt-out so you can BYO proxy and/or CAPTCHA tooling.
 
 ### [Configurable Proxies](/proxies/overview)
 Bring your own proxy network or use Kernel's managed pool (selectable down to ZIP-code level). If needed, use the same IP to reduce detection and allow for regional testing or QA.
@@ -72,5 +72,17 @@ Once you have a stable baseline, replicate those conditions in your automations.
 | **Session Persistence** | Use **Profiles** to retain cookies and local storage between sessions. |
 | **Typing & Scrolling** | Add natural variation to interaction timing. |
 | **Rate Limits** | Many sites monitor request frequency; rapid / concurrent actions can trigger blocking. |
-| **Network Identity** | Use stable IP addresses, especially if logging in. |
+| **Network Identity** | Use stable IP addresses, especially if logging in. See [Choosing a proxy type](#choosing-a-proxy-type) below. |
 | **Extensions** | Use the [Extensions API](/browsers/extensions) carefully — each adds its own fingerprint, which can be detected. |
+
+## Choosing a Proxy Type
+
+IP address is one of the strongest signals bot detection systems use. Kernel offers several [proxy types](/proxies/overview), each with different trade-offs for detection avoidance:
+
+- **[ISP proxies](/proxies/isp)** use IP addresses assigned by real internet service providers. They provide a stable exit IP for the lifetime of the proxy, making them a good default for most automation workflows — especially login flows, session-based tasks, and sites that track IP consistency. The stealth mode default proxy is an ISP proxy.
+
+- **[Residential proxies](/proxies/residential)** route traffic through real consumer devices. They tend to look more like organic traffic to detection systems, but the exit IP [rotates per connection](/proxies/residential#ip-rotation-behavior) — different tabs or requests to different sites may show different IPs. This can be an advantage for scraping workloads where IP diversity matters, but a disadvantage for session-based workflows where a changing IP may trigger re-authentication or blocks.
+
+- **[Datacenter proxies](/proxies/datacenter)** are the fastest and most cost-effective option, but their IP ranges are well-known to detection systems. Some sites block datacenter IPs outright; others treat them with higher scrutiny.
+
+There is no universally "best" proxy type — it depends on the target site's detection approach. We recommend starting with the stealth default (ISP) and switching to residential or datacenter only if your specific use case requires it.

--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -6,10 +6,14 @@ All Kernel browsers ship with anti-detection optimizations by default — you do
 
 Enabling `stealth` mode adds two managed services on top:
 
-1. **Default residential proxy** — traffic routes through Kernel's residential proxy pool.
+1. **Default proxy** — traffic routes through a static ISP proxy, providing a stable exit IP for the session.
 2. **Automatic CAPTCHA solver** — solves [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo), Cloudflare challenges, and similar tests automatically.
 
 Both are opt-out so you can [bring your own](#bring-your-own-proxy-or-captcha-solver) where it makes sense.
+
+### IP Rotation Behavior
+
+The default stealth proxy provides a **static exit IP** — all connections within the session exit through the same IP address. If you override the default with a [residential proxy](/proxies/residential), exit IPs will rotate per connection. See [Residential IP Rotation Behavior](/proxies/residential#ip-rotation-behavior) for details.
 
 To turn on stealth mode, set its flag when instantiating Kernel browsers:
 

--- a/proxies/datacenter.mdx
+++ b/proxies/datacenter.mdx
@@ -4,6 +4,10 @@ title: "Datacenter Proxies"
 
 Datacenter proxies use IP addresses assigned from datacenter servers to route your traffic and access locations around the world. With a shorter journey and simplified architecture, datacenter proxies are both the fastest and most cost-effective proxy option.
 
+## IP Rotation Behavior
+
+Datacenter proxies provide a **static exit IP** — the same IP address is used for all connections throughout the lifetime of the proxy. Every tab, request, and reconnection within a browser session exits through the same IP.
+
 ## Configuration
 
 Datacenter proxies require a country to route traffic through:

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -4,6 +4,10 @@ title: "ISP Proxies"
 
 ISP (Internet Service Provider) proxies combine the speed of datacenter proxies with better legitimacy, as they use IP addresses assigned by real ISPs.
 
+## IP Rotation Behavior
+
+ISP proxies provide a **static exit IP** — the same IP address is used for all connections throughout the lifetime of the proxy. Every tab, request, and reconnection within a browser session exits through the same IP. This makes ISP proxies ideal for session-based workflows, login flows, and any use case where a consistent IP is important.
+
 ## Configuration
 
 Create an ISP proxy:


### PR DESCRIPTION
## Summary
- Adds "IP Rotation Behavior" section to ISP and datacenter proxy pages documenting static exit IP behavior
- Fixes stealth mode docs: default proxy is a static ISP proxy, not residential
- Adds IP rotation behavior subsection to stealth page noting that overriding with a residential proxy will rotate IPs

Follow-up to #344 which added the same section to the residential proxies page.

## Test plan
- [ ] Verify Mintlify preview renders correctly on all three pages
- [ ] Confirm link to `/proxies/residential#ip-rotation-behavior` resolves from stealth page

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that clarify proxy defaults and IP rotation behavior without affecting runtime code.
> 
> **Overview**
> Clarifies that `stealth` mode’s managed proxy is a **static ISP proxy** (not residential) and documents how IP rotation differs when overriding with residential proxies.
> 
> Adds new *IP Rotation Behavior* sections to the `ISP` and `datacenter` proxy docs, and expands the bot-detection overview with guidance on choosing proxy types and linking the network-identity recommendation to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50372ecd0e6b4662debc2db2b75338a0e24908a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->