### PR TITLE
Add browser curl

### DIFF
--- a/browsers/curl.mdx
+++ b/browsers/curl.mdx
@@ -5,14 +5,14 @@ description: "Send HTTP requests through Kernel browsers"
 
 Browser curl lets you run HTTP requests through Kernel browsers, automatically attaching the browser's cookie jar, transport fingerprint, [stealth and proxy settings](/browsers/bot-detection/overview), and other defaults that browsers send. This allows you to efficiently fetch resources from websites while getting the benefits of real browsers, including bot anti-detection and session cookie state.
 
-## Why this beats server-side `fetch()`
+## Why use browser curl instead of `fetch()`
 
 When you call `fetch()` or `httpx`, you're on a different TLS stack, IP, cookie store, and header profile than the browsers your agents (or automations) are using. Browser curl runs requests directly through a Kernel browser's networking stack.
 
 ### What curl requests inherit from Kernel browsers
 
 - **Cookies and storage policy** — Same cookie jar as the profile, including Chromium inclusion rules, `Set-Cookie` persistence, session cookies, encryption, `SameSite`, partitioning, and content settings. Response `Set-Cookie` headers update that same profile.
-- **Transport fingerprint** — BoringSSL TLS, ALPN, HTTP/2, HTTP/3/QUIC where enabled, Alt-Svc, connection reuse, Happy Eyeballs, certificate verification, CT/HSTS policy.
+- **Transport fingerprint** — BoringSSL TLS, ALPN, HTTP/2, Alt-Svc, connection reuse, Happy Eyeballs, certificate verification, CT/HSTS policy.
 - **Network configuration** — Proxy and PAC settings, DNS and Secure DNS, SSL and cert policy, cache, HTTP server properties, network quality signals.
 - **Default client behavior** — Chromium user agent, `Accept-Language`, brotli/zstd support, and typical fetch metadata behavior.
 - **Chromium request lifecycle** — Browser-managed redirects, decompression, HTTP authentication and client certificate eligibility, and cache behavior.
@@ -92,6 +92,5 @@ Browser curl concurrency is constrained by Chromium's internal networking limits
 - **Proxied chains** — On the order of tens of sockets per proxy chain (Chromium clamps configured values into a bounded range).
 - **HTTP stream pool** — Similar per-group and per-pool behavior to HTTP/1.x direct connections.
 - **HTTP/2** — Roughly 100 concurrent streams per session initially, updated from the server's `SETTINGS_MAX_CONCURRENT_STREAMS`, with an upper cap in Chromium (on the order of 256).
-- **HTTP/3 / QUIC** — Stream creation can queue when peer or open-stream limits are hit.
 
 If you're issuing many parallel curls from one browser, you're sharing those pools with navigation, XHR, and other session traffic. Latency may vary, as Chromium may queue requests when it reaches its limits.

--- a/browsers/curl.mdx
+++ b/browsers/curl.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Curl"
-description: "Send HTTP requests through a browser session's Chromium network stack so cookies, proxies, and TLS match real browsers"
+description: "Send HTTP requests through Kernel browsers"
 ---
 
 Browser curl lets you run HTTP requests through Kernel browsers, automatically attaching the browser's cookie jar, transport fingerprint, [stealth and proxy settings](/bot-detection/overview), and other defaults that browsers send. This allows you to efficiently fetch resources from websites while getting the benefits of real browsers, including bot anti-detection and session cookie state.
@@ -28,11 +28,13 @@ You can stream or read the body incrementally, which avoids buffering the full p
 import Kernel from '@onkernel/sdk';
 
 const kernel = new Kernel();
+
 const browser = await kernel.browsers.create({});
 
 const response: Response = await kernel.browsers.fetch(browser.session_id, 'https://example.com', {
-  method: 'GET',
+method: 'GET',
 });
+console.log('body', await response.text());
 ```
 
 ```python Python
@@ -40,11 +42,12 @@ import httpx
 
 from kernel import Kernel
 
