### PR TITLE
update MCP server tool list to match current API

### DIFF
--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -287,37 +287,29 @@ Configure these values wherever the tool expects MCP server settings.
 
 ## Tools
 
-### Browser Automation
+Each Kernel feature has a single `manage_*` tool with an `action` parameter, keeping the tool set small and consistent. Four standalone tools handle high-frequency workflows.
 
-- `create_browser` - Launch a new browser session with options (headless, stealth, timeout, profile)
-- `get_browser` - Get browser session information
-- `list_browsers` - List active browser sessions
-- `delete_browser` - Terminate a browser session
-- `execute_playwright_code` - Execute Playwright/TypeScript code in a fresh browser session with automatic video replay and cleanup
-- `take_screenshot` - Capture a screenshot of the current browser page, optionally specifying a region
+### `manage_*` tools
 
-### Profile Management
+- `manage_browsers` - Create, list, get, and delete browser sessions. Supports headless/stealth modes, profiles, proxies, viewports, extensions, and SSH tunneling.
+- `manage_profiles` - Setup (with guided live browser session), list, and delete browser profiles for persisting cookies and logins.
+- `manage_browser_pools` - Create, list, get, delete, and flush pools of pre-warmed browsers. Acquire and release browsers from pools.
+- `manage_proxies` - Create, list, and delete proxy configurations (datacenter, ISP, residential, mobile, custom).
+- `manage_extensions` - List and delete uploaded browser extensions.
+- `manage_apps` - List apps, invoke actions, get/list deployments, and get invocation results.
 
-- `setup_profile` - Create or update browser profiles with guided setup process
-- `list_profiles` - List all available browser profiles
-- `delete_profile` - Delete browser profile permanently
+### Standalone tools
 
-### App Management
-
-- `list_apps` - List apps in your Kernel organization with optional filtering
-- `invoke_action` - Execute actions in Kernel apps
-- `get_deployment` - Get deployment status and logs
-- `list_deployments` - List all deployments with optional filtering
-- `get_invocation` - Get action invocation details
-
-### Documentation & Search
-
-- `search_docs` - Search Kernel platform documentation and guides
+- `computer_action` - Mouse, keyboard, and screenshot controls for browser sessions (click, type, press_key, scroll, move, get_position, screenshot).
+- `execute_playwright_code` - Execute Playwright/TypeScript code against a browser with automatic video replay and cleanup.
+- `exec_command` - Run shell commands inside a browser VM. Returns decoded stdout/stderr.
+- `search_docs` - Search Kernel platform documentation and guides.
 
 ## Resources
 
-- `profiles://` - Access browser profiles (list all or get specific profile)
 - `browsers://` - Access browser sessions (list all or get specific session)
+- `browser_pools://` - Access browser pools (list all or get specific pool)
+- `profiles://` - Access browser profiles (list all or get specific profile)
 - `apps://` - Access deployed apps (list all or get specific app)
 
 ## Prompts
@@ -339,7 +331,7 @@ Configure these values wherever the tool expects MCP server settings.
 ```
 Human: Run my web-scraper app to get data from reddit.com
 Assistant: I'll execute your web-scraper action with reddit.com as the target.
-[Uses invoke_action tool to run your deployed app in the cloud]
+[Uses manage_apps tool with action: "invoke" to run your deployed app in the cloud]
 ```
 
 ### Execute Playwright code dynamically
@@ -356,11 +348,11 @@ Returns: { success: true, result: "Example Domain", replay_url: "https://..." }
 ```
 Human: Set up a profile for my work accounts
 Assistant: I'll create a profile and guide you through the setup process.
-[Uses setup_profile tool]
+[Uses manage_profiles tool with action: "setup"]
 
 Human: I'm done setting up my accounts
 Assistant: Perfect! I'll close the browser session and save your profile.
-[Uses delete_browser tool to save profile]
+[Uses manage_browsers tool with action: "delete" to save profile]
 ```
 
 ### Debug a browser session


### PR DESCRIPTION
## Summary

The MCP server Tools section in `reference/mcp-server.mdx` listed old per-action tool names that no longer exist on the server. Updates to reflect the actual current tool surface (verified against `kernel-mcp-server/src/app/[transport]/route.ts`).

## What changed

- Replaced the old tool list (`create_browser`, `get_browser`, `list_browsers`, `delete_browser`, `take_screenshot`, `setup_profile`, `list_profiles`, `delete_profile`, `list_apps`, `invoke_action`, `get_deployment`, `list_deployments`, `get_invocation`) with the current consolidated `manage_*` tools and standalone tools.
- Added the missing tools: `manage_browser_pools`, `manage_proxies`, `manage_extensions`, `computer_action`, `exec_command`.
- Added the missing `browser_pools://` resource.
- Updated Examples block to use current tool names.

## Test plan

- [ ] Preview the page in Mintlify
- [ ] Confirm tool names match `src/app/[transport]/route.ts` in kernel-mcp-server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates tool/resource names and examples; main risk is confusing users if any names/actions are still mismatched with the live MCP server.
> 
> **Overview**
> Updates `reference/mcp-server.mdx` to reflect the current Kernel MCP surface by replacing legacy per-action tool names with consolidated `manage_*` tools and a small set of standalone tools.
> 
> Adds missing tool/resource documentation (notably `manage_browser_pools`, `manage_proxies`, `manage_extensions`, `computer_action`, `exec_command`, and `browser_pools://`) and updates examples to use the new `manage_*` + `action` pattern (e.g., `manage_apps` invoke, `manage_profiles` setup, `manage_browsers` delete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1aebcb2d2bd07f84dd8758c137c2e5a3a0aeb74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->