### PR TITLE
Document kernel profiles download and delete commands

### DIFF
--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -509,6 +509,11 @@ Download a profile as a ZIP archive.
 |------|-------------|
 | `--to <path>` | Output zip file path. Required. |
 | `--pretty` | Pretty-print JSON to file. |
+| `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |
+| `--log-level <level>` | Set log verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `print`). |
+| `--no-color` | Disable ANSI colors in output. |
+| `--help`, `-h` | Help for `download`. |
+| `--version`, `-v` | Print the CLI version. |
 
 ### `kernel profiles delete <id-or-name>`
 Delete a profile by ID or name.
@@ -516,3 +521,8 @@ Delete a profile by ID or name.
 | Flag | Description |
 |------|-------------|
 | `--yes`, `-y` | Skip confirmation prompt. |
+| `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |
+| `--log-level <level>` | Set log verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `print`). |
+| `--no-color` | Disable ANSI colors in output. |
+| `--help`, `-h` | Help for `delete`. |
+| `--version`, `-v` | Print the CLI version. |

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -501,3 +501,18 @@ Create a new browser profile.
 |------|-------------|
 | `--name <name>` | Optional unique name for the profile. |
 | `--output json`, `-o json` | Output raw JSON object. |
+
+### `kernel profiles download <id-or-name>`
+Download a profile as a ZIP archive.
+
+| Flag | Description |
+|------|-------------|
+| `--to <path>` | Output zip file path. Required. |
+| `--pretty` | Pretty-print JSON to file. |
+
+### `kernel profiles delete <id-or-name>`
+Delete a profile by ID or name.
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `-y` | Skip confirmation prompt. |

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -509,7 +509,6 @@ Download a profile as a ZIP archive.
 |------|-------------|
 | `--to <path>` | Output zip file path. Required. |
 | `--pretty` | Pretty-print JSON to file. |
-| `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |
 
 ### `kernel profiles delete <id-or-name>`
 Delete a profile by ID or name.
@@ -517,4 +516,3 @@ Delete a profile by ID or name.
 | Flag | Description |
 |------|-------------|
 | `--yes`, `-y` | Skip confirmation prompt. |
-| `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -510,10 +510,6 @@ Download a profile as a ZIP archive.
 | `--to <path>` | Output zip file path. Required. |
 | `--pretty` | Pretty-print JSON to file. |
 | `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |
-| `--log-level <level>` | Set log verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `print`). |
-| `--no-color` | Disable ANSI colors in output. |
-| `--help`, `-h` | Help for `download`. |
-| `--version`, `-v` | Print the CLI version. |
 
 ### `kernel profiles delete <id-or-name>`
 Delete a profile by ID or name.
@@ -522,7 +518,3 @@ Delete a profile by ID or name.
 |------|-------------|
 | `--yes`, `-y` | Skip confirmation prompt. |
 | `--project <id-or-name>` | Project ID or name to scope the request to (or set `KERNEL_PROJECT`). |
-| `--log-level <level>` | Set log verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `print`). |
-| `--no-color` | Disable ANSI colors in output. |
-| `--help`, `-h` | Help for `delete`. |
-| `--version`, `-v` | Print the CLI version. |


### PR DESCRIPTION
## Summary

Adds documentation for `kernel profiles download <id-or-name>` and `kernel profiles delete <id-or-name>` to the CLI reference under the Profiles section in `reference/cli/browsers.mdx`. These commands exist in the CLI but were not documented.

Flags documented match the CLI source:
- `download`: `--to <path>`, `--pretty`
- `delete`: `--yes`/`-y`

## Test plan

- [ ] Preview renders the new sections under Profiles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds CLI reference sections without affecting runtime behavior.
> 
> **Overview**
> Adds missing CLI reference docs for **browser profiles** commands `kernel profiles download <id-or-name>` and `kernel profiles delete <id-or-name>`.
> 
> Documents the supported flags for each command (`download`: `--to`, `--pretty`; `delete`: `--yes`/`-y`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253b7752d4a59060ef01ef2516b9380eec940070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->