### PR TITLE
remove references to persistent browser feature

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -190,7 +190,6 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="February 27" tags={["Product", "Docs"]}>
 ## Product updates
 - We launched our new look! Our visual identity has been updated across our website, product, and docs.
-- **Important:** Persistent browser functionality will be end-of-life'd as of May 18th. If you're using this functionality, you've received an email from us with next steps. Please reach out for further support.
 - Improved the [MCP server](/reference/mcp-server) by adding 21 new tools covering browser pools, computer controls, proxies, extensions, and more. Consolidated 36 individual tools into 10 streamlined tools and enhanced the computer_action tool to support executing multiple actions in a single call.
 - Added API support for clipboard operations, enabling programmatic copy/paste between your automation code and the remote browser.
 - Introduced human-like Bezier curve mouse movements for more natural-looking browser interactions that better evade bot detection.
@@ -304,7 +303,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="December 12" tags={["Product", "Docs"]}>
 ## Product updates
 - Refreshed our [Vercel template](https://kernel-nextjs-template.vercel.app/) with an enhanced UI and AI agent example
-- Deprecated the "persistent" feature from browsers in favor of using extended `timeout_seconds` with [Profiles](/auth/profiles#3-use-the-browser,-then-close-it-to-persist-the-state); added `name` field to browsers for easier identification
+- Added `name` field to browsers for easier identification
 - Unified browser creation tools by porting [Create Kernel App](/reference/cli/create) functionality into the Kernel CLI
 - Improved replay videos to include full video length metadata, enabling timestamp navigation and deep linking
 


### PR DESCRIPTION
## Summary
Persistent browsers have been end-of-lifed, so remove the two changelog references to the feature:

- February 27 entry: removes the EOL-on-May-18 warning bullet (now obsolete).
- December 12 entry: removes the deprecation bullet; keeps the `name` field announcement.

No live docs (auth, browsers, reference) referenced persistent browsers — only the historical changelog entries.

## Test plan
- [ ] Confirm the changelog still renders cleanly in Mintlify preview.