### PR TITLE
add commentary about skills

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -168,6 +168,14 @@
             ]
           },
           {
+            "group": "Agent Skills",
+            "pages": [
+              "skills/overview",
+              "skills/bot-detection",
+              "skills/profiles"
+            ]
+          },
+          {
             "group": "Integrations",
             "pages": [
               "integrations/overview",

--- a/skills/bot-detection.mdx
+++ b/skills/bot-detection.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Bot Detection Profiler"
+title: "Bot Detection"
 url: "https://skills.sh/kernel/skills/profile-website-bot-detection"
 ---

--- a/skills/bot-detection.mdx
+++ b/skills/bot-detection.mdx
@@ -1,0 +1,4 @@
+---
+title: "Bot Detection Profiler"
+url: "https://skills.sh/kernel/skills/profile-website-bot-detection"
+---

--- a/skills/overview.mdx
+++ b/skills/overview.mdx
@@ -1,0 +1,11 @@
+---
+title: "Overview"
+---
+
+Kernel offers a suite of agent skills that can be used to debug your development workflows and give your browser agents runtime superpowers.
+
+Especially useful skills:
+- [Bot Detection Profiler](/skills/bot-detection)
+- [Browser Profiles](/skills/profiles)
+
+View Kernel's full list of available skills [here](https://skills.sh/kernel/skills).

--- a/skills/profiles.mdx
+++ b/skills/profiles.mdx
@@ -1,0 +1,4 @@
+---
+title: "Browser Profiles"
+url: "https://skills.sh/kernel/skills/diff-profile-archives"
+---


### PR DESCRIPTION
Add links to kernel skills in docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds new navigation entries and MDX pages linking out to external `skills.sh` content.
> 
> **Overview**
> Adds a new **Agent Skills** section to the docs navigation (`docs.json`) with pages for an overview plus two skills.
> 
> Introduces `skills/overview.mdx`, `skills/bot-detection.mdx`, and `skills/profiles.mdx`, primarily to link readers to the corresponding Kernel skills (including external `skills.sh` URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17954f949f6c6760cdf537186f85e875b7f82e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->