### PR TITLE
Add May 8 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,23 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="May 8" tags={["Product", "Docs"]}>
+## Product updates
+
+- Released [`@onkernel/managed-auth-react`](https://github.com/kernel/managed-auth-react), a drop-in React component library for embedding [managed auth](/auth/overview) flows directly into your app. Ship a Kernel-powered login experience without rebuilding the credential entry, MFA, and SSO dialogs yourself.
+- Added a [Docker Sandboxes mixin kit](https://github.com/kernel/docker-sbx-kit) for running Kernel inside Docker's AI sandboxes (`sbx`). The kit ships the [Kernel CLI](https://github.com/kernel/cli), Claude Code [skills](https://github.com/kernel/skills), and a proxy-managed auth header pre-configured, so agents inside the sandbox can call the Kernel API while your real `KERNEL_API_KEY` stays on the host.
+- Hardened [Projects](/info/projects) for orgs running many environments: profile, browser pool, extension, and credential names are now scoped per-project (so a `production` profile in one project no longer collides with the same name in another), and the `GET /projects` API and dashboard project selector now support server-side search and pagination for orgs with hundreds of projects.
+- Made the [1Password](/integrations/1password) credential dropdown searchable in [managed auth](/auth/overview) dialogs, and stopped page analysis from clicking on out-of-viewport elements — both improve managed auth reliability for users with large 1Password vaults or long sign-in pages.
+- Fixed a class of managed auth autofill misfires where TOTP entry, "use another method" switcher detection, and MFA auto-click could write into the wrong visible input field on multi-step pages.
+- Managed auth connections will no longer attempt auto-reauth until the connection has had at least one prior successful login, preventing repeated reauth attempts on connections that were never functional in the first place.
+- Added `-o json` output to `kernel browsers playwright execute` in the [CLI](https://github.com/kernel/cli), matching the other `browsers` subcommands, so script runs can be piped into other tooling.
+
+## Documentation updates
+
+- Documented in the [computer controls](/browsers/computer-controls) docs that computer controls screenshots are faster than CDP screenshots on WebGL-heavy pages, since computer controls bypasses the CDP screenshot path that triggers a full WebGL render.
+- Updated `kernel-cli` skill examples in the [Kernel skills repo](https://github.com/kernel/skills) and documented the return value of `playwright execute` so agents can use the result in follow-on steps.
+</Update>
+
 <Update label="May 1" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -14,15 +14,14 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 
 - Released [`@onkernel/managed-auth-react`](https://github.com/kernel/managed-auth-react), a drop-in React component library for embedding [managed auth](/auth/overview) flows directly into your app. Ship a Kernel-powered login experience without rebuilding the credential entry, MFA, and SSO dialogs yourself.
 - Added a [Docker Sandboxes mixin kit](https://github.com/kernel/docker-sbx-kit) for running Kernel inside Docker's AI sandboxes (`sbx`). The kit ships the [Kernel CLI](https://github.com/kernel/cli), Claude Code [skills](https://github.com/kernel/skills), and a proxy-managed auth header pre-configured, so agents inside the sandbox can call the Kernel API while your real `KERNEL_API_KEY` stays on the host.
-- Hardened [Projects](/info/projects) for orgs running many environments: profile, browser pool, extension, and credential names are now scoped per-project (so a `production` profile in one project no longer collides with the same name in another), and the `GET /projects` API and dashboard project selector now support server-side search and pagination for orgs with hundreds of projects.
-- Made the [1Password](/integrations/1password) credential dropdown searchable in [managed auth](/auth/overview) dialogs, and stopped page analysis from clicking on out-of-viewport elements — both improve managed auth reliability for users with large 1Password vaults or long sign-in pages.
-- Fixed a class of managed auth autofill misfires where TOTP entry, "use another method" switcher detection, and MFA auto-click could write into the wrong visible input field on multi-step pages.
-- Managed auth connections will no longer attempt auto-reauth until the connection has had at least one prior successful login, preventing repeated reauth attempts on connections that were never functional in the first place.
+- Extended [Projects](/info/projects): profile, browser pool, extension, and credential names are now scoped per-project, and the `GET /projects` API and dashboard project selector support server-side search and pagination.
+- Made the [1Password](/integrations/1password) credential dropdown searchable in [managed auth](/auth/overview) dialogs.
+- Improved [managed auth](/auth/overview) autofill reliability on multi-step sign-in pages.
 - Added `-o json` output to `kernel browsers playwright execute` in the [CLI](https://github.com/kernel/cli), matching the other `browsers` subcommands, so script runs can be piped into other tooling.
 
 ## Documentation updates
 
-- Documented in the [computer controls](/browsers/computer-controls) docs that computer controls screenshots are faster than CDP screenshots on WebGL-heavy pages, since computer controls bypasses the CDP screenshot path that triggers a full WebGL render.
+- Documented in the [computer controls](/browsers/computer-controls) docs that computer controls screenshots are faster than CDP screenshots on WebGL-heavy pages.
 - Updated `kernel-cli` skill examples in the [Kernel skills repo](https://github.com/kernel/skills) and documented the return value of `playwright execute` so agents can use the result in follow-on steps.
 </Update>
 


### PR DESCRIPTION
## Summary

Adds the **May 8** entry to `changelog.mdx`, covering the public launches and improvements shipped between May 1 and May 8.

### Product updates included
- `@onkernel/managed-auth-react` v0.1.0 — drop-in React components for embedding managed auth UI
- Docker Sandboxes mixin kit (`docker-sbx-kit`) — run Kernel inside `sbx` with proxy-managed auth
- Projects hardening — per-project name uniqueness for profiles, browser pools, extensions, credentials; server-side search + pagination on `GET /projects` and the dashboard project selector
- Managed auth UX: searchable 1Password dropdown, out-of-viewport elements dropped from page analysis
- Managed auth bug fixes: TOTP/switcher/MFA auto-click no longer hijacks visible inputs; auto-reauth blocked until the first successful login
- CLI: `-o json` output on `kernel browsers playwright execute`

### Documentation updates included
- Note that computer-controls screenshots are faster than CDP screenshots on WebGL-heavy pages
- Updated `kernel-cli` skill examples and documented the `playwright execute` return value

## Test plan

- [ ] Render the changelog page locally and confirm the May 8 `<Update>` block appears above May 1
- [ ] Confirm all internal doc links resolve (`/auth/overview`, `/info/projects`, `/integrations/1password`, `/browsers/computer-controls`)
- [ ] Confirm external links to `managed-auth-react`, `docker-sbx-kit`, `cli`, and `skills` repos open correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new changelog entry and links; no runtime code paths are affected.
> 
> **Overview**
> Adds a new **May 8** `<Update>` block to `changelog.mdx` ahead of May 1, summarizing recent launches and improvements (managed-auth React components, Docker sandbox kit, Projects scoping + search/pagination, managed auth UX/autofill tweaks, and CLI `-o json` for `playwright execute`).
> 
> Also includes documentation notes about screenshot performance in computer controls and updated `kernel-cli` skill examples/`playwright execute` return-value guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ee2018419c3d56eca47347484b26e8f4358d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->