### PR TITLE
Add Stripe Projects docs for llm_context

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -14,7 +14,9 @@
     { "source": "/browsers/create-a-browser", "destination": "/introduction/create" },
     { "source": "/introduction", "destination": "/" },
     { "source": "/quickstart", "destination": "/" },
-    { "source": "/home", "destination": "/" }
+    { "source": "/home", "destination": "/" },
+    { "source": "/llm.md", "destination": "/integrations/stripe-projects" },
+    { "source": "/llm-browser.md", "destination": "/integrations/stripe-projects-browser" }
   ],
   "theme": "palm",
   "appearance": {
@@ -214,6 +216,13 @@
                   "integrations/vercel/overview",
                   "integrations/vercel/ai-sdk",
                   "integrations/vercel/marketplace"
+                ]
+              },
+              {
+                "group": "Stripe Projects",
+                "pages": [
+                  "integrations/stripe-projects",
+                  "integrations/stripe-projects-browser"
                 ]
               },
               "integrations/1password"

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -40,6 +40,7 @@ Kernel provides detailed guides for popular agent frameworks:
 - **[Magnitude](/integrations/magnitude)** - Vision-focused browser automation framework
 - **[Notte](/integrations/notte)** - AI agent framework for browser automation
 - **[Val Town](/integrations/valtown)** - Serverless function runtime
