### PR TITLE
Expand control.mdx with computer use + playwright execution patterns

### DIFF
--- a/introduction/control.mdx
+++ b/introduction/control.mdx
@@ -163,6 +163,11 @@ If you're reaching for Playwright, prefer the execution API over `connectOverCDP
 
 Computer controls drive the browser the way a person would — they don't speak the programmatic API surface. Anything you'd reach for the DOM or Playwright client for (reading text and attributes, `page.goto`, file uploads, cookie or storage access, switching tabs) belongs on the [playwright execution](/browsers/playwright-execution) side. The recommended pattern for agents is computer controls for interaction, playwright execution as a tool the agent can call when it needs structured data or a programmatic action.
 
+A couple of patterns this enables:
+
+- **Checkpoint between steps.** After a step you can't verify from a screenshot — a login, a cart add, a multi-step form — use playwright execution to assert cookies or DOM state before letting the agent continue. Cheaper than another screenshot round-trip and harder to hallucinate around.
+- **Drop the agent once selectors are stable.** The agent's job was finding the right things to click and extract. Once you have stable selectors, the next million requests don't need a model — hit URLs directly via playwright execution.
+
 <CodeGroup>
 ```typescript Typescript/Javascript
 const response = await kernel.browsers.playwright.execute(


### PR DESCRIPTION
## Summary

Stacks on top of #370. Adds three named patterns as short bullets under the existing "Computer use + playwright execution" section in `introduction/control.mdx`:

- **Expose it as a tool** — model calls `playwright.execute` for structured data, the agent stays in charge of navigation.
- **Checkpoint between steps** — assert cookies / DOM state after a CUA step before continuing.
- **Drop the agent once selectors are stable** — replay at scale without a model in the loop.

No new page, no extra code. Just names + one-sentence explanations so customers asking "how do I combine these?" have something concrete to point at.

## Test plan

- [ ] `mintlify dev` renders control.mdx with the new bullets
- [ ] No broken links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds usage guidance; no runtime behavior or APIs are modified.
> 
> **Overview**
> Expands `introduction/control.mdx` with a short set of recommended patterns for combining computer controls with `playwright.execute`, emphasizing when to validate state via Playwright and when to switch from model-driven interaction to fully scripted execution once selectors are stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c879c0274bda1bf4a35585c9ccbb3ecfeb4efde6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->