### PR TITLE
docs: add session intelligence privacy page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -232,6 +232,7 @@
             "pages": [
               "browsers/faq",
               "info/concepts",
+              "info/session-intelligence",
               "info/pricing",
               "info/support",
               "info/unikernels"

--- a/info/session-intelligence.mdx
+++ b/info/session-intelligence.mdx
@@ -1,0 +1,24 @@
+---
+title: "Session Intelligence"
+---
+
+Session intelligence helps Kernel understand how browser sessions navigate and perform, so we can debug issues, improve reliability, and make browser automation more predictable.
+
+Our approach is privacy-first: collect the minimum operational telemetry needed to improve the service, keep it scoped to the browser session, and honor opt-out requests.
+
+## What we collect
+
+When session intelligence is enabled, Kernel may collect navigation and performance metadata from Kernel browsers, including:
+
+- The domain and normalized URL path, without query strings or URL fragments
+- Navigation status, such as completed navigations or navigation errors
+- HTTP status code for main-frame navigations
+- Page load timing, DOMContentLoaded timing, resource count, and transfer size
+
+Session intelligence doesn't record your screen, capture screenshots, store page contents, collect keystrokes, or collect form field values.
+
+## Opt out
+
+If you want session intelligence disabled for your organization, [contact Kernel support](/info/support) or email [privacy@onkernel.com](mailto:privacy@onkernel.com).
+
+Include your organization name and the environment or project you want opted out. We'll confirm once session intelligence is disabled for that scope.

--- a/info/session-intelligence.mdx
+++ b/info/session-intelligence.mdx
@@ -19,6 +19,6 @@ Session intelligence doesn't record your screen, capture screenshots, store page
 
 ## Opt out
 
-If you want session intelligence disabled for your organization, [contact Kernel support](/info/support) or email [privacy@onkernel.com](mailto:privacy@onkernel.com).
+If you want session intelligence disabled for your organization, [contact Kernel support](/docs/info/support) or email [privacy@onkernel.com](mailto:privacy@onkernel.com).
 
 Include your organization name and the environment or project you want opted out. We'll confirm once session intelligence is disabled for that scope.

--- a/info/session-intelligence.mdx
+++ b/info/session-intelligence.mdx
@@ -19,6 +19,6 @@ Session intelligence doesn't record your screen, capture screenshots, store page
 
 ## Opt out
 
-If you want session intelligence disabled for your organization, [contact Kernel support](/docs/info/support) or email [privacy@onkernel.com](mailto:privacy@onkernel.com).
+If you want session intelligence disabled for your organization, [contact Kernel support](https://www.kernel.sh/docs/info/support) or email [privacy@onkernel.com](mailto:privacy@onkernel.com).
 
 Include your organization name and the environment or project you want opted out. We'll confirm once session intelligence is disabled for that scope.


### PR DESCRIPTION
## Summary
- Add a concise Session Intelligence docs page covering privacy posture, collected navigation/performance metadata, and opt-out instructions.
- Link the page from the Info docs navigation.

## Test plan
- ReadLints reported no diagnostics for the edited docs files.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new informational page and updates navigation; no code or runtime behavior is affected.
> 
> **Overview**
> Adds a new `info/session-intelligence` docs page describing Kernel’s *Session Intelligence* telemetry (what navigation/performance metadata may be collected, what is explicitly not collected, and opt-out instructions).
> 
> Updates `docs.json` to link this new page under the **Info** section of the Guides navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab1365d61d6468e92d9935157875963e09a86e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->