### PR TITLE
drop 'connection' prefix from auth sidebar entries

### DIFF
--- a/auth/configuration.mdx
+++ b/auth/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Connection Configuration"
+sidebarTitle: "Configuration"
 description: "Shared options for managed auth connections, regardless of integration flow"
 ---
 

--- a/auth/connection-lifecycle.mdx
+++ b/auth/connection-lifecycle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Connection Lifecycle"
+sidebarTitle: "Lifecycle"
 description: "How connections stay authenticated, and what to do when one breaks"
 ---
 


### PR DESCRIPTION
## Summary
- Adds `sidebarTitle` overrides so the Auth section of the sidebar reads "Configuration" and "Lifecycle" instead of "Connection Configuration" and "Connection Lifecycle".
- Page titles (H1) and URLs are unchanged, so no redirects are needed.

## Test plan
- [ ] Preview the docs and confirm the sidebar under Auth shows "Configuration" and "Lifecycle".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only frontmatter change that affects sidebar labels but not page content, URLs, or runtime behavior.
> 
> **Overview**
> Updates the Auth docs sidebar labels by adding `sidebarTitle` overrides so `auth/configuration.mdx` shows “Configuration” and `auth/connection-lifecycle.mdx` shows “Lifecycle”, while keeping the existing page titles and routes unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c385a14a68f72aba508910bdb93b55311a29c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->