+- **[Stripe Projects](/integrations/stripe-projects)** - Provision Kernel plans and API keys via the Stripe Projects CLI
 - **[Vercel](https://github.com/onkernel/vercel-template)** - Deploy browser automations to Vercel
 - **[Web Bot Authentication](/browsers/bot-detection/web-bot-auth)** - Create signed Chrome extensions for web bot authentication
 - **[1Password](/integrations/1password)** - Use credentials from your 1Password vaults for Managed Auth

--- a/integrations/stripe-projects-browser.mdx
+++ b/integrations/stripe-projects-browser.mdx
@@ -1,0 +1,66 @@
+---
+title: "Stripe Projects — browser API access"
+description: "LLM context for the kernel/browser:api-access Stripe Projects service"
+---
+
+This page describes the **`kernel/browser:api-access`** deployable service provisioned through Stripe Projects.
+
+## What this resource is
+
+A **project-scoped Kernel API key** used to create and manage cloud browsers (CDP, Playwright, Computer Controls, etc.) for that Stripe Project’s Kernel project.
+
+## Provisioning
+
+```bash
+stripe projects add kernel/browser:api-access --config '{"name":"production"}'
+stripe projects env --pull
+```
+
+### Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Label for the API key (e.g. `production`, `staging`) |
+
+## After provisioning
+
+1. Run `stripe projects env --pull` to sync credentials into `.env` / `.projects/vault`.
+2. Use the Kernel API key from the environment (typically `KERNEL_API_KEY`) with the SDK or CLI.
+
+```typescript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel(); // uses KERNEL_API_KEY from env
+
+const browser = await kernel.browsers.create();
+```
+
+```bash
+kernel browsers create
+```
+
+## Pricing
+
+| Situation | Price |
+|-----------|--------|
+| No active Kernel plan on the org | Usage-based: **$0.01/min** (standard), **$0.02/min** (stealth) |
+| Active `plan:developer`, `plan:hobbyist`, or `plan:startup` | **Included** with plan (component pricing `free` under parent plan) |
+
+Provision a plan first when the developer needs predictable monthly credits and concurrency limits.
+
+## Operations
+
+```bash
+# Rotate credentials (invalidates old key)
+stripe projects rotate kernel/browser:api-access
+
+# Remove the resource
+stripe projects remove kernel/browser:api-access
+```
+
+## Further reading
+
+- [Stripe Projects (provider overview)](/integrations/stripe-projects)
+- [Create a browser](https://kernel.sh/docs/introduction/create)
+- [API keys](https://kernel.sh/docs/info/api-keys)
+- [Projects](https://kernel.sh/docs/info/projects)

--- a/integrations/stripe-projects.mdx
+++ b/integrations/stripe-projects.mdx
@@ -1,0 +1,84 @@
+---
+title: "Stripe Projects"
+description: "Provision Kernel cloud browsers and plans through the Stripe Projects CLI"
+---
+
+Kernel is a Stripe Projects provider. Use the Stripe CLI to link your Kernel account, choose a plan, and provision per-project API keys without using the dashboard for setup.
+
+This page is the provider-level LLM context for agents (`stripe projects llm-context`). Service-specific guidance for cloud browser API keys is in [Stripe Projects — browser API access](/integrations/stripe-projects-browser).
+
+## Service catalog
+
+Stripe service slugs are prefixed with `kernel/` (from the app manifest name).
+
+| Service ID | Kind | Scope | Summary |
+|------------|------|-------|---------|
+| `kernel/plan:developer` | plan | account | Free tier — $5/mo credits, 5 concurrent browsers |
+| `kernel/plan:hobbyist` | plan | account | $30/mo, $10/mo credits, 10 concurrent browsers (email KYC) |
+| `kernel/plan:startup` | plan | account | $200/mo, $50/mo credits, 150 concurrent browsers (email KYC) |
+| `kernel/browser:api-access` | deployable | project | API key for launching browsers in a Stripe Project |
+
+- Only **one plan** can be active per Kernel org at a time (`allowed_updates` defines upgrade/downgrade paths).
+- `browser:api-access` is **free** when any active plan is provisioned; otherwise it is usage-based ($0.01/min standard, $0.02/min stealth).
+
+## Common CLI flows
+
+```bash
+# Link Kernel to your Stripe Projects workspace
+stripe projects link kernel
+
+# Browse the catalog (confirm exact slugs before provisioning)
+stripe projects services list
+
+# Provision a paid plan (requires verified email / KYC)
+stripe projects add kernel/plan:hobbyist
+stripe projects add kernel/plan:startup
+
+# Provision a project-scoped API key (configuration: {"name": "production"})
+stripe projects add kernel/browser:api-access --config '{"name":"production"}'
+
+# Sync credentials into .env
+stripe projects env --pull
+
+# Rotate API key credentials
+stripe projects rotate kernel/browser:api-access
+
+# Open the Kernel dashboard
+stripe projects open kernel --purpose dashboard
+```
+
+Run `stripe projects services list` and copy the **exact** service slug from the output before `stripe projects add` — do not guess slugs.
+
+## Account and project mapping
+
+| Stripe | Kernel |
+|--------|--------|
+| Stripe account | Kernel organization (billing + linking) |
+| Stripe Project | Kernel project (API keys, sessions, pools, etc.) |
+| Plan resources | Org-wide subscription tier |
+| `browser:api-access` | Project-scoped API key |
+
+Each Stripe Project maps 1:1 to a Kernel project within the org. Resources provisioned for a new `project_id` create a Kernel project if needed.
+
+## Authentication
+
+New accounts use the **agentic credentials** flow: after `stripe projects link` / account request, Kernel returns bearer access and refresh tokens. Use `stripe projects env --pull` to load credentials locally.
+
+- **Dashboard (humans):** https://dashboard.onkernel.com
+- **Existing Kernel customers** with billing already on file may receive `payment_credentials: "provider"` when linking to avoid double-billing.
+
+## Billing and Shared Payment Tokens (SPT)
+
+Paid plans are charged through Stripe **Shared Payment Tokens** on the Metronome-managed Stripe customer.
+
+<Warning>
+The default SPT monthly spending limit is often **$50**. The Start-Up plan is **$200/mo**. Before upgrading to Start-Up, confirm the developer’s SPT limit covers the plan (`stripe projects billing show`) or ask them to raise the limit. Charges above the limit will fail.
+</Warning>
+
+## Full documentation
+
+- Doc index for agents: https://kernel.sh/docs/llms.txt
+- Create and connect browsers: https://kernel.sh/docs/introduction/create
+- API keys: https://kernel.sh/docs/info/api-keys
+- Pricing: https://kernel.sh/docs/info/pricing
+- Cursor / Claude skills: https://github.com/kernel/skills


### PR DESCRIPTION
## Summary
- Add provider-level guide at `/integrations/stripe-projects` for Stripe manifest `llm_context`
- Add service-level guide at `/integrations/stripe-projects-browser` for `browser:api-access`
- Redirect legacy `/llm.md` and `/llm-browser.md` paths to the new pages
- Link from integrations overview

## URLs (after deploy)
- https://kernel.sh/docs/integrations/stripe-projects.md
- https://kernel.sh/docs/integrations/stripe-projects-browser.md

## Test plan
- [ ] Mintlify preview shows both pages under Integrations → Stripe Projects
- [ ] `curl -sL https://kernel.sh/docs/integrations/stripe-projects.md` returns markdown (post-deploy)
- [ ] Redirects `/llm.md` → stripe-projects page


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or API behavior modifications.
> 
> **Overview**
> Adds **Stripe Projects** documentation so agents and developers can provision Kernel via the Stripe CLI instead of relying on ad-hoc LLM markdown URLs.
> 
> A **provider-level** page (`integrations/stripe-projects`) documents the service catalog (`kernel/plan:*`, `kernel/browser:api-access`), common CLI flows, Stripe↔Kernel account mapping, agentic auth, and an SPT spending-limit warning for the Start-Up plan. A **service-level** page (`integrations/stripe-projects-browser`) covers `kernel/browser:api-access`: provisioning, env sync, SDK/CLI usage, pricing when a plan is active vs usage-based, and rotate/remove operations.
> 
> **Mintlify** gains a **Stripe Projects** nav group with both pages, **redirects** from `/llm.md` and `/llm-browser.md` to the new routes, and a bullet on the **integrations overview**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d669cb0436a49dd3fc28c0581e0e589f594eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->