### PR TITLE
docs: update Yutori integration to Navigator n1.5

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,16 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="May 13" tags={["Product", "Docs"]}>
+## Product updates
+
+- Updated the [Yutori](/integrations/computer-use/yutori) `kernel create` template (TypeScript + Python) to Yutori's [Navigator n1.5](https://yutori.com/blog/introducing-n1-5) model. The template runs n1.5 in computer-use-only mode against the `browser_tools_core-20260403` tool set, picks up the new actions (`mouse_move`, `mouse_down`/`mouse_up`, `middle_click`, `hold_key`, `go_forward`, click `modifier`), and trims request payloads on long sessions to stay under the API ceiling.
+
+## Documentation updates
+
+- Updated the [Yutori](/integrations/computer-use/yutori) integration page to reference Navigator n1.5 and document the computer-use-only tool set used by the template.
+</Update>
+
 <Update label="May 8" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,16 +9,6 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
-<Update label="May 13" tags={["Product", "Docs"]}>
-## Product updates
-
-- Updated the [Yutori](/integrations/computer-use/yutori) `kernel create` template (TypeScript + Python) to Yutori's [Navigator n1.5](https://yutori.com/blog/introducing-n1-5) model. The template runs n1.5 in computer-use-only mode against the `browser_tools_core-20260403` tool set, picks up the new actions (`mouse_move`, `mouse_down`/`mouse_up`, `middle_click`, `hold_key`, `go_forward`, click `modifier`), and trims request payloads on long sessions to stay under the API ceiling.
-
-## Documentation updates
-
-- Updated the [Yutori](/integrations/computer-use/yutori) integration page to reference Navigator n1.5 and document the computer-use-only tool set used by the template.
-</Update>
-
 <Update label="May 8" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/integrations/computer-use/yutori.mdx
+++ b/integrations/computer-use/yutori.mdx
@@ -16,10 +16,6 @@ kernel create --name my-yutori-app --template yutori
 
 Choose `TypeScript` or `Python` as the programming language.
 
-The template runs n1.5 in **computer-use-only mode**, using the `browser_tools_core-20260403` tool set for coordinate-based browser actions. The DOM/Playwright "expanded" tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) are disabled because the template doesn't expose a Playwright page to the model.
-
-Yutori n1.5 recommends a **1280×800 (WXGA, 16:10)** viewport for best grounding accuracy. See [viewports](/browsers/viewport) for supported configurations.
-
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Yutori automation on Kernel's infrastructure.
 
 ## Benefits of using Kernel with Yutori n1.5

--- a/integrations/computer-use/yutori.mdx
+++ b/integrations/computer-use/yutori.mdx
@@ -2,13 +2,13 @@
 title: "Yutori"
 ---
 
-[n1](https://yutori.com/blog/introducing-n1) is Yutori's pixels-to-actions LLM that predicts browser actions from screenshots. This computer use model enables AI agents to interact with web interfaces by analyzing visual content and generating appropriate mouse and keyboard actions.
+[Navigator n1.5](https://yutori.com/blog/introducing-n1-5) is Yutori's pixels-to-actions LLM that predicts browser actions from screenshots. This computer use model enables AI agents to interact with web interfaces by analyzing visual content and generating appropriate mouse and keyboard actions.
 
-By integrating Yutori n1 with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure, eliminating the need for local browser management and enabling scalable, reliable AI agents.
+By integrating Yutori n1.5 with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure, eliminating the need for local browser management and enabling scalable, reliable AI agents.
 
 ## Quick setup with our Yutori example app
 
-Get started quickly with our Kernel app template that includes a pre-configured Yutori n1 integration:
+Get started quickly with our Kernel app template that includes a pre-configured Yutori n1.5 integration:
 
 ```bash
 kernel create --name my-yutori-app --template yutori
@@ -16,11 +16,15 @@ kernel create --name my-yutori-app --template yutori
 
 Choose `TypeScript` or `Python` as the programming language.
 
+The template runs n1.5 in **computer-use-only mode**, using the `browser_tools_core-20260403` tool set for coordinate-based browser actions. The DOM/Playwright "expanded" tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) are disabled because the template doesn't expose a Playwright page to the model.
+
+Yutori n1.5 recommends a **1280×800 (WXGA, 16:10)** viewport for best grounding accuracy. See [viewports](/browsers/viewport) for supported configurations.
+
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Yutori automation on Kernel's infrastructure.
 
-## Benefits of using Kernel with Yutori n1
+## Benefits of using Kernel with Yutori n1.5
 
-- **No local browser management**: Run n1 automations without installing or maintaining browsers locally
+- **No local browser management**: Run n1.5 automations without installing or maintaining browsers locally
 - **Scalability**: Launch multiple browser sessions in parallel for concurrent AI agents
 - **Stealth mode**: Built-in anti-detection features for reliable web interactions
 - **Session state**: Maintain browser state across runs via [Profiles](/auth/profiles)
@@ -33,4 +37,4 @@ Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to depl
 - Learn about [stealth mode](/browsers/bot-detection/stealth) for avoiding detection
 - Learn how to properly [terminate browser sessions](/browsers/termination)
 - Learn how to [deploy](/apps/deploy) your Yutori app to Kernel
-- Read the [Yutori n1 API documentation](https://docs.yutori.com/reference/n1) for model details
+- Read the [Yutori n1.5 API documentation](https://docs.yutori.com/reference/n1-5) for model details

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -35,7 +35,7 @@ Kernel provides detailed guides for popular agent frameworks:
 - **[Computer Use (OpenAI)](/integrations/computer-use/openai)** - OpenAI's computer use capability
 - **[Computer Use (Gemini)](/integrations/computer-use/gemini)** - Gemini's computer use capability
 - **[Computer Use (OpenAGI)](/integrations/computer-use/openagi)** - OpenAGI's computer use capability
-- **[Computer Use (Yutori)](/integrations/computer-use/yutori)** - Yutori n1 pixels-to-actions model
+- **[Computer Use (Yutori)](/integrations/computer-use/yutori)** - Yutori Navigator n1.5 pixels-to-actions model
 - **[Laminar](/integrations/laminar)** - Observability and tracing for AI browser automations
 - **[Magnitude](/integrations/magnitude)** - Vision-focused browser automation framework
 - **[Notte](/integrations/notte)** - AI agent framework for browser automation


### PR DESCRIPTION
## Summary

Reflects the CLI's [v0.19.1](https://github.com/kernel/cli/releases/tag/v0.19.1) Yutori template upgrade in the docs:

- Integration page (`integrations/computer-use/yutori.mdx`) now references **Navigator n1.5** instead of n1, and links to the n1.5 blog post and API docs.
- Integrations overview entry updated to "Yutori Navigator n1.5".

## Test plan

- [ ] Preview renders cleanly on Mintlify
- [ ] Links resolve (yutori.com/blog/introducing-n1-5, docs.yutori.com/reference/n1-5)