### PR TITLE
docs: clarify ISP proxies use residential ASNs on datacenter infra

### DIFF
--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -2,7 +2,7 @@
 title: "ISP Proxies"
 ---
 
-ISP (Internet Service Provider) proxies combine the speed of datacenter proxies with better legitimacy, as they use IP addresses assigned by real ISPs.
+ISP (Internet Service Provider) proxies are hosted on datacenter infrastructure but use IP addresses assigned by real residential ISPs (e.g. AT&T, Spectrum, Comcast). Because the ASN belongs to a residential ISP, target sites see them as residential IPs — while the underlying datacenter hosting gives you the speed and stability you'd expect from a datacenter proxy.
 
 ## IP Rotation Behavior
 

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -2,7 +2,7 @@
 title: "ISP Proxies"
 ---
 
-ISP (Internet Service Provider) proxies are hosted on datacenter infrastructure but use IP addresses assigned by real residential ISPs (e.g. AT&T, Spectrum, Comcast). Because the ASN belongs to a residential ISP, target sites see them as residential IPs — while the underlying datacenter hosting gives you the speed and stability you'd expect from a datacenter proxy.
+ISP (Internet Service Provider) proxies are hosted on datacenter infrastructure but use IP addresses assigned by real residential ISPs. Because the ASN belongs to a residential ISP, target sites see them as residential IPs — while the underlying datacenter hosting gives you the speed and stability you'd expect from a datacenter proxy.
 
 ## IP Rotation Behavior
 


### PR DESCRIPTION
## Summary

Follow-up to #382. The `/proxies/isp` lede said "IP addresses assigned by real ISPs" without specifying *residential* ISPs or that the hosting itself is on datacenter infrastructure. Tightens the opening sentence so the page actually explains the trade-off it's selling:

- IPs are assigned by real **residential** ISPs (AT&T, Spectrum, Comcast) — so the ASN looks residential to target sites
- Hosting is on datacenter infra — so performance and stability match datacenter proxies

Matches [Ping Proxies' own framing](https://documentation.pingproxies.com/general/static-residential-isp-proxies) and gives the link from `stealth.mdx` real weight.

## Test plan

- [ ] Mintlify preview renders the page without layout regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy change on a single MDX page; no runtime or API behavior.
> 
> **Overview**
> The **ISP Proxies** page opening is rewritten so it states the product model explicitly: **datacenter-hosted** infrastructure with IPs from **residential** ISPs, residential ASN appearance to targets, and datacenter-grade speed/stability.
> 
> This replaces a vaguer line about “speed of datacenter” and “legitimacy” from real ISPs without naming residential ASNs or where the servers run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5585928dc204f8b4cf4d6c68bb901cb21222666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->