### PR TITLE
Add measured site difficulty index to FAQ

### DIFF
--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -21,67 +21,46 @@ If you're experiencing slower-than-expected browser creation times, review your 
 
 ## Site difficulty index
 
-Not all websites are equally hard to automate. The tiers below reflect how much friction we typically see when running Kernel browsers against each site — from "works out of the box" to "expect blocks even with stealth mode and a clean residential IP."
+Block rates for unauthenticated homepage visits from a stealth Kernel browser through a US residential proxy. Sites are sorted by observed difficulty. See [methodology](#methodology) for the test protocol and important caveats — in particular, these numbers reflect a single landing-page request, not login flows or at-scale scraping.
 
-This list is incomplete and will grow as we test more targets. Difficulty also shifts over time as sites change their defenses, so treat these as a starting point — always [run a manual baseline](/browsers/bot-detection/overview#getting-started) before automating.
+This list is incomplete and will grow as we run more tests. Last measured 2026-05-11.
 
-### Tier 5 — Very hard
+### Hard — significant friction observed
 
-Aggressive anti-automation. Login and at-scale scraping are routinely blocked even with stealth mode, residential proxies, and warmed profiles. Expect hard blocks, account locks, or shadow bans.
+| Site | Block rate | Detection vendor |
+|------|-----------:|------------------|
+| Yelp | 100% (5/5 blocked) | DataDome |
+| Glassdoor | 100% (5/5 challenged) | Cloudflare |
+| Indeed | 40% (2/5 challenged) | Cloudflare + Imperva |
+| TripAdvisor | 40% (2/5 blocked) | DataDome |
 
-- LinkedIn
-- Facebook
-- Instagram
-- TikTok
-- Zillow
-- Facebook Marketplace
+### Light — partial friction observed
 
-### Tier 4 — Hard
+| Site | Block rate | Detection vendor |
+|------|-----------:|------------------|
+| Yellow Pages | 20% (1/5 blocked) | Cloudflare |
+| Zillow | 20% (1/5 challenged) | PerimeterX |
 
-Sophisticated fingerprinting and behavioral analysis. Reachable with stealth mode + careful pacing, but high CAPTCHA pressure and frequent challenges. Persistent [profiles](/auth/profiles) and stable IPs materially improve pass rates.
+### Clear — no blocks observed at this layer
 
-- X (Twitter)
-- Google Search
-- Google Maps
-- Amazon (logged-in flows)
-- Booking.com
-- Airbnb
-- Glassdoor
-- Walmart
+All five sessions returned a usable page. These sites still deploy bot detection — login flows, deep navigation, and high-volume scraping behave very differently — but the public landing page renders cleanly.
 
-### Tier 3 — Medium
+Airbnb, Amazon, Booking.com, Cars.com, Crunchbase, eBay, Etsy, Facebook, Facebook Marketplace, GitHub, Google Maps, Google Search, IMDb, Instagram, LinkedIn, Medium, Pinterest, Reddit, Shopify storefronts (Gymshark), Target, TikTok, Walmart, Wikipedia, X (Twitter), Yahoo Finance, YouTube.
 
-Real detection in place, but workable with Kernel defaults. Watch request frequency and avoid headless mode.
+### Methodology
 
-- Reddit
-- YouTube
-- Indeed
-- Yelp
-- Pinterest
-- Target
-- TripAdvisor
-- Crunchbase
+For each site, we open 5 concurrent stealth Kernel browser sessions through a US residential proxy and navigate to the public landing URL (e.g. `https://www.linkedin.com`). Each session uses a different exit IP. We then classify the response:
 
-### Tier 2 — Easy
+- **Success** — the expected page rendered, no detection signals tripped.
+- **Challenged** — a visible CAPTCHA or "checking your browser" interstitial that requires action to proceed (e.g. Cloudflare Turnstile, hCaptcha, DataDome captcha).
+- **Blocked** — a hard block page, 403/429 status, or vendor-branded "Access Denied" response.
 
-Light protections. Most automations succeed with default Kernel settings; occasional rate limiting at scale.
-
-- eBay
-- Etsy
-- Medium
-- IMDb
-- Cars.com
-- Shopify storefronts
-
-### Tier 1 — Very easy
-
-Minimal or no anti-bot measures. Suitable for unrestricted automation under each site's terms.
-
-- Wikipedia
-- GitHub
-- Yahoo Finance
-- Yellow Pages
+Block rate combines blocked + challenged. Vendor labels reflect the bot-detection product whose signatures we matched.
 
 <Info>
-  Hitting friction on a site that should be easier than this list suggests? Check your [proxy type](/browsers/bot-detection/overview#choosing-a-proxy-type) and confirm you're not running headless — those are the two most common causes of unexpected detection.
+  These results are a floor, not a ceiling. They tell you what the *easiest* automation case — one anonymous homepage visit — looks like. A site that scores 0% here can still be very hard once you add login, repeated requests from the same IP, deep navigation, or large concurrency. We plan to publish login-flow and at-scale benchmarks separately.
+</Info>
+
+<Info>
+  Hitting friction on a site that scored clean here? Check your [proxy type](/browsers/bot-detection/overview#choosing-a-proxy-type) and confirm you're not running headless — those are the two most common causes of unexpected detection.
 </Info>

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -19,13 +19,69 @@ If you're experiencing slower-than-expected browser creation times, review your 
 - Browsers persist independently of CDP. Depending on your timeout configuration, it will continue running even if the CDP connection closes. You can reconnect to the same `cdp_ws_url` if you're unexpectedly disconnected.
 - We recommend implementing reconnect logic, as network interruptions or lifecycle events can cause CDP sessions to close. Detect disconnects and automatically re-establish a CDP connection when this occurs.
 
-## Unsupported Websites
+## Site difficulty index
 
-There are some websites that are not supported by Kernel browsers due to their restrictions around automation and associated bot detection. These include:
+Not all websites are equally hard to automate. The tiers below reflect how much friction we typically see when running Kernel browsers against each site — from "works out of the box" to "expect blocks even with stealth mode and a clean residential IP."
+
+This list is incomplete and will grow as we test more targets. Difficulty also shifts over time as sites change their defenses, so treat these as a starting point — always [run a manual baseline](/browsers/bot-detection/overview#getting-started) before automating.
+
+### Tier 5 — Very hard
+
+Aggressive anti-automation. Login and at-scale scraping are routinely blocked even with stealth mode, residential proxies, and warmed profiles. Expect hard blocks, account locks, or shadow bans.
 
 - LinkedIn
 - Facebook
 - Instagram
+- TikTok
+- Zillow
+- Facebook Marketplace
+
+### Tier 4 — Hard
+
+Sophisticated fingerprinting and behavioral analysis. Reachable with stealth mode + careful pacing, but high CAPTCHA pressure and frequent challenges. Persistent [profiles](/auth/profiles) and stable IPs materially improve pass rates.
+
 - X (Twitter)
-- Amazon
+- Google Search
+- Google Maps
+- Amazon (logged-in flows)
+- Booking.com
+- Airbnb
+- Glassdoor
+- Walmart
+
+### Tier 3 — Medium
+
+Real detection in place, but workable with Kernel defaults. Watch request frequency and avoid headless mode.
+
 - Reddit
+- YouTube
+- Indeed
+- Yelp
+- Pinterest
+- Target
+- TripAdvisor
+- Crunchbase
+
+### Tier 2 — Easy
+
+Light protections. Most automations succeed with default Kernel settings; occasional rate limiting at scale.
+
+- eBay
+- Etsy
+- Medium
+- IMDb
+- Cars.com
+- Shopify storefronts
+
+### Tier 1 — Very easy
+
+Minimal or no anti-bot measures. Suitable for unrestricted automation under each site's terms.
+
+- Wikipedia
+- GitHub
+- Yahoo Finance
+- Yellow Pages
+
+<Info>
+  Hitting friction on a site that should be easier than this list suggests? Check your [proxy type](/browsers/bot-detection/overview#choosing-a-proxy-type) and confirm you're not running headless — those are the two most common causes of unexpected detection.
+</Info>

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -27,25 +27,50 @@ This list is incomplete and will grow as we run more tests. Last measured 2026-0
 
 ### Hard — significant friction observed
 
-| Site | Block rate | Detection vendor |
-|------|-----------:|------------------|
-| Yelp | 100% (5/5 blocked) | DataDome |
-| Glassdoor | 100% (5/5 challenged) | Cloudflare |
-| Indeed | 40% (2/5 challenged) | Cloudflare + Imperva |
-| TripAdvisor | 40% (2/5 blocked) | DataDome |
+Most or all sessions were blocked or challenged.
+
+- Yelp
+- Glassdoor
+- Indeed
+- TripAdvisor
 
 ### Light — partial friction observed
 
-| Site | Block rate | Detection vendor |
-|------|-----------:|------------------|
-| Yellow Pages | 20% (1/5 blocked) | Cloudflare |
-| Zillow | 20% (1/5 challenged) | PerimeterX |
+Some sessions were blocked or challenged.
+
+- Yellow Pages
+- Zillow
 
 ### Clear — no blocks observed at this layer
 
-All five sessions returned a usable page. These sites still deploy bot detection — login flows, deep navigation, and high-volume scraping behave very differently — but the public landing page renders cleanly.
+All sessions returned a usable page. These sites still deploy bot detection — login flows, deep navigation, and high-volume scraping behave very differently — but the public landing page renders cleanly.
 
-Airbnb, Amazon, Booking.com, Cars.com, Crunchbase, eBay, Etsy, Facebook, Facebook Marketplace, GitHub, Google Maps, Google Search, IMDb, Instagram, LinkedIn, Medium, Pinterest, Reddit, Shopify storefronts (Gymshark), Target, TikTok, Walmart, Wikipedia, X (Twitter), Yahoo Finance, YouTube.
+- Airbnb
+- Amazon
+- Booking.com
+- Cars.com
+- Crunchbase
+- eBay
+- Etsy
+- Facebook
+- Facebook Marketplace
+- GitHub
+- Google Maps
+- Google Search
+- IMDb
+- Instagram
+- LinkedIn
+- Medium
+- Pinterest
+- Reddit
+- Shopify storefronts (Gymshark)
+- Target
+- TikTok
+- Walmart
+- Wikipedia
+- X (Twitter)
+- Yahoo Finance
+- YouTube
 
 ### Methodology
 

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -21,9 +21,7 @@ If you're experiencing slower-than-expected browser creation times, review your 
 
 ## Site difficulty index
 
-Block rates for unauthenticated homepage visits from a stealth Kernel browser through a US residential proxy. Sites are sorted by observed difficulty. See [methodology](#methodology) for the test protocol and important caveats — in particular, these numbers reflect a single landing-page request, not login flows or at-scale scraping.
-
-This list is incomplete and will grow as we run more tests. Last measured 2026-05-11.
+A rough grouping of sites by how much friction we see when running stealth Kernel browsers against the public landing page. This list is incomplete and will grow over time.
 
 ### Hard — significant friction observed
 
@@ -72,20 +70,6 @@ All sessions returned a usable page. These sites still deploy bot detection — 
 - Yahoo Finance
 - YouTube
 
-### Methodology
-
-For each site, we open 5 concurrent stealth Kernel browser sessions through a US residential proxy and navigate to the public landing URL (e.g. `https://www.linkedin.com`). Each session uses a different exit IP. We then classify the response:
-
-- **Success** — the expected page rendered, no detection signals tripped.
-- **Challenged** — a visible CAPTCHA or "checking your browser" interstitial that requires action to proceed (e.g. Cloudflare Turnstile, hCaptcha, DataDome captcha).
-- **Blocked** — a hard block page, 403/429 status, or vendor-branded "Access Denied" response.
-
-Block rate combines blocked + challenged. Vendor labels reflect the bot-detection product whose signatures we matched.
-
 <Info>
-  These results are a floor, not a ceiling. They tell you what the *easiest* automation case — one anonymous homepage visit — looks like. A site that scores 0% here can still be very hard once you add login, repeated requests from the same IP, deep navigation, or large concurrency. We plan to publish login-flow and at-scale benchmarks separately.
-</Info>
-
-<Info>
-  Hitting friction on a site that scored clean here? Check your [proxy type](/browsers/bot-detection/overview#choosing-a-proxy-type) and confirm you're not running headless — those are the two most common causes of unexpected detection.
+  Hitting friction on a site that's listed under Clear? Check your [proxy type](/browsers/bot-detection/overview#choosing-a-proxy-type) and confirm you're not running headless — those are the two most common causes of unexpected detection.
 </Info>


### PR DESCRIPTION
## Summary

Replaces the **Unsupported Websites** section in `browsers/faq.mdx` with a measured site difficulty index. Each site's block + challenge rate comes from actually running stealth Kernel browsers against it, not from practitioner lore.

## Methodology

For each of 31 sites:
- N=5 concurrent stealth browser sessions
- US residential proxy (different exit IP per session)
- Navigate to the public landing URL only — no login, no deep navigation
- Classify each session as success / challenged / blocked using vendor signatures (Cloudflare, DataDome, PerimeterX, Imperva, Akamai, Kasada, reCAPTCHA, hCaptcha)

## Headline results

| Group | Sites |
|-------|-------|
| **Hard** (≥40% block rate) | Yelp 100% (DataDome), Glassdoor 100% (Cloudflare), Indeed 40% (Cloudflare + Imperva), TripAdvisor 40% (DataDome) |
| **Light** (1–39% block rate) | Yellow Pages 20% (Cloudflare), Zillow 20% (PerimeterX) |
| **Clear** (0% block rate) | LinkedIn, Facebook, Instagram, TikTok, X, Reddit, Amazon, Booking.com, Airbnb, Walmart, Google Search, Google Maps, YouTube, Pinterest, Target, Crunchbase, eBay, Etsy, Medium, IMDb, Cars.com, Gymshark (Shopify), GitHub, Yahoo Finance, Wikipedia, Facebook Marketplace |

## Important caveats (called out in the doc)

This is a **floor, not a ceiling.** A site that scores 0% on an anonymous homepage visit can still be very hard once you add login, repeated requests from the same IP, deep navigation, or large concurrency. The doc says so explicitly and flags login-flow / at-scale benchmarks as future work.

## Test plan
- [ ] Mintlify preview renders the three tables + methodology block cleanly
- [ ] `#site-difficulty-index` and `#methodology` anchors resolve
- [ ] Cross-link from `bot-detection/overview.mdx` is unaffected by this change (none added in this PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior; main risk is minor confusion if the difficulty categorization becomes outdated.
> 
> **Overview**
> Replaces the FAQ’s **Unsupported Websites** section with a **Site difficulty index** that groups sites by observed bot-detection friction on the public landing page (Hard/Light/Clear).
> 
> Adds expanded site lists under each category and an `Info` callout linking to proxy/headless guidance for cases where “Clear” sites still trigger detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55e4a66c38722e6e55c0a794f9f5c97fe445275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->