### PR TITLE
Add May 1 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,21 +12,21 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="May 1" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added a `kernel browsers curl` command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly to a browser session. Chromium synthesizes `User-Agent`, `Sec-CH-UA*`, and other identity headers so requests use the browser's real identity instead of leaking SDK defaults like `Go-http-client/1.1`.
+- Added a [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a cloud browser session, so calls go out with the browser's cookies, session state, and network identity instead of your local terminal's.
 - Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
 - Improved mouse movement timing in cloud browsers with Gaussian-distributed delays between movements for more natural-looking interactions.
-- Profile downloads now extract directly to a local directory, with improved handling of in-progress download responses. The dashboard now respects the active project on download and surfaces errors as toasts; the API returns `409 no_saved_data` when a profile exists but has no captured state, distinct from `404` for missing profiles.
+- Profile downloads now extract directly to a local directory, with improved handling of in-progress download responses. The dashboard now respects the active project on download and surfaces errors as toasts.
 - Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.
 - Added a dedicated `switch` MFA option type so generic method-switcher links ("Use another method", "Try another way") are distinguished from buttons that name a specific method, improving auto-click reliability on multi-step MFA pages.
-- Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup. Connections created with `{ provider, auto: true }` previously dead-ended in `awaiting_input` because the CUA path skipped the lookup step.
+- Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup.
 - Managed auth connections now expose `browser_session_id` so callers can inspect or terminate the underlying browser session via the `/browsers` API.
 - Added a `diff-profile-archives` skill to the [Kernel skills repo](https://github.com/kernel/skills) for comparing Chrome profile archives directly from Claude Code.
 
 ## Documentation updates
 
-- Added documentation for the new [`kernel browsers curl`](/reference/cli) command, along with the `kernel profiles download` and `kernel profiles delete` commands.
+- Added documentation for the new [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command, along with the `kernel profiles download` and `kernel profiles delete` commands.
 - Documented [IP rotation behavior](/proxies/residential) for residential, ISP, and datacenter proxies.
-- Added guidance on [browser pool latency](/browsers/pools/overview) footguns and best practices.
+- Added a [How browser pools work](/browsers/pools/overview) walkthrough (declaration vs acquisition, fixed capacity, releasing browsers) and a new [browser creation performance](/browsers/performance) troubleshooting page.
 </Update>
 
 <Update label="April 24" tags={["Product", "Docs"]}>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,7 +12,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="May 1" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added a [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a cloud browser session, so calls go out with the browser's cookies, session state, and network identity instead of your local terminal's.
+- Added [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a cloud browser session using browser's cookies, session state, and network identity instead of your local terminal's.
 - Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
 - Improved mouse movement timing in cloud browsers with Gaussian-distributed delays between movements for more natural-looking interactions.
 - Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -15,7 +15,6 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Added a [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a cloud browser session, so calls go out with the browser's cookies, session state, and network identity instead of your local terminal's.
 - Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
 - Improved mouse movement timing in cloud browsers with Gaussian-distributed delays between movements for more natural-looking interactions.
-- Profile downloads now extract directly to a local directory, with improved handling of in-progress download responses. The dashboard now respects the active project on download and surfaces errors as toasts.
 - Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.
 - Added a dedicated `switch` MFA option type so generic method-switcher links ("Use another method", "Try another way") are distinguished from buttons that name a specific method, improving auto-click reliability on multi-step MFA pages.
 - Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,26 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="May 1" tags={["Product", "Docs"]}>
+## Product updates
+
+- Added a `kernel browsers curl` command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly to a browser session. Chromium synthesizes `User-Agent`, `Sec-CH-UA*`, and other identity headers so requests use the browser's real identity instead of leaking SDK defaults like `Go-http-client/1.1`.
+- Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
+- Improved mouse movement timing in cloud browsers with Gaussian-distributed delays between movements for more natural-looking interactions.
+- Profile downloads now extract directly to a local directory, with improved handling of in-progress download responses. The dashboard now respects the active project on download and surfaces errors as toasts; the API returns `409 no_saved_data` when a profile exists but has no captured state, distinct from `404` for missing profiles.
+- Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.
+- Added a dedicated `switch` MFA option type so generic method-switcher links ("Use another method", "Try another way") are distinguished from buttons that name a specific method, improving auto-click reliability on multi-step MFA pages.
+- Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup. Connections created with `{ provider, auto: true }` previously dead-ended in `awaiting_input` because the CUA path skipped the lookup step.
+- Managed auth connections now expose `browser_session_id` so callers can inspect or terminate the underlying browser session via the `/browsers` API.
+- Added a `diff-profile-archives` skill to the [Kernel skills repo](https://github.com/kernel/skills) for comparing Chrome profile archives directly from Claude Code.
+
+## Documentation updates
+
+- Added documentation for the new [`kernel browsers curl`](/reference/cli) command, along with the `kernel profiles download` and `kernel profiles delete` commands.
+- Documented [IP rotation behavior](/proxies/residential) for residential, ISP, and datacenter proxies.
+- Added guidance on [browser pool latency](/browsers/pools/overview) footguns and best practices.
+</Update>
+
 <Update label="April 24" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,9 +12,9 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="May 1" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a cloud browser session using browser's cookies, session state, and network identity instead of your local terminal's.
+- Added [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a browser session using browser's cookies, session state, and network identity instead of your local terminal's.
 - Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
-- Improved mouse movement timing in cloud browsers with Gaussian-distributed delays between movements for more natural-looking interactions.
+- Improved mouse movement timing with Gaussian-distributed delays between movements for more natural-looking interactions.
 - Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.
 - Added a dedicated `switch` MFA option type so generic method-switcher links ("Use another method", "Try another way") are distinguished from buttons that name a specific method, improving auto-click reliability on multi-step MFA pages.
 - Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -19,7 +19,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Added a dedicated `switch` MFA option type so generic method-switcher links ("Use another method", "Try another way") are distinguished from buttons that name a specific method, improving auto-click reliability on multi-step MFA pages.
 - Managed auth CUA flow now resolves external credentials (e.g. 1Password) via auto-lookup.
 - Managed auth connections now expose `browser_session_id` so callers can inspect or terminate the underlying browser session via the `/browsers` API.
-- Added a `diff-profile-archives` skill to the [Kernel skills repo](https://github.com/kernel/skills) for comparing Chrome profile archives directly from Claude Code.
+- Added a `diff-profile-archives` skill to the [Kernel skills repo](https://github.com/kernel/skills) for comparing Chrome profile archives directly with a coding agent.
 
 ## Documentation updates
 


### PR DESCRIPTION
## Summary

Adds the May 1 changelog entry covering product and docs updates shipped between April 24 and May 1.

### Product updates
- `kernel browsers curl` CLI command + browser-synthesized identity headers
- Projects support extended to CLI (`--project` flag) and MCP server (name resolution)
- Gaussian-distributed mouse movement timing
- Profile download UX: direct-to-directory extraction, dashboard project scoping + error toasts, `409 no_saved_data` API status
- Managed auth UX: MFA channel display, `--credential-auto` default, `switch` MFA option type, external credential auto-lookup in CUA flow, `browser_session_id` exposed on connections
- `diff-profile-archives` skill in the Kernel skills repo

### Docs updates
- `kernel browsers curl`, `kernel profiles download`, `kernel profiles delete`
- IP rotation behavior for residential/ISP/datacenter proxies
- Browser pool latency guidance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new changelog entry without modifying product code or behavior.
> 
> **Overview**
> Adds a new **May 1** `changelog.mdx` entry summarizing recent Product and Docs updates, including the new `kernel browsers curl` CLI command, expanded Projects support in the CLI/MCP server, managed auth UX improvements, and newly documented proxy IP rotation and browser pool guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a4f4ff1548984b9381b7680689f3cb0fe73b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->