### PR TITLE
auth: refresh managed auth docs for May 2026 changes

### DIFF
--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -100,7 +100,7 @@ Managed Auth is designed for login and authentication flows — entering credent
 
 Go to the **Browser Sessions** tab in the Kernel dashboard to watch what the managed auth session is doing in real time. Each auth login runs in a browser session with a live view, so you can see exactly where the flow is getting stuck. This is useful for diagnosing login flow problems or understanding why a session isn't staying authenticated.
 
-For flakes that only show up intermittently or are hard to reproduce live, set `record_session: true` on the connection (or per-login on `.login()`) to capture a [replay](/browsers/replays) of every login attempt. Recording starts automatically when the auth browser is created and stops when it's destroyed. The `replay_id` is persisted on the session, and recordings count toward your normal replay storage. See the [Hosted UI guide](/auth/hosted-ui#record-sessions-for-debugging) for examples.
+For flakes that only show up intermittently or are hard to reproduce live, set `record_session: true` on the connection to capture a [replay](/browsers/replays) of every auth browser session — logins, periodic health checks, and automatic reauths. To record only a single login attempt without recording subsequent health checks and reauths, pass `record_session: true` on `.login()` instead. Recordings start automatically when each auth browser is created and stop when it's destroyed, the `replay_id` is persisted on each session, and recordings count toward your normal replay storage. See the [Hosted UI guide](/auth/hosted-ui#record-sessions-for-debugging) for examples.
 
 ## Can I attach multiple auth connections to one profile?
 

--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -100,6 +100,8 @@ Managed Auth is designed for login and authentication flows — entering credent
 
 Go to the **Browser Sessions** tab in the Kernel dashboard to watch what the managed auth session is doing in real time. Each auth login runs in a browser session with a live view, so you can see exactly where the flow is getting stuck. This is useful for diagnosing login flow problems or understanding why a session isn't staying authenticated.
 
+For flakes that only show up intermittently or are hard to reproduce live, set `record_session: true` on the connection (or per-login on `.login()`) to capture a [replay](/browsers/replays) of every login attempt. Recording starts automatically when the auth browser is created and stops when it's destroyed. The `replay_id` is persisted on the session, and recordings count toward your normal replay storage. See the [Hosted UI guide](/auth/hosted-ui#record-sessions-for-debugging) for examples.
+
 ## Can I attach multiple auth connections to one profile?
 
 Yes. A profile can have any number of auth connections, each for a different domain. When you create a browser with that profile, it is already logged in to every connected domain.

