### PR TITLE
rename guides introduction section to overview

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -67,7 +67,7 @@
         "tab": "Guides",
         "groups": [
           {
-            "group": "Introduction",
+            "group": "Overview",
             "pages": [
               "index",
               "introduction/create",


### PR DESCRIPTION
Renames the "Introduction" group in the Guides tab to "Overview" in docs.json.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic docs navigation label change with no runtime, auth, or API impact.
> 
> **Overview**
> Renames the **Guides** sidebar group label from **Introduction** to **Overview** in `docs.json`. The listed pages (`index`, `introduction/create`, `introduction/control`, `introduction/observe`) are unchanged—only the navigation group title shown in the docs site updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8c4aea1a6218432a71287f93e824d695d350cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->