### PR TITLE
Clarify ISP proxies provide a static IP across sessions

### DIFF
--- a/proxies/datacenter.mdx
+++ b/proxies/datacenter.mdx
@@ -6,9 +6,9 @@ Datacenter proxies use IP addresses assigned from datacenter servers to route yo
 
 ## IP Rotation Behavior
 
-Datacenter proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
+Datacenter proxies use **rotating exit IPs** — a new exit IP is assigned per request, so different requests within the same browser session can exit through different IPs.
 
-For cross-session IP stability (e.g. IP allowlists or [managed auth](/auth/overview) health checks), see [IP rotation behavior across proxy types](/proxies/overview).
+If you need a stable IP across requests and sessions (e.g. for IP allowlists or [managed auth](/auth/overview) health checks), use an [ISP proxy](/proxies/isp) instead. See [IP rotation behavior across proxy types](/proxies/overview) for the full comparison.
 
 ## Configuration
 

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -6,9 +6,9 @@ ISP (Internet Service Provider) proxies are hosted on datacenter infrastructure 
 
 ## IP Rotation Behavior
 
-ISP proxies provide a **stable exit IP within a single browser session** — every tab, request, and reconnection inside that session exits through the same IP, and it does not rotate mid-session (unlike residential).
+ISP proxies provide a **static exit IP that persists across sessions** — every tab, request, reconnection, and future browser session attached to this proxy exits through the same IP. The IP only changes in rare ISP-initiated replacement events (a few times per year on a small number of subnets).
 
-For cross-session IP stability (e.g. IP allowlists or [managed auth](/auth/overview) health checks), see [IP rotation behavior across proxy types](/proxies/overview).
+This makes ISP proxies suitable for use cases that require a stable IP, such as IP allowlists or [managed auth](/auth/overview) health checks. For comparison with other proxy types, see [IP rotation behavior across proxy types](/proxies/overview).
 
 ## Configuration
 

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -6,7 +6,7 @@ ISP (Internet Service Provider) proxies are hosted on datacenter infrastructure 
 
 ## IP Rotation Behavior
 
-ISP proxies provide a **static exit IP that persists across sessions** — every tab, request, reconnection, and future browser session attached to this proxy exits through the same IP. The IP only changes in rare ISP-initiated replacement events (a few times per year on a small number of subnets).
+ISP proxies provide a **static exit IP that persists across sessions** — every tab, request, reconnection, and future browser session attached to this proxy exits through the same IP. The IP only changes in rare ISP-initiated replacement events.
 
 This makes ISP proxies suitable for use cases that require a stable IP, such as IP allowlists or [managed auth](/auth/overview) health checks. For comparison with other proxy types, see [IP rotation behavior across proxy types](/proxies/overview).
 

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -16,7 +16,9 @@ Kernel supports four types of proxies:
 Datacenter has the fastest speed, while residential is least detectable. ISP is a balance between the two options, with less-flexible geotargeting. Kernel recommends to use the first option in the list that works for your use case.
 
 <Info>
-Datacenter and ISP proxies provide a **stable exit IP within a single browser session** — the IP does not rotate mid-session. Across separate sessions, however, Kernel does not guarantee the same exit IP. If you need a truly static IP that persists across every session (for example, an IP allowlist or a [managed auth](/auth/overview) connection whose health checks must egress from a single IP), use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
+ISP proxies provide a **static exit IP that persists across sessions** — every browser session attached to the proxy exits through the same IP, and it only changes in rare ISP-initiated replacement events. This makes them suitable for IP allowlists or [managed auth](/auth/overview) health checks that must egress from a single IP.
+
+Datacenter proxies provide a **stable exit IP within a single browser session** — the IP does not rotate mid-session, but Kernel does not guarantee the same exit IP across separate sessions. For cross-session stability without using an ISP proxy, use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
 
 Residential proxies use **rotating exit IPs** that may change per connection — see [Residential Proxies](/proxies/residential#ip-rotation-behavior) for details.
 </Info>

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -18,7 +18,7 @@ Datacenter has the fastest speed, while residential is least detectable. ISP is 
 <Info>
 ISP proxies provide a **static exit IP that persists across sessions** — every browser session attached to the proxy exits through the same IP, and it only changes in rare ISP-initiated replacement events. This makes them suitable for IP allowlists or [managed auth](/auth/overview) health checks that must egress from a single IP.
 
-Datacenter proxies provide a **stable exit IP within a single browser session** — the IP does not rotate mid-session, but Kernel does not guarantee the same exit IP across separate sessions. For cross-session stability without using an ISP proxy, use a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
+Datacenter proxies use **rotating exit IPs** — a new exit IP is assigned per request, so different requests within the same browser session can exit through different IPs. For a stable IP across requests and sessions, use an ISP proxy or a [custom (BYO) proxy](/proxies/custom) pointed at infrastructure you control.
 
 Residential proxies use **rotating exit IPs** that may change per connection — see [Residential Proxies](/proxies/residential#ip-rotation-behavior) for details.
 </Info>


### PR DESCRIPTION
## Summary

- Update `proxies/isp.mdx` IP rotation section: ISP proxies are static across sessions (not just within a session), only changing in rare ISP-initiated replacement events.
- Update the info callout on `proxies/overview.mdx` to split ISP (cross-session stable) from datacenter (session-stable only).

## Test plan

- [ ] Visual check in Mintlify preview that both callouts render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes to proxy rotation behavior; no runtime or API changes.
> 
> **Overview**
> Updates proxy docs so **ISP** and **datacenter** IP behavior match the product: ISP is described as a **static exit IP across sessions** (only rare ISP replacements), and datacenter as **rotating per request**, including within one browser session.
> 
> On `proxies/isp.mdx` and `proxies/datacenter.mdx`, the **IP Rotation Behavior** sections and cross-links are rewritten to point stable-IP use cases (allowlists, managed auth) at ISP instead of implying datacenter session stability.
> 
> The `proxies/overview.mdx` **Info** callout no longer groups datacenter and ISP as session-stable; it now contrasts **cross-session static (ISP)** vs **per-request rotation (datacenter)** and when to use ISP, custom BYO, or residential.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ec31ced7233b7fee503127a842926d45c66077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->