### PR TITLE
Persist sidebar scroll position across navigation

### DIFF
--- a/sidebar-scroll.js
+++ b/sidebar-scroll.js
@@ -1,0 +1,86 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  var KEY = "kernel-docs-sidebar-scroll";
+
+  function findSidebar() {
+    var candidates = document.querySelectorAll(
+      "aside, nav[aria-label='Sidebar'], aside[aria-label='Sidebar'], #sidebar"
+    );
+    for (var i = 0; i < candidates.length; i++) {
+      var el = candidates[i];
+      if (el.scrollHeight > el.clientHeight + 1) return el;
+    }
+    return null;
+  }
+
+  function save() {
+    var sb = findSidebar();
+    if (sb) {
+      try { sessionStorage.setItem(KEY, String(sb.scrollTop)); } catch (e) {}
+    }
+  }
+
+  function restore() {
+    var sb = findSidebar();
+    if (!sb) return false;
+    var raw;
+    try { raw = sessionStorage.getItem(KEY); } catch (e) { return false; }
+    if (raw === null) return false;
+    var top = parseInt(raw, 10);
+    if (isNaN(top)) return false;
+    if (Math.abs(sb.scrollTop - top) > 1) sb.scrollTop = top;
+    return true;
+  }
+
+  var saveTimer;
+  document.addEventListener(
+    "scroll",
+    function (e) {
+      var sb = findSidebar();
+      if (!sb) return;
+      var t = e.target;
+      if (t === sb || (t.contains && t.contains(sb)) || sb.contains(t)) {
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(save, 80);
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      if (e.target && e.target.closest && e.target.closest("a")) save();
+    },
+    true
+  );
+
+  function pollRestore() {
+    var attempts = 0;
+    var iv = setInterval(function () {
+      attempts++;
+      if (restore() || attempts > 30) clearInterval(iv);
+    }, 50);
+  }
+
+  var origPush = history.pushState;
+  history.pushState = function () {
+    var r = origPush.apply(this, arguments);
+    pollRestore();
+    return r;
+  };
+  var origReplace = history.replaceState;
+  history.replaceState = function () {
+    var r = origReplace.apply(this, arguments);
+    pollRestore();
+    return r;
+  };
+  window.addEventListener("popstate", pollRestore);
+
+  if (document.readyState === "complete") {
+    pollRestore();
+  } else {
+    window.addEventListener("load", pollRestore);
+  }
+})();


### PR DESCRIPTION
## Summary
- Adds `sidebar-scroll.js` at the repo root. Mintlify auto-injects any `.js` file in the content directory on every page.
- The script saves the sidebar's `scrollTop` to `sessionStorage` whenever the user scrolls the sidebar or clicks a link inside it, and restores it after navigation (both SPA route changes via patched `history.pushState`/`replaceState` and full page loads).
- Net effect: clicking an item deep in the sidebar no longer scrolls the menu back to the top — the next page renders with the sidebar still scrolled to where you were.

## Why
Mintlify has no built-in setting to preserve sidebar scroll position. After clicking a nav link the sidebar resets to the top, so picking the page directly below the one you just visited requires re-scrolling.

## Notes
- Selector strategy is defensive (tries multiple sidebar candidates and picks the one that's actually scrollable) since Mintlify's DOM is not a stable contract.
- If Mintlify ships a first-party fix, this file can be deleted.

## Test plan
- [ ] `mintlify dev`, open the API reference, scroll the sidebar down, click a deep link, confirm sidebar stays scrolled.
- [ ] Verify on full reload (hard refresh on a deep page) the sidebar restores its position.
- [ ] Confirm no console errors on initial load or navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UX script with no auth, API, or data changes; main risk is brittle DOM selectors if Mintlify changes markup.
> 
> **Overview**
> Adds a root-level **`sidebar-scroll.js`** script (intended for Mintlify to inject on every docs page) so the **docs sidebar keeps its scroll position** when users navigate.
> 
> On scroll (debounced) and on link clicks inside the sidebar, the script stores **`scrollTop`** in **`sessionStorage`**. After route changes it restores that offset by polling until the sidebar element exists, and it hooks **`history.pushState`**, **`history.replaceState`**, **`popstate`**, and **`load`** so both SPA navigations and full reloads get the same behavior.
> 
> Sidebar targeting is defensive: it picks the first matching **`aside` / labeled nav / `#sidebar`** element that is actually scrollable, since Mintlify’s DOM is not guaranteed stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34326a0d466ecf9e16e63670e7ae6fccd6e48076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->