### PR TITLE
docs(bot-detection): add GPU Acceleration to Kernel Features That Help

### DIFF
--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -124,7 +124,6 @@ The most valuable workflows live behind logins. Managed Auth provides:
 - **2FA/OTP handling** - TOTP codes automated with automatic retry on expiry, SMS/email/push OTP are supported
 - **Post-login URL** - Get the URL where login landed (`post_login_url`) so you can start automations from the right page
 - **Session monitoring** - Automatic re-authentication when sessions expire with stored credentials
-- **[GPU acceleration](/browsers/gpu-acceleration)** - Login flows on sites with rendering-based fingerprinting (canvas, WebGL) clear consistently when paired with GPU-enabled browsers, which produce hardware-rendered output indistinguishable from a real consumer GPU
 - **Secure by default** - Credentials encrypted at rest, never exposed in API responses, or passed to LLMs
 
 ## Security

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -124,6 +124,7 @@ The most valuable workflows live behind logins. Managed Auth provides:
 - **2FA/OTP handling** - TOTP codes automated with automatic retry on expiry, SMS/email/push OTP are supported
 - **Post-login URL** - Get the URL where login landed (`post_login_url`) so you can start automations from the right page
 - **Session monitoring** - Automatic re-authentication when sessions expire with stored credentials
+- **[GPU acceleration](/browsers/gpu-acceleration)** - Login flows on sites with rendering-based fingerprinting (canvas, WebGL) clear consistently when paired with GPU-enabled browsers, which produce hardware-rendered output indistinguishable from a real consumer GPU
 - **Secure by default** - Credentials encrypted at rest, never exposed in API responses, or passed to LLMs
 
 ## Security

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -47,6 +47,9 @@ Kernel automatically applies Patchright to remove automation fingerprints, inclu
 Controls the browser without using the Chrome DevTools Protocol (CDP), which can reduce bot detection signals.
 Emulates native keyboard and mouse input directly at the OS level and includes human-like [bezier curves](/browsers/computer-controls#move-the-mouse) by default.
 
+### [GPU Acceleration](/browsers/gpu-acceleration)
+Many detection systems fingerprint canvas and WebGL rendering output and cross-check it against the claimed GPU. Software-rendered browsers produce pixel hashes that don't match any real consumer GPU, which is a strong bot signal on sites with rendering-based fingerprinting. GPU-enabled Kernel browsers render through real hardware, producing output consistent with a normal user's device.
+
 ## Getting Started
 
 Before you start automating your workflow, we recommend that you manually test your website to understand how it behaves with Kernel's browsers. Here's how to do that:


### PR DESCRIPTION
## Summary

Adds a **GPU Acceleration** section under "Kernel Features That Help" on the bot-detection overview, alongside Stealth Mode, Configurable Proxies, Profiles, Browser Pools, Playwright Execution, and Computer Controls.

Many detection systems fingerprint canvas/WebGL rendering output and cross-check it against the claimed GPU. Software-rendered (SwiftShader) browsers produce pixel hashes that don't match any real consumer GPU — a strong bot signal on sites with rendering-based fingerprinting. GPU-enabled Kernel browsers render through real hardware, producing output consistent with a normal user's device.

Links to the existing `/browsers/gpu-acceleration` page so users can opt in.

(Earlier draft of this PR put the bullet on the Managed Auth overview — moved it to bot-detection overview where it sits with the other anti-detection levers.)

## Test plan

- [ ] Render `browsers/bot-detection/overview.mdx` locally and confirm the new section + link render correctly
- [ ] Confirm `/browsers/gpu-acceleration` link resolves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new section and link; main risk is incorrect/misleading copy or a broken `/browsers/gpu-acceleration` link.
> 
> **Overview**
> Adds a new **GPU Acceleration** entry under *Kernel Features That Help* in `browsers/bot-detection/overview.mdx`, explaining how hardware-backed rendering can reduce canvas/WebGL fingerprint mismatches and linking to `/browsers/gpu-acceleration` for details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9882f89369ece2f5a9f60add33ee8b729253b4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->