-const response: httpx.Response = client.browsers.request(
-  browser.session_id,
-  "GET",
-  "https://example.com",
-);
+client = Kernel()
+
+browser = client.browsers.create()
+
+response: httpx.Response = client.browsers.request(browser.session_id, "GET", "https://example.com")
+print("status", response.status_code)
 ```
 </CodeGroup>
 
@@ -67,6 +70,7 @@ const buffered = await kernel.browsers.curl(browser.session_id, {
   url: 'https://example.com',
   method: 'GET',
 });
+console.log('body', buffered.body);
 ```
 
 ```python Python
@@ -76,6 +80,7 @@ client = Kernel()
 browser = client.browsers.create()
 
 buffered = client.browsers.curl(browser.session_id, url="https://example.com", method="GET")
+print("body", buffered.body)
 ```
 </CodeGroup>
 

--- a/browsers/curl.mdx
+++ b/browsers/curl.mdx
@@ -1,0 +1,92 @@
+---
+title: "Curl"
+description: "Send HTTP requests through a browser session's Chromium network stack so cookies, proxies, and TLS match real browsers"
+---
+
+Browser curl lets you run HTTP requests through Kernel browsers, automatically attaching the browser's cookie jar, transport fingerprint, [stealth and proxy settings](/bot-detection/overview), and other defaults that browsers send. This allows you to efficiently fetch resources from websites while getting the benefits of real browsers, including bot anti-detection and session cookie state.
+
+## Why this beats server-side `fetch()`
+
+When you call `fetch()` or `httpx`, you're on a different TLS stack, IP, cookie store, and header profile than the browsers your agents (or automations) are using. Browser curl runs requests directly through a Kernel browser's networking stack.
+
+### What curl requests inherit from Kernel browsers
+
+- **Cookies and storage policy** — Same cookie jar as the profile, including Chromium inclusion rules, `Set-Cookie` persistence, session cookies, encryption, `SameSite`, partitioning, and content settings. Response `Set-Cookie` headers update that same profile.
+- **Transport fingerprint** — BoringSSL TLS, ALPN, HTTP/2, HTTP/3/QUIC where enabled, Alt-Svc, connection reuse, Happy Eyeballs, certificate verification, CT/HSTS policy.
+- **Network configuration** — Proxy and PAC settings, DNS and Secure DNS, SSL and cert policy, cache, HTTP server properties, network quality signals.
+- **Default client behavior** — Chromium user agent, `Accept-Language`, brotli/zstd support, and typical fetch metadata behavior.
+- **Chromium request lifecycle** — Browser-managed redirects, decompression, HTTP authentication and client certificate eligibility, and cache behavior.
+
+## Streaming browser requests
+
+Streaming requests go through the browser's Chromium network stack, and the SDK mirrors platform-native HTTP ergonomics.
+
+You can stream or read the body incrementally, which avoids buffering the full payload in the browser for large responses.
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+const browser = await kernel.browsers.create({});
+
+const response: Response = await kernel.browsers.fetch(browser.session_id, 'https://example.com', {
+  method: 'GET',
+});
+```
+
+```python Python
+import httpx
+
+from kernel import Kernel
+
+const response: httpx.Response = client.browsers.request(
+  browser.session_id,
+  "GET",
+  "https://example.com",
+);
+```
+</CodeGroup>
+
+## Buffered browser curl
+
+Buffered browser curl calls the HTTP API and returns a single JSON envelope: `status`, `headers`, `body`, and `duration_ms`. Use it when the response is small enough to hold in memory and you want one structured object back—typical APIs, HTML snippets, and JSON payloads.
+
+<Info>
+  Buffered curl loads the **entire** response body into the browser process before it returns to you. Requesting a very large payload can exhaust memory and cause OOMs. For big downloads or unknown sizes, use [streaming browser requests](#streaming-browser-requests) instead.
+</Info>
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+const browser = await kernel.browsers.create({});
+
+const buffered = await kernel.browsers.curl(browser.session_id, {
+  url: 'https://example.com',
+  method: 'GET',
+});
+```
+
+```python Python
+from kernel import Kernel
+
+client = Kernel()
+browser = client.browsers.create()
+
+buffered = client.browsers.curl(browser.session_id, url="https://example.com", method="GET")
+```
+</CodeGroup>
+
+## Concurrency limits
+
+Browser curl concurrency is constrained by Chromium's internal networking limits:
+
+- **HTTP/1.x (direct)** — About 6 sockets per host group and up to 256 active sockets per pool.
+- **Proxied chains** — On the order of tens of sockets per proxy chain (Chromium clamps configured values into a bounded range).
+- **HTTP stream pool** — Similar per-group and per-pool behavior to HTTP/1.x direct connections.
+- **HTTP/2** — Roughly 100 concurrent streams per session initially, updated from the server's `SETTINGS_MAX_CONCURRENT_STREAMS`, with an upper cap in Chromium (on the order of 256).
+- **HTTP/3 / QUIC** — Stream creation can queue when peer or open-stream limits are hit.
+
+If you're issuing many parallel curls from one browser, you're sharing those pools with navigation, XHR, and other session traffic. Latency may vary, as Chromium may queue requests when it reaches its limits.

