### PR TITLE
docs: clarify stealth ISP proxy nuance

### DIFF
--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -12,7 +12,7 @@ Enabling `stealth` mode adds two managed services on top:
 Both are opt-out so you can [bring your own](#bring-your-own-proxy-or-captcha-solver) where it makes sense.
 
 <Info>
-ISP proxies are hosted in datacenters but announced to residential networks like Spectrum, RCN, and Windstream. Their ASN makes them look like residential IPs to most sites, while keeping datacenter-grade performance.
+The default ISP proxy appears as a residential IP to target sites (matching a real ISP's ASN) while running on datacenter infrastructure for speed and stability.
 </Info>
 
 ### IP Rotation Behavior

--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -6,14 +6,10 @@ All Kernel browsers ship with anti-detection optimizations by default — you do
 
 Enabling `stealth` mode adds two managed services on top:
 
-1. **Default proxy** — traffic routes through a static ISP proxy, providing a stable exit IP for the session.
+1. **Default proxy** — traffic routes through a static [ISP proxy](/proxies/isp), providing a stable exit IP for the session.
 2. **Automatic CAPTCHA solver** — solves [reCAPTCHAs](https://www.google.com/recaptcha/api2/demo), Cloudflare challenges, and similar tests automatically.
 
 Both are opt-out so you can [bring your own](#bring-your-own-proxy-or-captcha-solver) where it makes sense.
-
-<Info>
-The default ISP proxy appears as a residential IP to target sites (matching a real ISP's ASN) while running on datacenter infrastructure for speed and stability.
-</Info>
 
 ### IP Rotation Behavior
 

--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -11,6 +11,10 @@ Enabling `stealth` mode adds two managed services on top:
 
 Both are opt-out so you can [bring your own](#bring-your-own-proxy-or-captcha-solver) where it makes sense.
 
+<Info>
+ISP proxies are hosted in datacenters but announced to residential networks like Spectrum, RCN, and Windstream. Their ASN makes them look like residential IPs to most sites, while keeping datacenter-grade performance.
+</Info>
+
 ### IP Rotation Behavior
 
 The default stealth proxy provides a **static exit IP** — all connections within the session exit through the same IP address. If you override the default with a [residential proxy](/proxies/residential), exit IPs will rotate per connection. See [Residential IP Rotation Behavior](/proxies/residential#ip-rotation-behavior) for details.


### PR DESCRIPTION
## Summary

Follow-up to #381. Adds a short callout on the stealth page explaining what an ISP proxy actually is — datacenter-hosted but ASN-announced on residential networks — so readers don't conflate it with either pure datacenter or residential proxies.

## Test plan

- [ ] Mintlify preview renders the Info callout without layout regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with a single cross-link; no runtime or security impact.
> 
> **Overview**
> The stealth mode docs now link **ISP proxy** in the default-proxy bullet to the dedicated [ISP Proxies](/proxies/isp) page, so readers can jump from stealth setup to how ISP proxies work and how they differ from residential or datacenter options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f030abafab4ff09a6fdcd0235d246a69961592be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->