### PR TITLE
docs(pools): clarify profile updates don't propagate to idle pool browsers

### DIFF
--- a/browsers/pools/faq.mdx
+++ b/browsers/pools/faq.mdx
@@ -24,6 +24,12 @@ When a browser from a pool is set to be destroyed (by reaching its specified `ti
 
 Yes, use `kernel.browserPools.update()`. By default, idle browsers are discarded and rebuilt with new configuration. Set `discard_all_idle: false` to only apply changes to newly created browsers.
 
+### If I update a profile's contents, will my pool's idle browsers pick up the change?
+
+No. Idle browsers in a pool are pre-loaded with the profile's contents at the time they were filled. Updating the profile (for example, re-saving auth state to the same `profile_id`) does not propagate to already-warmed browsers — only newly-filled browsers will use the updated profile.
+
+To force the pool to pick up new profile contents, either call `kernel.browserPools.flush()` to destroy idle browsers (the pool refills automatically), or call `kernel.browserPools.update()` with `discard_all_idle: true`.
+
 ### Should I set `reuse: true` or `reuse: false` when releasing?
 
 Use `reuse: true` (default) for efficiency. Only use `reuse: false` when you suspect browser state corruption or need a guaranteed clean browser session.


### PR DESCRIPTION
## Summary

Adds a pools FAQ entry explaining that updating a profile's contents does not propagate to already-warmed idle browsers in a pool. Pool browsers load profile contents at fill time; the only way to force a pool to pick up new profile contents is to flush idle browsers (or `browserPools.update` with `discard_all_idle: true`).

## Test plan

- [ ] Mintlify preview renders the new FAQ entry under `browsers/pools/faq.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that clarifies expected pool behavior and how to force refreshed profile contents.
> 
> **Overview**
> Adds a new FAQ entry to `browsers/pools/faq.mdx` clarifying that updating a profile’s contents does **not** propagate to already-warmed *idle* pool browsers.
> 
> Documents the recommended ways to pick up updated profile data: `kernel.browserPools.flush()` (to rebuild idle browsers via refill) or `kernel.browserPools.update()` with `discard_all_idle: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e88c5ae9356b8f5d5bcf14b6e59954d6a376df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->