--- a/auth/hosted-ui.mdx
+++ b/auth/hosted-ui.mdx
@@ -285,7 +285,48 @@ await kernel.auth.connections.update(
 ```
 </CodeGroup>
 
-You can update `login_url`, `credential`, `allowed_domains`, `health_check_interval`, `save_credentials`, and `proxy`. Only the fields you provide will be changed. Changes to `health_check_interval` and `proxy` take effect immediately on the running connection workflow.
+You can update `login_url`, `credential`, `allowed_domains`, `health_check_interval`, `save_credentials`, `record_session`, and `proxy`. Only the fields you provide will be changed. Changes to `health_check_interval` and `proxy` take effect immediately on the running connection workflow.
+
+### Record Sessions for Debugging
+
+Set `record_session: true` to capture a [replay](/browsers/replays) of every login session for the connection. Recordings start automatically when the auth browser is created and stop when it's destroyed — no explicit stop call needed.
+
+<CodeGroup>
+```typescript TypeScript
+const auth = await kernel.auth.connections.create({
+  domain: 'example.com',
+  profile_name: 'my-profile',
+  record_session: true,
+});
+```
+
+```python Python
+auth = await kernel.auth.connections.create(
+    domain="example.com",
+    profile_name="my-profile",
+    record_session=True,
+)
+```
+</CodeGroup>
+
+You can also override the connection default for a single login by passing `record_session` on `.login()` — useful for one-off debugging without flipping the connection-wide flag.
+
+<CodeGroup>
+```typescript TypeScript
+const login = await kernel.auth.connections.login(auth.id, {
+  record_session: true,
+});
+```
+
+```python Python
+login = await kernel.auth.connections.login(
+    auth.id,
+    record_session=True,
+)
+```
+</CodeGroup>
+
+Recordings count toward your replay storage like any other browser replay. The `replay_id` of the captured session is persisted on the managed auth session row.
 
 ### Post-Login URL
 

--- a/auth/hosted-ui.mdx
+++ b/auth/hosted-ui.mdx
@@ -289,7 +289,7 @@ You can update `login_url`, `credential`, `allowed_domains`, `health_check_inter
 
 ### Record Sessions for Debugging
 
-Set `record_session: true` to capture a [replay](/browsers/replays) of every login session for the connection. Recordings start automatically when the auth browser is created and stop when it's destroyed — no explicit stop call needed.
+Set `record_session: true` to capture a [replay](/browsers/replays) of every browser session tied to the connection — initial logins, background health checks, and automatic re-authentications. Recordings start automatically when each auth browser is created and stop when it's destroyed — no explicit stop call needed.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -309,7 +309,7 @@ auth = await kernel.auth.connections.create(
 ```
 </CodeGroup>
 
-You can also override the connection default for a single login by passing `record_session` on `.login()` — useful for one-off debugging without flipping the connection-wide flag.
+You can also override the connection default for a single login by passing `record_session` on `.login()` — useful for one-off debugging on a specific login attempt without flipping the connection-wide flag (which would also record subsequent health checks and reauths).
 
 <CodeGroup>
 ```typescript TypeScript
@@ -326,7 +326,7 @@ login = await kernel.auth.connections.login(
 ```
 </CodeGroup>
 
-Recordings count toward your replay storage like any other browser replay. The `replay_id` of the captured session is persisted on the managed auth session row.
+Recordings count toward your replay storage like any other browser replay. Each managed auth session row stores its own `replay_id` for the recording captured during that session.
 
 ### Post-Login URL
 

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -99,11 +99,16 @@ await page.goto("https://netflix.com")
 
 ## Choose Your Integration
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Hosted UI" icon="browser" href="/auth/hosted-ui">
     **Start here** - Simplest integration
 
     Redirect users to Kernel's hosted page. Add features incrementally: save credentials for auto-reauth, custom login URLs, SSO support.
+  </Card>
+  <Card title="React Component" icon="react" href="/auth/react">
+    **Embed in your app** - Drop-in component
+
+    Mount `<KernelManagedAuth />` on a route in your own app. Same flow as Hosted UI, rendered on your origin with a Clerk-style appearance API.
   </Card>
   <Card title="Programmatic" icon="code" href="/auth/programmatic">
     **Full control** - Custom UI or headless

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -108,7 +108,7 @@ await page.goto("https://netflix.com")
   <Card title="React Component" icon="react" href="/auth/react">
     **Embed in your app** - Drop-in component
 
-    Mount `<KernelManagedAuth />` on a route in your own app. Same flow as Hosted UI, rendered on your origin with a Clerk-style appearance API.
+    Mount `<KernelManagedAuth />` on a route in your own app. Same flow as Hosted UI, rendered on your origin and trivial to restyle to match your brand.
   </Card>
   <Card title="Programmatic" icon="code" href="/auth/programmatic">
     **Full control** - Custom UI or headless

--- a/auth/profiles.mdx
+++ b/auth/profiles.mdx
@@ -9,7 +9,7 @@ Profiles let you capture browser state created during a session (cookies and loc
 
 When you create a [Managed Auth connection](/auth/overview), it is attached to a profile. A single profile can hold multiple auth connections — one per domain — so a browser launched with that profile is logged in to all of them at once.
 
-You can also use profiles without Managed Auth. The first step in using profiles is to create one, optionally giving it a meaningful `name` that is unique within your organization.
+You can also use profiles without Managed Auth. The first step in using profiles is to create one, optionally giving it a meaningful `name` that is unique within your [project](/info/projects).
 
 <CodeGroup>
 ```typescript Typescript/Javascript
@@ -268,7 +268,7 @@ browser = await kernel.browsers.create(
 
 ## Notes
 
-- A profile's `name` must be unique within your organization.
+- A profile's `name` must be unique within your [project](/info/projects). The same name can be reused across different projects in the same org.
 - Profiles store cookies and local storage. Start the session with `save_changes: true` to write changes back when the browser is closed.
 - To keep a profile immutable for a run, omit `save_changes` (default) when creating the browser.
 - Multiple browsers in parallel can use the same profile, but only one browser should write (`save_changes: true`) to it at a time. Parallel browsers with `save_changes: true` may cause profile corruption and unpredictable behavior.

--- a/auth/programmatic.mdx
+++ b/auth/programmatic.mdx
@@ -461,6 +461,7 @@ After creating a connection, you can update its configuration with `PATCH /auth/
 | `allowed_domains` | Update allowed redirect domains |
 | `health_check_interval` | Seconds between health checks (minimum varies by plan) |
 | `save_credentials` | Whether to save credentials on successful login |
+| `record_session` | Record a [replay](/browsers/replays) of every login session for this connection |
 | `proxy` | Proxy configuration for login sessions |
 
 Only the fields you include are updated—everything else stays the same.

--- a/auth/programmatic.mdx
+++ b/auth/programmatic.mdx
@@ -302,7 +302,7 @@ When the site offers multiple MFA methods, they appear in `mfa_options`:
 <CodeGroup>
 ```typescript TypeScript
 if (state.mfa_options?.length) {
-  // Available types: sms, email, totp, push, call, security_key
+  // Available types: sms, email, totp, push, call, password, switch
   for (const opt of state.mfa_options) {
     console.log(`${opt.type}: ${opt.label}`);
   }
@@ -316,7 +316,7 @@ if (state.mfa_options?.length) {
 
 ```python Python
 if state.mfa_options:
-    # Available types: sms, email, totp, push, call, security_key
+    # Available types: sms, email, totp, push, call, password, switch
     for opt in state.mfa_options:
         print(f"{opt['type']}: {opt['label']}")
 
@@ -329,6 +329,10 @@ if state.mfa_options:
 </CodeGroup>
 
 After selecting an MFA method, the flow continues. Poll for `discovered_fields` to submit the code, or handle external actions for push/security key.
+
+<Info>
+The `switch` type represents generic method-switcher links like "Use another method" or "Try another way" that don't name a specific factor. Submit it the same way as any other MFA option to reveal the underlying alternatives on the next page.
+</Info>
 
 ### Sign-In Options (Account/Org Pickers)
 
@@ -380,8 +384,16 @@ if (state.flow_step === 'AWAITING_EXTERNAL_ACTION') {
   // Show the message to the user
   console.log(state.external_action_message);
   // e.g., "Check your phone for a push notification"
-  
-  // Keep polling—the flow resumes automatically when the user completes the action
+
+  // Some sites offer fallback methods alongside the external action
+  // (e.g. "Try another way"). Submit one to switch verification methods.
+  if (state.mfa_options?.length) {
+    await kernel.auth.connections.submit(auth.id, {
+      mfa_option_id: state.mfa_options[0].type,
+    });
+  }
+
+  // Otherwise keep polling—the flow resumes automatically when the user completes the action
 }
 ```
 
@@ -390,10 +402,22 @@ if state.flow_step == "AWAITING_EXTERNAL_ACTION":
     # Show the message to the user
     print(state.external_action_message)
     # e.g., "Check your phone for a push notification"
-    
-    # Keep polling—the flow resumes automatically when the user completes the action
+
+    # Some sites offer fallback methods alongside the external action
+    # (e.g. "Try another way"). Submit one to switch verification methods.
+    if state.mfa_options:
+        await kernel.auth.connections.submit(
+            auth.id,
+            mfa_option_id=state.mfa_options[0]["type"],
+        )
+
+    # Otherwise keep polling—the flow resumes automatically when the user completes the action
 ```
 </CodeGroup>
+
+<Info>
+`mfa_options`, `pending_sso_buttons`, and `sign_in_options` may be populated during `AWAITING_EXTERNAL_ACTION` when the site exposes fallback methods alongside the external action (for example, "Try another way" on a push prompt). Submit one of them to switch verification methods, or keep polling to let the user complete the external action.
+</Info>
 
 ## Step Reference
 

--- a/auth/programmatic.mdx
+++ b/auth/programmatic.mdx
@@ -461,7 +461,7 @@ After creating a connection, you can update its configuration with `PATCH /auth/
 | `allowed_domains` | Update allowed redirect domains |
 | `health_check_interval` | Seconds between health checks (minimum varies by plan) |
 | `save_credentials` | Whether to save credentials on successful login |
-| `record_session` | Record a [replay](/browsers/replays) of every login session for this connection |
+| `record_session` | Record a [replay](/browsers/replays) of every auth browser session for this connection (logins, health checks, and reauths) |
 | `proxy` | Proxy configuration for login sessions |
 
 Only the fields you include are updated—everything else stays the same.

--- a/auth/react.mdx
+++ b/auth/react.mdx
@@ -1,0 +1,246 @@
+---
+title: "React Component"
+description: "Embed the Kernel managed auth login flow in your own app with a drop-in React component"
+---
+
+[`@onkernel/managed-auth-react`](https://www.npmjs.com/package/@onkernel/managed-auth-react) is a React component library that renders the entire managed auth login flow inside your own app. It calls the same APIs as the [Hosted UI](/auth/hosted-ui), but renders on your origin so it inherits your styling, domain, and CSP.
+
+Use the React component when:
+- You want the [Hosted UI](/auth/hosted-ui) experience but rendered inside your own app
+- You want to fully restyle the login UI to match your brand without rebuilding the flow
+- You want same-origin auth traffic for cookies, CSP, or observability
+
+## Install
+
+```bash
+bun add @onkernel/managed-auth-react
+# or: npm install @onkernel/managed-auth-react
+```
+
+## Getting started
+
+### 1. Start a Login Session on your backend
+
+Same as the Hosted UI flow — create a connection and start a login. The login response includes a `hosted_url` that points at the route you'll mount the component on.
+
+<CodeGroup>
+```typescript TypeScript
+const auth = await kernel.auth.connections.create({
+  domain: 'netflix.com',
+  profile_name: 'user-123',
+});
+
+const { hosted_url } = await kernel.auth.connections.login(auth.id);
+// hosted_url is shaped like https://<your-domain>/<your-route>/{id}?code=<handoff>
+```
+
+```python Python
+auth = await kernel.auth.connections.create(
+    domain="netflix.com",
+    profile_name="user-123",
+)
+
+login = await kernel.auth.connections.login(auth.id)
+# login.hosted_url is shaped like https://<your-domain>/<your-route>/{id}?code=<handoff>
+```
+</CodeGroup>
+
+Redirect (or open in a popup) the end user to `hosted_url`.
+
+### 2. Render `<KernelManagedAuth />` on the login route
+
+The route just needs to surface the connection `id` (path param) and the `code` (query param) and hand them to the component. In Next.js App Router:
+
+```tsx app/login/[id]/page.tsx
+"use client";
+
+import { use } from "react";
+import { useSearchParams } from "next/navigation";
+import { KernelManagedAuth } from "@onkernel/managed-auth-react";
+import "@onkernel/managed-auth-react/styles.css";
+
+export default function LoginPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const code = useSearchParams().get("code") ?? "";
+
+  return (
+    <KernelManagedAuth
+      sessionId={id}
+      handoffCode={code}
+      onSuccess={({ profileName, domain }) => {
+        window.location.href = `/connected?profile=${profileName}`;
+      }}
+      onError={({ code, message }) => {
+        console.error(code, message);
+      }}
+    />
+  );
+}
+```
+
+The component is client-only — `"use client"` is required in any RSC framework (Next.js App Router, Remix, etc.).
+
+## Backend connectivity
+
+By default the component talks directly to `https://api.onkernel.com`. That works out of the box; nothing else to configure.
+
+If you'd rather keep all auth traffic same-origin (cookies, CSP, observability), set `baseUrl=""` and proxy the three endpoints the package hits through your own framework:
+
+```ts next.config.ts
+export default {
+  async rewrites() {
+    return [
+      {
+        source: "/auth/connections/:id/exchange",
+        destination: `${process.env.KERNEL_BASE_URL}/auth/connections/:id/exchange`,
+      },
+      {
+        source: "/auth/connections/:id",
+        destination: `${process.env.KERNEL_BASE_URL}/auth/connections/:id`,
+      },
+      {
+        source: "/auth/connections/:id/submit",
+        destination: `${process.env.KERNEL_BASE_URL}/auth/connections/:id/submit`,
+      },
+    ];
+  },
+};
+```
+
+```tsx
+<KernelManagedAuth sessionId={id} handoffCode={code} baseUrl="" {...rest} />
+```
+
+## Styling
+
+Pass an `appearance` prop to restyle any part of the component. Four composable layers:
+
+### Design tokens
+
+```tsx
+<KernelManagedAuth
+  appearance={{
+    variables: {
+      colorPrimary: "#0f172a",
+      borderRadius: 12,
+      fontFamily: "'Inter', sans-serif",
+    },
+  }}
+  {...rest}
+/>
+```
+
+Every variable becomes a `--kma-*` CSS custom property on the component root, so you can also wire them up from your own stylesheet.
+
+### Per-element overrides
+
+Every rendered element has a stable key. Target it with a class, a style object, or both:
+
+```tsx
+<KernelManagedAuth
+  appearance={{
+    elements: {
+      card: "my-card-class",
+      buttonPrimary: {
+        className: "my-button",
+        style: { letterSpacing: "0.02em" },
+      },
+      title: { style: { fontSize: 28 } },
+    },
+  }}
+  {...rest}
+/>
+```
+
+Style objects support nested pseudo-state selectors (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `::placeholder`) which compile to scoped CSS at runtime.
+
+Every rendered element also carries a `data-kma-element="<key>"` attribute, so you can target them from global CSS:
+
+```css
+[data-kma-element="buttonPrimary"] {
+  text-transform: uppercase;
+}
+```
+
+### Layout toggles
+
+```tsx
+<KernelManagedAuth
+  appearance={{
+    layout: {
+      poweredByKernel: false,
+      kernelLogoColor: "white", // 'auto' | 'green' | 'black' | 'white'
+      showLegalText: false,
+      showSecurityCard: false,
+      socialButtonsPlacement: "top",
+      skipPrimeStep: true,
+    },
+  }}
+  {...rest}
+/>
+```
+
+### Theme
+
+```tsx
+<KernelManagedAuth appearance={{ theme: "dark" }} {...rest} />
+// "light" | "dark" | "auto" (default: auto, respects prefers-color-scheme)
+```
+
+## Localization
+
+Pass a partial map of string overrides; every key not provided falls back to English.
+
+```tsx
+<KernelManagedAuth
+  localization={{
+    primeTitle: (site) => `Connectez-vous à ${site}`,
+    primeContinueButton: "Continuer",
+    submitButton: "Se connecter",
+    mfaTypeLabels: { sms: "SMS", email: "E-mail", switch: "Autre méthode" },
+  }}
+  {...rest}
+/>
+```
+
+## Props
+
+| Prop           | Type                              | Required | Default                      | Description                                                                              |
+| -------------- | --------------------------------- | -------- | ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `sessionId`    | `string`                          | yes      | —                            | Managed auth connection ID from your backend.                                            |
+| `handoffCode`  | `string`                          | yes      | —                            | Single-use handoff code from the login response, exchanged for a JWT.                    |
+| `appearance`   | `Appearance`                      | no       | —                            | Styling — variables, elements, layout, theme.                                            |
+| `localization` | `Localization`                    | no       | English                      | Partial string overrides.                                                                |
+| `onSuccess`    | `(p: AuthSuccessPayload) => void` | no       | —                            | Fires on `SUCCESS`. Payload: `{ profileName: string; domain: string }`.                  |
+| `onError`     | `(p: AuthErrorPayload) => void`   | no       | —                            | Fires on `FAILED`, `CANCELED`, `EXPIRED`. Payload: `{ code?: string; message: string }`. |
+| `baseUrl`      | `string`                          | no       | `"https://api.onkernel.com"` | Override the Kernel API origin. Use `""` for same-origin proxying via your own rewrites. |
+| `fetch`        | `typeof fetch`                    | no       | `globalThis.fetch`           | Inject a custom fetch (for SSR or instrumentation).                                      |
+
+## Headless step components
+
+For most integrations `<KernelManagedAuth />` is all you need. If you want to drive the UI yourself — custom controllers, test harnesses, or a non-standard flow — the underlying step components are exported individually:
+
+```tsx
+import {
+  Shell,
+  StepPrime,
+  StepSuccess,
+  StepError,
+  StepExpired,
+  LoadingState,
+  ExternalActionWaiting,
+  UnifiedAuthForm,
+  AppearanceProvider,
+  LocalizationProvider,
+} from "@onkernel/managed-auth-react";
+```
+
+Wrap them in `<AppearanceProvider>` and `<LocalizationProvider>` to inherit the same styling/localization plumbing as the all-in-one component.
+
+## Reference integration
+
+A full reference integration — Next.js shell, rewrites, end-to-end flow — lives at [`kernel/managed-auth-hosted-ui`](https://github.com/kernel/managed-auth-hosted-ui). It powers Kernel's own hosted login page and is a copy-pasteable starting point for embedding the component in your own app.

--- a/auth/react.mdx
+++ b/auth/react.mdx
@@ -21,7 +21,7 @@ bun add @onkernel/managed-auth-react
 
 ### 1. Start a Login Session on your backend
 
-Same as the Hosted UI flow — create a connection and start a login. The login response includes a `hosted_url` that points at the route you'll mount the component on.
+Same as the Hosted UI flow — create a connection and start a login. The login response returns the connection `id` and a one-time `handoff_code`; those are the two values you'll hand to the component on the frontend.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -30,8 +30,7 @@ const auth = await kernel.auth.connections.create({
   profile_name: 'user-123',
 });
 
-const { hosted_url } = await kernel.auth.connections.login(auth.id);
-// hosted_url is shaped like https://<your-domain>/<your-route>/{id}?code=<handoff>
+const { id, handoff_code } = await kernel.auth.connections.login(auth.id);
 ```
 
 ```python Python
@@ -41,15 +40,17 @@ auth = await kernel.auth.connections.create(
 )
 
 login = await kernel.auth.connections.login(auth.id)
-# login.hosted_url is shaped like https://<your-domain>/<your-route>/{id}?code=<handoff>
+# login.id, login.handoff_code
 ```
 </CodeGroup>
 
-Redirect (or open in a popup) the end user to `hosted_url`.
+<Info>
+The login response also includes a `hosted_url`. That URL points at Kernel's own hosted login page and is only relevant if you're using the [Hosted UI](/auth/hosted-ui) flow. When you're embedding the React component in your own app, ignore `hosted_url` and just hand `id` + `handoff_code` to your frontend however your app normally routes — a redirect with them as path/query params, a popup, props on the same page, etc.
+</Info>
 
-### 2. Render `<KernelManagedAuth />` on the login route
+### 2. Render `<KernelManagedAuth />` on the frontend
 
-The route just needs to surface the connection `id` (path param) and the `code` (query param) and hand them to the component. In Next.js App Router:
+Pass the `id` and `handoff_code` from your backend into the component. How you get them to the page is up to you — the example below shows a Next.js App Router route that surfaces `id` as a path param and `code` as a query param, but any plumbing works.
 
 ```tsx app/login/[id]/page.tsx
 "use client";
@@ -211,8 +212,8 @@ Pass a partial map of string overrides; every key not provided falls back to Eng
 
 | Prop           | Type                              | Required | Default                      | Description                                                                              |
 | -------------- | --------------------------------- | -------- | ---------------------------- | ---------------------------------------------------------------------------------------- |
-| `sessionId`    | `string`                          | yes      | —                            | Managed auth connection ID from your backend.                                            |
-| `handoffCode`  | `string`                          | yes      | —                            | Single-use handoff code from the login response, exchanged for a JWT.                    |
+| `sessionId`    | `string`                          | yes      | —                            | Managed auth connection `id` from the `.login()` response.                               |
+| `handoffCode`  | `string`                          | yes      | —                            | Single-use `handoff_code` from the `.login()` response, exchanged for a JWT.             |
 | `appearance`   | `Appearance`                      | no       | —                            | Styling — variables, elements, layout, theme.                                            |
 | `localization` | `Localization`                    | no       | English                      | Partial string overrides.                                                                |
 | `onSuccess`    | `(p: AuthSuccessPayload) => void` | no       | —                            | Fires on `SUCCESS`. Payload: `{ profileName: string; domain: string }`.                  |

--- a/browsers/extensions.mdx
+++ b/browsers/extensions.mdx
@@ -42,7 +42,7 @@ kernel extensions upload ./my-extension --name my-extension
 ```
 
 Extensions uploaded to Kernel are assigned a random ID, but you can also give them a name for easier reference.
-This name must be unique within your organization.
+This name must be unique within your [project](/info/projects).
 
 ## Using extensions in a browser
 

--- a/docs.json
+++ b/docs.json
@@ -99,6 +99,7 @@
                         "group": "Integration Types",
                         "pages": [
                           "auth/hosted-ui",
+                          "auth/react",
                           "auth/programmatic"
                         ]
                       },

--- a/reference/cli/extensions.mdx
+++ b/reference/cli/extensions.mdx
@@ -29,7 +29,7 @@ Upload an unpacked browser extension directory or zip file.
 
 | Flag | Description |
 |------|-------------|
-| `--name <name>` | Optional unique name for the extension. Must be unique within your organization. |
+| `--name <name>` | Optional unique name for the extension. Must be unique within your [project](/info/projects). |
 
 **Example:**
 


### PR DESCRIPTION
## Summary

Refreshes the managed auth docs to reflect everything that's shipped since the docs were last touched in early April. Goal: docs match current behavior.

### New
- **`auth/react.mdx`** — full integration guide for [`@onkernel/managed-auth-react`](https://www.npmjs.com/package/@onkernel/managed-auth-react): install, Next.js example, same-origin proxying, appearance API (variables / elements / layout / theme), localization, props, and headless step exports. Added to the **Auth → Integration Types** nav alongside Hosted UI and Programmatic. Overview page now shows a 3-card chooser.

### Updated
- **`auth/programmatic.mdx`**
  - MFA type enum updated to current SDK shape: `sms, email, totp, push, call, password, switch` (was: `sms, email, totp, push, call, security_key`). `password` and `switch` are new; `security_key` was never in the SDK enum.
  - Added a callout for `switch` (generic "Use another method" / "Try another way" links).
  - `AWAITING_EXTERNAL_ACTION` section now shows that `mfa_options` / `pending_sso_buttons` / `sign_in_options` can be populated alongside the external action message — submit one to switch verification methods, or keep polling. Added a code example for the push + "Try another way" fallback.
- **`auth/profiles.mdx`**, **`browsers/extensions.mdx`**, **`reference/cli/extensions.mdx`** — name uniqueness scope corrected from org to project (matches DB constraint change).

## Test plan

- [ ] Mintlify preview renders the new `auth/react` page and the 3-card chooser on `auth/overview`
- [ ] No broken internal links
- [ ] Code samples in `auth/programmatic.mdx` match current SDK shape (verified `MfaOption.type` against `kernel-node-sdk` types)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (new guide, nav updates, and behavior clarifications) with no runtime code modifications.
> 
> **Overview**
> Adds a new `auth/react` guide documenting the `@onkernel/managed-auth-react` embedded login flow (installation, backend handoff, same-origin proxying, styling/localization, and headless exports) and surfaces it in navigation; `auth/overview` is updated to present Hosted UI/React/Programmatic as three integration options.
> 
> Updates Managed Auth docs to match current behavior: documents `record_session` replay recording on connections/logins (`auth/hosted-ui`, `auth/faq`, `auth/programmatic`), refreshes programmatic MFA option types (including `password` and `switch`) and clarifies fallback options during `AWAITING_EXTERNAL_ACTION`, and corrects multiple places to state that profile/extension names are unique per *project* (not org).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1580c54f9a5f414017bf1c912171235837ed7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->