### PR TITLE
auth: cover short-session reauth and multi-step login forms in FAQ

### DIFF
--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -20,6 +20,12 @@ Health checks run on configurable cadences. Your plan sets the minimum interval:
 
 You can increase the interval above your plan's minimum, but not below it.
 
+## What if my site's session expires faster than the health check interval?
+
+Kernel keeps re-authenticating even when every health check finds the session expired. A successful login resets the auto-reauth state, so a site whose session TTL is shorter than your health check interval is re-authenticated on every cycle rather than being given up on.
+
+If you're seeing the connection flip to `NEEDS_AUTH` frequently and want shorter detection windows, lower the connection's `health_check_interval` down to your plan's minimum. Enterprise plans can go as low as 5 minutes.
+
 ## How do I know if a Kernel can automatically re-authenticate a connection?
 
 Check the `can_reauth` field on a connection. This boolean checks the following conditions:
@@ -94,7 +100,7 @@ if state.status == "NEEDS_AUTH":
 
 ## What types of flows does Managed Auth support?
 
-Managed Auth is designed for login and authentication flows — entering credentials, handling SSO redirects, completing MFA challenges, and maintaining sessions. For other browser interactions like form filling, sign-ups, or multi-step workflows, use [Kernel's browser automation](/browsers/create-a-browser) directly.
+Managed Auth handles login and authentication flows end-to-end: entering credentials, multi-step login forms (e.g. email on one page, password on the next), SSO redirects, MFA challenges, and keeping sessions alive. For post-login browser work like form filling, sign-ups, or other workflows, use [Kernel's browser automation](/browsers/create-a-browser) directly.
 
 ## How do I debug a managed auth session?
 


### PR DESCRIPTION
## Summary

The May 2026 managed-auth doc refresh missed two shipped behaviors. This PR adds them to `auth/faq.mdx`:

- **Short-session site reauth** — auto-reauth keeps running when a site's session TTL is shorter than the health-check interval. Each successful login resets the auto-reauth state, so the connection isn't given up on after consecutive "expired" health checks. Added an FAQ entry plus a pointer at the `health_check_interval` knob for users who want shorter detection windows.
- **Multi-step login forms** — the existing "What types of flows does Managed Auth support?" answer lumped "multi-step workflows" into the "use browser automation instead" bucket, which contradicts current behavior. Reworded to make clear that multi-step login forms (e.g. email on page 1, password revealed on page 2) are handled end-to-end, while *post-login* multi-step workflows still belong in browser automation.

## Test plan

- [ ] Mintlify preview renders both FAQ entries
- [ ] Wording flows with the surrounding tone (short, direct, no marketing fluff)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or API behavior is modified.
> 
> **Overview**
> Adds an FAQ entry explaining how automatic re-authentication behaves when a site's session TTL is shorter than the `health_check_interval`, including guidance on reducing the interval to avoid frequent `NEEDS_AUTH` states.
> 
> Rewords the "What types of flows does Managed Auth support?" answer to explicitly include *multi-step login forms* as supported, while still directing post-login workflows to browser automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf79ed63bc6279f13cb80058e8767c6fed6aead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->