--- a/browsers/curl.mdx
+++ b/browsers/curl.mdx
@@ -3,7 +3,7 @@ title: "Curl"
 description: "Send HTTP requests through Kernel browsers"
 ---
 
-Browser curl lets you run HTTP requests through Kernel browsers, automatically attaching the browser's cookie jar, transport fingerprint, [stealth and proxy settings](/bot-detection/overview), and other defaults that browsers send. This allows you to efficiently fetch resources from websites while getting the benefits of real browsers, including bot anti-detection and session cookie state.
+Browser curl lets you run HTTP requests through Kernel browsers, automatically attaching the browser's cookie jar, transport fingerprint, [stealth and proxy settings](/browsers/bot-detection/overview), and other defaults that browsers send. This allows you to efficiently fetch resources from websites while getting the benefits of real browsers, including bot anti-detection and session cookie state.
 
 ## Why this beats server-side `fetch()`
 

--- a/docs.json
+++ b/docs.json
@@ -81,7 +81,6 @@
                   "browsers/termination",
                   "browsers/standby",
                   "browsers/headless",
-                  "browsers/curl",
                   "info/projects"
                 ]
               },
@@ -109,6 +108,7 @@
                     ]
                   },
                   "browsers/file-io",
+                  "browsers/curl",
                   "browsers/ssh",
                   "browsers/computer-controls",
                   "browsers/playwright-execution"

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
                   "browsers/termination",
                   "browsers/standby",
                   "browsers/headless",
+                  "browsers/curl",
                   "info/projects"
                 ]
               },

--- a/skills/overview.mdx
+++ b/skills/overview.mdx
@@ -5,7 +5,7 @@ title: "Overview"
 Kernel offers a suite of agent skills that can be used to debug your development workflows and give your browser agents runtime superpowers.
 
 Especially useful skills:
-- [Bot Detection Profiler](/skills/bot-detection)
+- [Bot Detection](/skills/bot-detection)
 - [Browser Profiles](/skills/profiles)
 
 View Kernel's full list of available skills [here](https://skills.sh/kernel/skills).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes: adds a new `browsers/curl` guide and updates navigation/linking, with no runtime or API behavior changes.
> 
> **Overview**
> Adds a new `browsers/curl` documentation page describing how to issue HTTP requests through a Kernel browser (streaming via `browsers.fetch`/`browsers.request` and buffered via `browsers.curl`), including examples and concurrency/memory cautions.
> 
> Updates `docs.json` navigation to include the new Browser curl page and tweaks `skills/overview.mdx` to reference `Bot Detection` more consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f05c09db23d5d1f9d04feb0339190cec007c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->