### PR TITLE
document success_url / error_url query params on hosted ui

### DIFF
--- a/auth/hosted-ui.mdx
+++ b/auth/hosted-ui.mdx
@@ -204,6 +204,44 @@ if state.status == "AUTHENTICATED":
 ```
 </CodeGroup>
 
+## Success / error redirects
+
+To redirect the user back to your app once the flow finishes — for example, to auto-close the auth window inside a mobile in-app browser — append `success_url` and/or `error_url` query params to `hosted_url`. These mirror the `onSuccess` / `onError` callbacks exposed by the [React Component](/auth/react).
+
+- `success_url` — visited when the session reaches `SUCCESS`. The hosted page appends `profile_name` and `domain` as query params.
+- `error_url` — visited when the session reaches `FAILED`, `CANCELED`, or `EXPIRED`. The hosted page appends `code` (when present) and `message` as query params.
+
+Any scheme is accepted, so mobile integrators can pass a custom scheme (`myapp://auth/done`) to bounce back into the host app.
+
+<CodeGroup>
+```typescript TypeScript
+const login = await kernel.auth.connections.login(auth.id);
+
+const url = new URL(login.hosted_url);
+url.searchParams.set("success_url", "https://example.com/connected");
+url.searchParams.set("error_url", "https://example.com/auth-failed");
+
+window.location.href = url.toString();
+```
+
+```python Python
+from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
+
+login = await kernel.auth.connections.login(auth.id)
+
+parsed = urlparse(login.hosted_url)
+query = dict(parse_qsl(parsed.query))
+query["success_url"] = "https://example.com/connected"
+query["error_url"] = "https://example.com/auth-failed"
+
+redirect_url = urlunparse(parsed._replace(query=urlencode(query)))
+```
+</CodeGroup>
+
+<Warning>
+The hosted page redirects to whatever URL you pass. Only set these from your own trusted backend — never let an end user supply them directly.
+</Warning>
+
 ## Connection Configuration
 
 Connection-level options — custom login URL, SSO/OAuth, custom proxy, session recording, post-login URL, and updates — apply equally to all integration flows and are documented in [Connection Configuration](/auth/configuration).


### PR DESCRIPTION
## Summary

- Adds a "Success / error redirects" section to `auth/hosted-ui.mdx` covering the new `success_url` and `error_url` query params on the hosted login page.
- Documents the appended payload (`profile_name`, `domain` on success; `code`, `message` on error) and shows TypeScript + Python snippets for building the URL on the backend.
- Includes a warning that these must only be set from a trusted backend (open-redirect surface).
- Pairs with kernel/managed-auth-hosted-ui#35.

## Test plan

- [ ] Preview the rendered page on the Mintlify preview URL and confirm formatting / code blocks render
- [ ] Verify the warning callout renders correctly
- [ ] Land kernel/managed-auth-hosted-ui#35 first so the documented behavior matches what's live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change describing redirect query params; no runtime or API behavior is modified in this PR.
> 
> **Overview**
> Documents new `success_url` and `error_url` query params for the Hosted UI login flow, including when each redirect triggers and what query payload is appended on success vs. error.
> 
> Adds TypeScript and Python examples for constructing the redirect URLs and a warning callout highlighting the open-redirect risk if these values are user-controlled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c20e896f340d7c681778ba220088bbd9d83e32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->