### PR TITLE
docs: document chrome_policy on on-demand browsers

### DIFF
--- a/browsers/chrome-policy.mdx
+++ b/browsers/chrome-policy.mdx
@@ -7,8 +7,8 @@ Kernel browsers accept an optional `chrome_policy` object that lets you apply [C
 
 `chrome_policy` is supported on:
 
-- [`browsers.create()`](https://kernel.sh/docs/api-reference/browsers/create-a-browser#body-chrome-policy) — on-demand browser sessions
-- [`browserPools.create()`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) and [`browserPools.update()`](https://kernel.sh/docs/api-reference/browser-pools/update-a-browser-pool#body-chrome-policy) — reserved browser pools
+- [`browsers.create()`](/api-reference/browsers/create-a-browser#body-chrome-policy) — on-demand browser sessions
+- [`browserPools.create()`](/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) and [`browserPools.update()`](/api-reference/browser-pools/update-a-browser-pool#body-chrome-policy) — reserved browser pools
 
 Keys are Chrome policy names and values are the corresponding settings.
 

--- a/browsers/chrome-policy.mdx
+++ b/browsers/chrome-policy.mdx
@@ -1,0 +1,143 @@
+---
+title: "Chrome policies"
+description: "Customize Chrome behavior on Kernel browsers using Chrome enterprise policies"
+---
+
+Kernel browsers accept an optional `chrome_policy` object that lets you apply [Chrome enterprise policies](https://chromeenterprise.google/policies/) to the browser at launch. Use this to control startup behavior, default homepages, bookmarks, download UI, notifications, and other browser-level settings.
+
+`chrome_policy` is supported on:
+
+- [`browsers.create()`](https://kernel.sh/docs/api-reference/browsers/create-a-browser#body-chrome-policy) — on-demand browser sessions
+- [`browserPools.create()`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) and [`browserPools.update()`](https://kernel.sh/docs/api-reference/browser-pools/update-a-browser-pool#body-chrome-policy) — reserved browser pools
+
+Keys are Chrome policy names and values are the corresponding settings.
+
+## On-demand browsers
+
+Pass `chrome_policy` when creating an on-demand browser. The policy is applied at session creation time.
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const kernelBrowser = await kernel.browsers.create({
+  chrome_policy: {
+    HomepageLocation: "https://kernel.sh",
+    HomepageIsNewTabPage: false,
+    ShowHomeButton: true,
+    DownloadBubbleEnabled: false,
+  },
+});
+```
+
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+kernel_browser = kernel.browsers.create(
+    chrome_policy={
+        "HomepageLocation": "https://kernel.sh",
+        "HomepageIsNewTabPage": False,
+        "ShowHomeButton": True,
+        "DownloadBubbleEnabled": False,
+    },
+)
+```
+</CodeGroup>
+
+The policy is echoed on `GET /browsers/{id}` and `GET /browsers` responses so you can verify what was applied.
+
+## Reserved browser pools
+
+Pass `chrome_policy` when [creating](/browsers/pools/overview#create-a-pool-of-reserved-browsers) or [updating](/browsers/pools/overview#update-a-pool) a pool. Every browser in the pool launches with the policy applied. See [Custom chrome policies on pools](/browsers/pools/policy-json) for the pool-specific update flow (including `discard_all_idle`).
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const pool = await kernel.browserPools.create({
+  name: "my-configured-pool",
+  size: 5,
+  chrome_policy: {
+    HomepageLocation: "https://kernel.sh",
+    HomepageIsNewTabPage: false,
+    ShowHomeButton: true,
+    NewTabPageLocation: "https://kernel.sh/docs",
+    RestoreOnStartup: 4,
+    RestoreOnStartupURLs: ["https://kernel.sh"],
+    BookmarkBarEnabled: true,
+    ManagedBookmarks: [
+      { toplevel_name: "Company Resources" },
+      { name: "Dashboard", url: "https://example.com/dashboard" },
+      { name: "Documentation", url: "https://example.com/docs" },
+      {
+        name: "Tools",
+        children: [
+          { name: "Jira Board", url: "https://example.com/jira" },
+          { name: "Slack", url: "https://example.com/slack" },
+          { name: "GitHub PRs", url: "https://example.com/github" },
+          { name: "Runbooks", url: "https://example.com/runbooks" }
+        ]
+      }
+    ]
+  }
+});
+```
+
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+pool = kernel.browser_pools.create(
+    name="my-configured-pool",
+    size=5,
+    chrome_policy={
+        "HomepageLocation": "https://kernel.sh",
+        "HomepageIsNewTabPage": False,
+        "ShowHomeButton": True,
+        "NewTabPageLocation": "https://kernel.sh/docs",
+        "RestoreOnStartup": 4,
+        "RestoreOnStartupURLs": ["https://kernel.sh"],
+        "BookmarkBarEnabled": True,
+        "ManagedBookmarks": [
+            {"toplevel_name": "Company Resources"},
+            {"name": "Dashboard", "url": "https://example.com/dashboard"},
+            {"name": "Documentation", "url": "https://example.com/docs"},
+            {
+                "name": "Tools",
+                "children": [
+                    {"name": "Jira Board", "url": "https://example.com/jira"},
+                    {"name": "Slack", "url": "https://example.com/slack"},
+                    {"name": "GitHub PRs", "url": "https://example.com/github"},
+                    {"name": "Runbooks", "url": "https://example.com/runbooks"}
+                ]
+            }
+        ]
+    }
+)
+```
+</CodeGroup>
+
+## Example policies
+
+| Policy | Type | Description |
+| --- | --- | --- |
+| `HomepageLocation` | `string` | URL loaded when clicking the home button |
+| `HomepageIsNewTabPage` | `boolean` | When `false`, the home button navigates to `HomepageLocation` instead of the new tab page |
+| `ShowHomeButton` | `boolean` | Shows the home button in the toolbar |
+| `NewTabPageLocation` | `string` | URL shown when opening a new tab |
+| `RestoreOnStartup` | `integer` | Set to `4` to open a specific list of URLs on browser startup |
+| `RestoreOnStartupURLs` | `string[]` | URLs to open when the browser starts. Requires `RestoreOnStartup` set to `4` |
+| `BookmarkBarEnabled` | `boolean` | Shows the bookmark bar |
+| `ManagedBookmarks` | `array` | Pre-configured bookmarks. Supports folders via nested `children` arrays |
+| `DownloadBubbleEnabled` | `boolean` | Controls the download bubble UI. Set to `false` to fall back to the classic download shelf |
+
+## Available policies
+
+Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object. Refer to the official docs for the full list of supported policy names, types, and values.

--- a/browsers/chrome-policy.mdx
+++ b/browsers/chrome-policy.mdx
@@ -61,31 +61,12 @@ import Kernel from '@onkernel/sdk';
 const kernel = new Kernel();
 
 const pool = await kernel.browserPools.create({
-  name: "my-configured-pool",
+  name: "my-pool",
   size: 5,
   chrome_policy: {
-    HomepageLocation: "https://kernel.sh",
-    HomepageIsNewTabPage: false,
-    ShowHomeButton: true,
-    NewTabPageLocation: "https://kernel.sh/docs",
-    RestoreOnStartup: 4,
-    RestoreOnStartupURLs: ["https://kernel.sh"],
-    BookmarkBarEnabled: true,
-    ManagedBookmarks: [
-      { toplevel_name: "Company Resources" },
-      { name: "Dashboard", url: "https://example.com/dashboard" },
-      { name: "Documentation", url: "https://example.com/docs" },
-      {
-        name: "Tools",
-        children: [
-          { name: "Jira Board", url: "https://example.com/jira" },
-          { name: "Slack", url: "https://example.com/slack" },
-          { name: "GitHub PRs", url: "https://example.com/github" },
-          { name: "Runbooks", url: "https://example.com/runbooks" }
-        ]
-      }
-    ]
-  }
+    DownloadBubbleEnabled: false,
+    HomepageLocation: "https://example.com",
+  },
 });
 ```
 
@@ -95,31 +76,12 @@ from kernel import Kernel
 kernel = Kernel()
 
 pool = kernel.browser_pools.create(
-    name="my-configured-pool",
+    name="my-pool",
     size=5,
     chrome_policy={
-        "HomepageLocation": "https://kernel.sh",
-        "HomepageIsNewTabPage": False,
-        "ShowHomeButton": True,
-        "NewTabPageLocation": "https://kernel.sh/docs",
-        "RestoreOnStartup": 4,
-        "RestoreOnStartupURLs": ["https://kernel.sh"],
-        "BookmarkBarEnabled": True,
-        "ManagedBookmarks": [
-            {"toplevel_name": "Company Resources"},
-            {"name": "Dashboard", "url": "https://example.com/dashboard"},
-            {"name": "Documentation", "url": "https://example.com/docs"},
-            {
-                "name": "Tools",
-                "children": [
-                    {"name": "Jira Board", "url": "https://example.com/jira"},
-                    {"name": "Slack", "url": "https://example.com/slack"},
-                    {"name": "GitHub PRs", "url": "https://example.com/github"},
-                    {"name": "Runbooks", "url": "https://example.com/runbooks"}
-                ]
-            }
-        ]
-    }
+        "DownloadBubbleEnabled": False,
+        "HomepageLocation": "https://example.com",
+    },
 )
 ```
 </CodeGroup>

--- a/browsers/create-a-browser.mdx
+++ b/browsers/create-a-browser.mdx
@@ -35,6 +35,31 @@ print(kernel_browser.session_id)
 ```
 </CodeGroup>
 
+### Customizing the browser
+
+`browsers.create()` accepts options to configure the session at launch — for example, [`chrome_policy`](/browsers/chrome-policy) to apply [Chrome enterprise policies](https://chromeenterprise.google/policies/) and `start_url` to open a specific URL when the browser starts.
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const kernelBrowser = await kernel.browsers.create({
+  start_url: "https://example.com",
+  chrome_policy: {
+    HomepageLocation: "https://kernel.sh",
+    DownloadBubbleEnabled: false,
+  },
+});
+```
+
+```python Python
+kernel_browser = kernel.browsers.create(
+    start_url="https://example.com",
+    chrome_policy={
+        "HomepageLocation": "https://kernel.sh",
+        "DownloadBubbleEnabled": False,
+    },
+)
+```
+</CodeGroup>
 
 ## 2. Connect to the browser
 

--- a/browsers/pools/policy-json.mdx
+++ b/browsers/pools/policy-json.mdx
@@ -1,11 +1,11 @@
 ---
 title: "custom chrome policies"
-description: "Customize Chrome behavior in reserved browser pools using Chrome policies"
+description: "Apply Chrome enterprise policies to every browser in a reserved pool"
 ---
 
-Browser pools accept an optional [`chrome_policy`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) object that lets you apply [Chrome enterprise policies](https://chromeenterprise.google/policies/) to every browser in the pool. Use this to control startup behavior, default homepages, bookmarks, and other browser-level settings.
+Browser pools accept an optional [`chrome_policy`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) object that applies [Chrome enterprise policies](https://chromeenterprise.google/policies/) to every browser in the pool. The same field is also available on on-demand browsers — see [Chrome policies](/browsers/chrome-policy) for the general reference, supported keys, and on-demand usage.
 
-## Setting chrome policies
+## Setting chrome policies on a pool
 
 Pass a `chrome_policy` object when [creating](/browsers/pools/overview#create-a-pool-of-reserved-browsers) or [updating](/browsers/pools/overview#update-a-pool) a pool. Keys are Chrome policy names and values are the corresponding settings.
 
@@ -112,21 +112,6 @@ You can update `chrome_policy` on an existing pool. Pass `discard_all_idle: true
 }
 ```
 
-## Example policies
-
-The example above demonstrates setting a default homepage and managed bookmarks. Here's what each policy does:
-
-| Policy | Type | Description |
-| --- | --- | --- |
-| `HomepageLocation` | `string` | URL loaded when clicking the home button |
-| `HomepageIsNewTabPage` | `boolean` | When `false`, the home button navigates to `HomepageLocation` instead of the new tab page |
-| `ShowHomeButton` | `boolean` | Shows the home button in the toolbar |
-| `NewTabPageLocation` | `string` | URL shown when opening a new tab |
-| `RestoreOnStartup` | `integer` | Set to `4` to open a specific list of URLs on browser startup |
-| `RestoreOnStartupURLs` | `string[]` | URLs to open when the browser starts. Requires `RestoreOnStartup` set to `4` |
-| `BookmarkBarEnabled` | `boolean` | Shows the bookmark bar |
-| `ManagedBookmarks` | `array` | Pre-configured bookmarks. Supports folders via nested `children` arrays |
-
 ## Available policies
 
-Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object. Refer to the official docs for the full list of supported policy names, types, and values.
+See [Chrome policies](/browsers/chrome-policy#example-policies) for a reference of commonly used policy keys. Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object.

--- a/browsers/pools/policy-json.mdx
+++ b/browsers/pools/policy-json.mdx
@@ -3,7 +3,7 @@ title: "custom chrome policies"
 description: "Apply Chrome enterprise policies to every browser in a reserved pool"
 ---
 
-Browser pools accept an optional [`chrome_policy`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) object that applies [Chrome enterprise policies](https://chromeenterprise.google/policies/) to every browser in the pool. The same field is also available on on-demand browsers — see [Chrome policies](/browsers/chrome-policy) for the general reference, supported keys, and on-demand usage.
+Browser pools accept an optional [`chrome_policy`](/api-reference/browser-pools/create-a-browser-pool#body-chrome-policy) object that applies [Chrome enterprise policies](https://chromeenterprise.google/policies/) to every browser in the pool. The same field is also available on on-demand browsers — see [Chrome policies](/browsers/chrome-policy) for the general reference, supported keys, and on-demand usage.
 
 ## Setting chrome policies on a pool
 

--- a/docs.json
+++ b/docs.json
@@ -91,6 +91,7 @@
                   "browsers/replays",
                   "browsers/viewport",
                   "browsers/gpu-acceleration",
+                  "browsers/chrome-policy",
                   {
                     "group": "Auth",
                     "pages": [

--- a/style.css
+++ b/style.css
@@ -124,6 +124,14 @@ table code {
   border-radius: 0 !important;
 }
 
+/* inline code inside links — drop padding/background so the link
+   underline matches the visible text width */
+a code,
+a.link code {
+  padding: 0 !important;
+  background: transparent !important;
+}
+
 /* first column bold for reference tables */
 .prose table tbody td:first-child,
 article table tbody td:first-child,


### PR DESCRIPTION
## Summary

- Add a new `/browsers/chrome-policy` page that covers `chrome_policy` for both on-demand `browsers.create()` and reserved pools, with a quick reference of common policy keys.
- Update `/browsers/create-a-browser` to show a `chrome_policy` (and `start_url`) example.
- Slim down `/browsers/pools/policy-json` to focus on the pool-only update flow (`discard_all_idle`) and link out to the general reference for shared content.
- Register `browsers/chrome-policy` in the Intermediate sidebar group in `docs.json`.

## Test plan

- [ ] Preview the new `browsers/chrome-policy` page and confirm code samples render correctly in both Typescript and Python tabs
- [ ] Verify the sidebar shows the new page under "Working with your browser" → "Intermediate"
- [ ] Click through internal links from `create-a-browser`, `pools/policy-json`, and `chrome-policy` to confirm they resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and styling-only changes; no runtime or API behavior is modified. Main risk is broken/incorrect links or misleading policy examples in the docs.
> 
> **Overview**
> Adds a new `browsers/chrome-policy` guide documenting the `chrome_policy` field for both on-demand `browsers.create()` sessions and reserved browser pools, including TS/Python examples and a small table of common policy keys.
> 
> Updates `browsers/create-a-browser` to show `start_url` + `chrome_policy` usage, and trims `browsers/pools/policy-json` to focus on the pool update flow (notably `discard_all_idle`) while linking to the new shared reference. Registers the new page in `docs.json` navigation and tweaks `style.css` so inline `code` inside links doesn’t add padding/background (fixing underline width).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f05af0a77d9d23d4fd20d5f6d53fb41775174cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->