### PR TITLE
Clarify managed proxy IP stability is per-session, not across sessions

### DIFF
--- a/auth/configuration.mdx
+++ b/auth/configuration.mdx
@@ -66,9 +66,9 @@ Pin the auth flow to a specific [proxy](/proxies/overview) so logins, health che
 
 How stable the exit IP is depends on the proxy type:
 
-- **[ISP](/proxies/isp)** and **[datacenter](/proxies/datacenter)** proxies provide a static exit IP that stays consistent across all connections.
+- **[ISP](/proxies/isp)** and **[datacenter](/proxies/datacenter)** proxies provide a stable exit IP within a single session, but Kernel does not guarantee the same IP across sessions. Sites with adaptive auth that trigger a step-up challenge (one-time code, device verification) when the client IP changes may flag the IP shift between the initial login and a subsequent health check or reauth.
 - **[Residential](/proxies/residential)** proxies rotate IPs per connection — use them when you need legitimacy from a real ISP pool but can tolerate IP changes.
-- **[Custom (BYO)](/proxies/custom)** proxies route through whatever you point them at, so this is the right pick if you need a truly static IP under your own control (e.g. an allowlisted egress your security team owns).
+- **[Custom (BYO)](/proxies/custom)** proxies route through whatever you point them at, so this is the right pick if you need a truly static IP that persists across the initial login and every subsequent health check and reauth (e.g. an allowlisted egress your security team owns).
 
 Create a proxy first, then attach it to the connection:
 

--- a/proxies/datacenter.mdx
+++ b/proxies/datacenter.mdx
@@ -8,7 +8,7 @@ Datacenter proxies use IP addresses assigned from datacenter servers to route yo
 
 Datacenter proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
 
-Across separate sessions, Kernel does not guarantee the same exit IP from a managed datacenter proxy. If a destination site requires the exact same IP across every session — for example, an IP allowlist, or a [managed auth](/auth/overview) connection whose health checks and reauths must look like the same client — use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
+For cross-session IP stability (e.g. IP allowlists or [managed auth](/auth/overview) health checks), see [IP rotation behavior across proxy types](/proxies/overview).
 
 ## Configuration
 

--- a/proxies/datacenter.mdx
+++ b/proxies/datacenter.mdx
@@ -6,7 +6,9 @@ Datacenter proxies use IP addresses assigned from datacenter servers to route yo
 
 ## IP Rotation Behavior
 
-Datacenter proxies provide a **static exit IP** — the same IP address is used for all connections throughout the lifetime of the proxy. Every tab, request, and reconnection within a browser session exits through the same IP.
+Datacenter proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
+
+Across separate sessions, Kernel does not guarantee the same exit IP from a managed datacenter proxy. If a destination site requires the exact same IP across every session — for example, an IP allowlist, or a [managed auth](/auth/overview) connection whose health checks and reauths must look like the same client — use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
 
 ## Configuration
 

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -6,7 +6,9 @@ ISP (Internet Service Provider) proxies combine the speed of datacenter proxies 
 
 ## IP Rotation Behavior
 
-ISP proxies provide a **static exit IP** — the same IP address is used for all connections throughout the lifetime of the proxy. Every tab, request, and reconnection within a browser session exits through the same IP. This makes ISP proxies ideal for session-based workflows, login flows, and any use case where a consistent IP is important.
+ISP proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
+
+Across separate sessions, Kernel does not guarantee the same exit IP from a managed ISP proxy. If a destination site requires the exact same IP across every session — for example, an IP allowlist, or a [managed auth](/auth/overview) connection whose health checks and reauths must look like the same client — use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
 
 ## Configuration
 

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -8,7 +8,7 @@ ISP (Internet Service Provider) proxies combine the speed of datacenter proxies 
 
 ISP proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
 
-Across separate sessions, Kernel does not guarantee the same exit IP from a managed ISP proxy. If a destination site requires the exact same IP across every session — for example, an IP allowlist, or a [managed auth](/auth/overview) connection whose health checks and reauths must look like the same client — use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
+For cross-session IP stability (e.g. IP allowlists or [managed auth](/auth/overview) health checks), see [IP rotation behavior across proxy types](/proxies/overview).
 
 ## Configuration
 

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -16,7 +16,9 @@ Kernel supports four types of proxies:
 Datacenter has the fastest speed, while residential is least detectable. ISP is a balance between the two options, with less-flexible geotargeting. Kernel recommends to use the first option in the list that works for your use case.
 
 <Info>
-Datacenter and ISP proxies provide a **stable exit IP** that stays consistent across all connections. Residential proxies use **rotating exit IPs** that may change per connection — see [Residential Proxies](/proxies/residential#ip-rotation-behavior) for details.
+Datacenter and ISP proxies provide a **stable exit IP within a single browser session** — the IP does not rotate mid-session. Across separate sessions, however, Kernel does not guarantee the same exit IP. If you need a truly static IP that persists across every session (for example, an IP allowlist or a [managed auth](/auth/overview) connection whose health checks must egress from a single IP), use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
+
+Residential proxies use **rotating exit IPs** that may change per connection — see [Residential Proxies](/proxies/residential#ip-rotation-behavior) for details.
 </Info>
 
 ## Create a proxy


### PR DESCRIPTION
## Summary

Our proxy docs currently state that ISP and datacenter proxies provide a "static exit IP that stays consistent across all connections." That's only true within a single session — the managed proxy service does not pin the same egress IP across separate sessions.

This matters for managed auth: when health checks and reauth attempts run on different egress IPs, sites with adaptive auth may flag the IP shift and trigger a step-up challenge (one-time code, device verification) that the agent can't solve.

This PR clarifies:

- ISP and datacenter proxies are stable **within** a session but not guaranteed across sessions.
- For a truly static IP across the initial login and every subsequent health check / reauth, use a custom (BYO) proxy pointed at infrastructure you control.

Updated:
- `proxies/overview.mdx`
- `proxies/isp.mdx`
- `proxies/datacenter.mdx`
- `auth/configuration.mdx`

## Test plan

- [ ] Mintlify preview renders without broken links
- [ ] Internal links to `/proxies/custom` and `/auth/overview` resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust wording around proxy IP rotation/stability; low risk aside from potentially changing user expectations and guidance for managed auth setups.
> 
> **Overview**
> Clarifies in proxy and managed-auth docs that **ISP** and **datacenter** proxies have a *stable exit IP only within a single browser session*, and are **not guaranteed** to keep the same egress IP across sessions.
> 
> Updates guidance to direct users who need a *truly static* cross-session egress (e.g. IP allowlists or managed-auth health checks/reauth) toward using a **custom (BYO) proxy**, and adds cross-links from the ISP/datacenter pages back to `proxies/overview`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4abc504385ed80ebb3ab19cca4ee21c0482e603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->