### PR TITLE
Trim curl bullet in May 1 changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,7 +12,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="May 1" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a browser session using browser's cookies, session state, and network identity instead of your local terminal's.
+- Added [`kernel browsers curl`](https://www.kernel.sh/docs/browsers/curl) command to the [CLI](https://github.com/kernel/cli) for making HTTP requests directly from a browser session using browser's cookies, session state, and network identity.
 - Extended [Projects](/info/projects) support to the [CLI](https://github.com/kernel/cli) and [MCP server](/reference/mcp-server) — use the `--project` flag to scope CLI commands to a specific project, and MCP tools now resolve projects by name.
 - Improved mouse movement timing with Gaussian-distributed delays between movements for more natural-looking interactions.
 - Improved managed auth UX: MFA prompts now display which channel (email or phone) the verification code was sent to, and `--credential-auto` now defaults to enabled when `--credential-provider` is set.


### PR DESCRIPTION
Removes "instead of your local terminal's" from the May 1 changelog curl bullet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tweaks a single changelog bullet; no code or behavior is affected.
> 
> **Overview**
> Updates `changelog.mdx` to shorten the May 1 product-update bullet for `kernel browsers curl` by removing the “instead of your local terminal’s” phrasing, keeping the description focused on using browser cookies/session state/network identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3441431eeda9820b4640711a1c432891949439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->