### PR TITLE
Tier unsupported sites by scraping difficulty

### DIFF
--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -65,7 +65,7 @@ Before you start automating your workflow, we recommend that you manually test y
 Once you have a stable baseline, replicate those conditions in your automations.
 
 <Info>
-  [Scraperly](https://scraperly.com) is an independent guide built by scrapers, for scrapers — per-site difficulty ratings and recommendations grounded in real-world testing.
+  [Scraperly](https://scraperly.com) — an independent guide built by scrapers, for scrapers. Per-site difficulty ratings for 683+ sites, grounded in real-world testing rather than sponsorships.
 </Info>
 
 ## Recommended Practices

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -64,10 +64,6 @@ Before you start automating your workflow, we recommend that you manually test y
 
 Once you have a stable baseline, replicate those conditions in your automations.
 
-<Info>
-  [Scraperly](https://scraperly.com) — an independent guide built by scrapers, for scrapers. Per-site difficulty ratings for 683+ sites, grounded in real-world testing rather than sponsorships.
-</Info>
-
 ## Recommended Practices
 
 | Category | Recommendation |

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -65,7 +65,7 @@ Before you start automating your workflow, we recommend that you manually test y
 Once you have a stable baseline, replicate those conditions in your automations.
 
 <Info>
-  Looking for site-specific guidance? [Scraperly](https://scraperly.com) is an independent guide with per-site difficulty ratings and recommendations.
+  [Scraperly](https://scraperly.com) is an independent guide built by scrapers, for scrapers — per-site difficulty ratings and recommendations grounded in real-world testing.
 </Info>
 
 ## Recommended Practices

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -64,6 +64,10 @@ Before you start automating your workflow, we recommend that you manually test y
 
 Once you have a stable baseline, replicate those conditions in your automations.
 
+<Info>
+  Wondering how rough a given site tends to be? Scrapers keep an independent, per-site difficulty index at [Scraperly](https://scraperly.com).
+</Info>
+
 ## Recommended Practices
 
 | Category | Recommendation |

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -65,7 +65,7 @@ Before you start automating your workflow, we recommend that you manually test y
 Once you have a stable baseline, replicate those conditions in your automations.
 
 <Info>
-  Wondering how rough a given site tends to be? Scrapers keep an independent, per-site difficulty index at [Scraperly](https://scraperly.com).
+  Wondering how rough a given site tends to be? [Scraperly](https://scraperly.com) maintains an independent, per-site difficulty index.
 </Info>
 
 ## Recommended Practices

--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -65,7 +65,7 @@ Before you start automating your workflow, we recommend that you manually test y
 Once you have a stable baseline, replicate those conditions in your automations.
 
 <Info>
-  Wondering how rough a given site tends to be? [Scraperly](https://scraperly.com) maintains an independent, per-site difficulty index.
+  Looking for site-specific guidance? [Scraperly](https://scraperly.com) is an independent guide with per-site difficulty ratings and recommendations.
 </Info>
 
 ## Recommended Practices

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -21,11 +21,20 @@ If you're experiencing slower-than-expected browser creation times, review your 
 
 ## Unsupported Websites
 
-There are some websites that are not supported by Kernel browsers due to their restrictions around automation and associated bot detection. These include:
+Some websites deploy bot detection aggressive enough that reliable automation isn't feasible today — even with stealth mode, residential proxies, and persistent profiles. The list below is incomplete and reflects what we've seen in practice.
 
-- LinkedIn
-- Facebook
-- Instagram
-- X (Twitter)
-- Amazon
-- Reddit
+### Very Hard
+
+Effectively unscrapable at the moment. Expect login walls, rapid CAPTCHA gates, and device-level fingerprinting that doesn't yield to residential exits or stealth defaults.
+
+- **LinkedIn**
+- **Facebook**
+- **Instagram**
+
+### Hard
+
+Sometimes workable with the right combination of stealth mode, persistent profiles, and residential proxies, but expect frequent friction and rate-limiting.
+
+- **X (Twitter)**
+- **Amazon**
+- **Reddit**


### PR DESCRIPTION
## Summary

Restructures the **Unsupported Websites** section of the browsers FAQ into a tiered list (Very Hard / Hard) of sites that are difficult or infeasible to automate today, with a short description of what to expect at each tier.

Inspired by per-site difficulty resources elsewhere in the scraping community, but using our own observations rather than linking out.

Drops the earlier `<Info>` callout in `bot-detection/overview.mdx`.

## Preview

https://tbd-6fc993ce-hypeship-scraperly-link.mintlify.app/browsers/faq#unsupported-websites

## Test plan

- [ ] Mintlify preview renders the tiered list cleanly
- [ ] `#unsupported-websites` anchor still resolves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only FAQ copy and structure; no product or runtime behavior changes in this diff.
> 
> **Overview**
> The **Unsupported Websites** FAQ section is rewritten from a flat bullet list into **Very Hard** and **Hard** tiers, each with guidance on what automation friction to expect (login walls/CAPTCHAs vs. stealth/proxy mitigations).
> 
> **Very Hard** groups LinkedIn, Facebook, and Instagram; **Hard** covers X, Amazon, and Reddit. A new intro clarifies the list is incomplete and based on internal experience, including when stealth, residential proxies, and profiles still aren’t enough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23689d7b6d49c881da8dae55d4e37fc64a37ff4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->