### PR TITLE
docs: add hCaptcha beta page

### DIFF
--- a/browsers/bot-detection/hcaptcha.mdx
+++ b/browsers/bot-detection/hcaptcha.mdx
@@ -12,6 +12,6 @@ The hCaptcha solver is in beta and isn't enabled for all organizations by defaul
 
 ## Get access
 
-To use the hCaptcha solver, [contact Kernel support](/docs/info/support) and ask to have the hCaptcha beta enabled for your organization.
+To use the hCaptcha solver, [contact Kernel support](https://www.kernel.sh/docs/info/support) and ask to have the hCaptcha beta enabled for your organization.
 
 Include the website or workflow you're testing, your expected volume, and whether you're already using [stealth mode](/browsers/bot-detection/stealth), [profiles](/auth/profiles), or custom [proxies](/proxies/overview). This helps us confirm the right setup for your use case.

--- a/browsers/bot-detection/hcaptcha.mdx
+++ b/browsers/bot-detection/hcaptcha.mdx
@@ -1,0 +1,17 @@
+---
+title: "hCaptcha"
+---
+
+Kernel's hCaptcha solver is a beta feature for teams that need help handling hCaptcha challenges in browser automations.
+
+When enabled for your organization, Kernel can attempt to solve supported hCaptcha challenges automatically from Kernel browsers. This is useful for permitted automation where hCaptcha appears as part of a normal browser workflow, such as QA, account operations, or user-authorized agent tasks.
+
+<Info>
+The hCaptcha solver is in beta and isn't enabled for all organizations by default.
+</Info>
+
+## Get access
+
+To use the hCaptcha solver, [contact Kernel support](/info/support) and ask to have the hCaptcha beta enabled for your organization.
+
+Include the website or workflow you're testing, your expected volume, and whether you're already using [stealth mode](/browsers/bot-detection/stealth), [profiles](/auth/profiles), or custom [proxies](/proxies/overview). This helps us confirm the right setup for your use case.

--- a/browsers/bot-detection/hcaptcha.mdx
+++ b/browsers/bot-detection/hcaptcha.mdx
@@ -12,6 +12,6 @@ The hCaptcha solver is in beta and isn't enabled for all organizations by defaul
 
 ## Get access
 
-To use the hCaptcha solver, [contact Kernel support](/info/support) and ask to have the hCaptcha beta enabled for your organization.
+To use the hCaptcha solver, [contact Kernel support](/docs/info/support) and ask to have the hCaptcha beta enabled for your organization.
 
 Include the website or workflow you're testing, your expected volume, and whether you're already using [stealth mode](/browsers/bot-detection/stealth), [profiles](/auth/profiles), or custom [proxies](/proxies/overview). This helps us confirm the right setup for your use case.

--- a/docs.json
+++ b/docs.json
@@ -126,6 +126,7 @@
                     "pages": [
                       "browsers/bot-detection/overview",
                       "browsers/bot-detection/stealth",
+                      "browsers/bot-detection/hcaptcha",
                       {
                         "group": "Proxies",
                         "pages": [


### PR DESCRIPTION
## Summary
- Add a concise hCaptcha beta docs page explaining the feature and how to request access.
- Link the page from the Bot Anti-Detection docs navigation.

## Test plan
- ReadLints reported no diagnostics for the edited docs files.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a new page and navigation link, with no runtime or API behavior changes.
> 
> **Overview**
> Adds a new `browsers/bot-detection/hcaptcha` docs page describing the beta hCaptcha solver, what it does, and how to request access via support.
> 
> Updates `docs.json` navigation to include the new hCaptcha page under *Advanced → Bot Anti-Detection*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac90c515a80d9a647744689f29f7d4fdd7aae84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->