### PR TITLE
add pool sizing calculator to reserved browsers overview

### DIFF
--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -472,9 +472,9 @@ Use the calculator below to estimate a pool size for your workload. It assumes `
 
 ### How the calculation works
 
-Two constraints have to be satisfied at the same time, so the recommended size is the larger of the two.
+The calculator converts tasks per hour into a peak acquisition rate `λ` per minute (`tasks_per_hour / 60`, multiplied by 2× for bursty traffic) and then applies two constraints. The recommended size is the larger of the two.
 
-**Concurrency floor.** With a peak acquisition rate `λ` (per minute) and an average acquired duration `d` (minutes), the number of browsers held simultaneously trends toward `λ × d`. We multiply by a 1.25× safety factor to keep ~10–20% of the pool available during normal load (see the [pool sizing guidance in the FAQ](/browsers/pools/faq#how-do-i-know-if-my-pool-is-too-small-or-too-large)).
+**Concurrency floor.** With acquisition rate `λ` and an average acquired duration `d` (minutes), the number of browsers held simultaneously trends toward `λ × d`. We multiply by a 1.25× safety factor to keep ~10–20% of the pool available during normal load (see the [pool sizing guidance in the FAQ](/browsers/pools/faq#how-do-i-know-if-my-pool-is-too-small-or-too-large)).
 
 ```
 concurrency_floor = ceil(λ × d × 1.25)

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -493,12 +493,3 @@ N = max(concurrency_floor, refill_floor)
 ```
 
 At the 25% fill ceiling, the two constraints meet at `d ≈ 3.2` minutes. Below that, the refill ceiling sets the floor; above it, concurrency does.
-
-### Worked examples
-
-| Acquisitions/min | Duration (min) | Refill floor | Concurrency floor | Pool size | Binding |
-| --- | --- | --- | --- | --- | --- |
-| 10 | 1 | 40 | 13 | **40** | refill |
-| 10 | 5 | 40 | 63 | **63** | concurrency |
-| 30 | 2 | 120 | 75 | **120** | refill |
-| 30 | 10 | 120 | 375 | **375** | concurrency |

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -492,4 +492,4 @@ refill_floor = ceil(100 × λ / fill_rate)
 N = max(concurrency_floor, refill_floor)
 ```
 
-At the 25% fill ceiling, the two constraints meet at `d ≈ 3.2` minutes. Below that, the refill ceiling sets the floor; above it, concurrency does.
+The two constraints meet when average session duration ≈ `80 / fill_rate` minutes — about 3.2 minutes at the default 25% ceiling. Below that, refill sets the floor; above it, concurrency does.

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -461,3 +461,44 @@ func main() {
 ## API reference
 
 For more details on all available endpoints and parameters, see the [Browser Pools API reference](https://kernel.sh/docs/api-reference/browser-pools/list-browser-pools).
+
+## Pool sizing calculator
+
+import { PoolSizingCalculator } from '/snippets/pool-sizing-calculator.jsx';
+
+Use the calculator below to estimate a pool size for your workload. It assumes `reuse: false` on release, so every acquisition ends in destruction and triggers a refill.
+
+<PoolSizingCalculator />
+
+### How the calculation works
+
+Two constraints have to be satisfied at the same time, so the recommended size is the larger of the two.
+
+**Concurrency floor.** With a peak acquisition rate `λ` (per minute) and an average acquired duration `d` (minutes), the number of browsers held simultaneously trends toward `λ × d`. We multiply by a 1.25× safety factor to keep ~10–20% of the pool available during normal load (see the [pool sizing guidance in the FAQ](/browsers/pools/faq#how-do-i-know-if-my-pool-is-too-small-or-too-large)).
+
+```
+concurrency_floor = ceil(λ × d × 1.25)
+```
+
+**Refill floor.** The [`fill_rate_per_minute`](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-fill-rate-per-minute) is a percentage of pool size and is capped at 25. With `reuse: false`, browsers are destroyed at the acquisition rate, so the refill rate must keep up:
+
+```
+refill_floor = ceil(100 × λ / fill_rate)
+```
+
+**Recommended pool size.**
+
+```
+N = max(concurrency_floor, refill_floor)
+```
+
+At the 25% fill ceiling, the two constraints meet at `d ≈ 3.2` minutes. Below that, the refill ceiling sets the floor; above it, concurrency does.
+
+### Worked examples
+
+| Acquisitions/min | Duration (min) | Refill floor | Concurrency floor | Pool size | Binding |
+| --- | --- | --- | --- | --- | --- |
+| 10 | 1 | 40 | 13 | **40** | refill |
+| 10 | 5 | 40 | 63 | **63** | concurrency |
+| 30 | 2 | 120 | 75 | **120** | refill |
+| 30 | 10 | 120 | 375 | **375** | concurrency |

--- a/snippets/pool-sizing-calculator.jsx
+++ b/snippets/pool-sizing-calculator.jsx
@@ -1,0 +1,105 @@
+const { useState, useEffect, useRef } = React;
+const { Card, Columns } = MintlifyComponents;
+
+export const PoolSizingCalculator = () => {
+    const defaults = { acquisitionRate: 10, sessionDurationMinutes: 5, fillRate: 25 };
+
+    const [acquisitionRate, setAcquisitionRate] = useState(defaults.acquisitionRate);
+    const [sessionDurationMinutes, setSessionDurationMinutes] = useState(defaults.sessionDurationMinutes);
+    const [fillRate, setFillRate] = useState(defaults.fillRate);
+    const [flash, setFlash] = useState(false);
+    const prevResultRef = useRef(null);
+    const hasInteracted = useRef(false);
+
+    useEffect(() => {
+        if (!hasInteracted.current) return;
+        var url = new URL(window.location);
+        url.searchParams.set('acquisitionRate', acquisitionRate);
+        url.searchParams.set('sessionDuration', sessionDurationMinutes);
+        url.searchParams.set('fillRate', fillRate);
+        url.hash = 'pool-sizing-calculator';
+        window.history.replaceState(null, '', url);
+    }, [acquisitionRate, sessionDurationMinutes, fillRate]);
+
+    const safety = 1.25;
+    const lambda = Number.isFinite(acquisitionRate) && acquisitionRate > 0 ? acquisitionRate : 0;
+    const duration = Number.isFinite(sessionDurationMinutes) && sessionDurationMinutes > 0 ? sessionDurationMinutes : 0;
+    const rate = Number.isFinite(fillRate) && fillRate > 0 ? Math.min(fillRate, 25) : 1;
+
+    const refillFloor = Math.ceil((100 * lambda) / rate);
+    const concurrencyFloor = Math.ceil(lambda * duration * safety);
+    const poolSize = Math.max(refillFloor, concurrencyFloor);
+    const bindingConstraint = concurrencyFloor >= refillFloor ? 'concurrency' : 'refill';
+
+    useEffect(() => {
+        var prev = prevResultRef.current;
+        if (prev !== null && prev.poolSize !== poolSize) {
+            setFlash(true);
+            var t = setTimeout(() => setFlash(false), 300);
+            return () => clearTimeout(t);
+        }
+        prevResultRef.current = { poolSize };
+    }, [poolSize]);
+
+    const labelStyle = { fontWeight: 600, fontSize: '0.875rem', minWidth: '12rem', flexShrink: 0, maxWidth: '12rem' };
+    const rowStyle = { display: 'flex', alignItems: 'center', gap: '0.5rem', minHeight: '2.25rem' };
+    const inputStyle = { minWidth: 0, flex: 1, maxWidth: '100%', boxSizing: 'border-box', background: 'transparent' };
+    const numberInputStyle = { borderBottom: '1px solid #81b300', textAlign: 'right' };
+    const flashStyle = { background: flash ? '#81b300' : 'transparent', transition: 'background 0.5s ease', marginLeft: 'auto' };
+
+    const setRate = (v) => {
+        hasInteracted.current = true;
+        const n = parseInt(v);
+        if (Number.isNaN(n)) { setFillRate(0); return; }
+        setFillRate(Math.max(1, Math.min(25, n)));
+    };
+
+    return (
+        <Columns cols={2}>
+            <Card title="Workload" icon="calculator">
+                <div style={rowStyle}>
+                    <label style={labelStyle}>Acquisitions / minute</label>
+                    <input type="number" min="0" style={{...inputStyle, ...numberInputStyle}} value={acquisitionRate}
+                        onChange={(e) => { hasInteracted.current = true; setAcquisitionRate(parseFloat(e.target.value)); }} />
+                </div>
+                <div style={rowStyle}>
+                    <label style={labelStyle}>Avg acquired duration (min)</label>
+                    <input type="number" min="0" step="0.5" style={{...inputStyle, ...numberInputStyle}} value={sessionDurationMinutes}
+                        onChange={(e) => { hasInteracted.current = true; setSessionDurationMinutes(parseFloat(e.target.value)); }} />
+                </div>
+                <div style={rowStyle}>
+                    <label style={labelStyle}>Fill rate (% / min, max 25)</label>
+                    <input type="number" min="1" max="25" style={{...inputStyle, ...numberInputStyle}} value={fillRate}
+                        onChange={(e) => setRate(e.target.value)} />
+                </div>
+                <div style={rowStyle}>
+                    <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
+                        Assumes <code>reuse: false</code> on release (every acquisition triggers a refill). Safety factor 1.25× covers the recommended 10–20% headroom.
+                    </span>
+                </div>
+            </Card>
+            <Card title="Recommended pool size" icon="layer-group">
+                <div style={rowStyle}>
+                    <span style={labelStyle}>Concurrency floor:</span>
+                    <span style={flashStyle}>{concurrencyFloor}</span>
+                </div>
+                <div style={rowStyle}>
+                    <span style={labelStyle}>Refill floor:</span>
+                    <span style={flashStyle}>{refillFloor}</span>
+                </div>
+                <div style={rowStyle}>
+                    <span style={labelStyle}>Pool size:</span>
+                    <span style={{...flashStyle, fontWeight: 600}}>{poolSize}</span>
+                </div>
+                <div style={rowStyle}>
+                    <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
+                        Binding constraint: <strong>{bindingConstraint}</strong>.
+                        {bindingConstraint === 'refill'
+                            ? ' Shorter sessions or higher acquisition rates push refill above concurrency — the 25% fill ceiling sets the floor.'
+                            : ' Longer-held browsers dominate — pool size scales with acquisitions × duration.'}
+                    </span>
+                </div>
+            </Card>
+        </Columns>
+    );
+};

--- a/snippets/pool-sizing-calculator.jsx
+++ b/snippets/pool-sizing-calculator.jsx
@@ -46,8 +46,8 @@ export const PoolSizingCalculator = () => {
         prevResultRef.current = { poolSize };
     }, [poolSize]);
 
-    const labelStyle = { fontWeight: 600, fontSize: '0.875rem', minWidth: '12rem', flexShrink: 0, maxWidth: '12rem' };
-    const rowStyle = { display: 'flex', alignItems: 'center', gap: '0.5rem', minHeight: '2.25rem' };
+    const labelStyle = { fontWeight: 600, fontSize: '0.875rem', minWidth: '10rem', flexShrink: 0, maxWidth: '10rem' };
+    const rowStyle = { display: 'flex', alignItems: 'center', gap: '0.5rem', minHeight: '2.25rem', flexWrap: 'wrap' };
     const inputStyle = { minWidth: 0, flex: 1, maxWidth: '100%', boxSizing: 'border-box', background: 'transparent' };
     const numberInputStyle = { borderBottom: '1px solid #81b300', textAlign: 'right' };
     const flashStyle = { background: flash ? '#81b300' : 'transparent', transition: 'background 0.5s ease', marginLeft: 'auto' };

--- a/snippets/pool-sizing-calculator.jsx
+++ b/snippets/pool-sizing-calculator.jsx
@@ -2,11 +2,13 @@ const { useState, useEffect, useRef } = React;
 const { Card, Columns } = MintlifyComponents;
 
 export const PoolSizingCalculator = () => {
-    const defaults = { acquisitionRate: 10, sessionDurationMinutes: 5, fillRate: 25 };
+    const defaults = { tasksPerHour: 600, sessionDurationMinutes: 5, burstMode: 'steady', fillRate: 25 };
 
-    const [acquisitionRate, setAcquisitionRate] = useState(defaults.acquisitionRate);
+    const [tasksPerHour, setTasksPerHour] = useState(defaults.tasksPerHour);
     const [sessionDurationMinutes, setSessionDurationMinutes] = useState(defaults.sessionDurationMinutes);
+    const [burstMode, setBurstMode] = useState(defaults.burstMode);
     const [fillRate, setFillRate] = useState(defaults.fillRate);
+    const [showAdvanced, setShowAdvanced] = useState(false);
     const [flash, setFlash] = useState(false);
     const prevResultRef = useRef(null);
     const hasInteracted = useRef(false);
@@ -14,18 +16,21 @@ export const PoolSizingCalculator = () => {
     useEffect(() => {
         if (!hasInteracted.current) return;
         var url = new URL(window.location);
-        url.searchParams.set('acquisitionRate', acquisitionRate);
+        url.searchParams.set('tasksPerHour', tasksPerHour);
         url.searchParams.set('sessionDuration', sessionDurationMinutes);
+        url.searchParams.set('burstMode', burstMode);
         url.searchParams.set('fillRate', fillRate);
         url.hash = 'pool-sizing-calculator';
         window.history.replaceState(null, '', url);
-    }, [acquisitionRate, sessionDurationMinutes, fillRate]);
+    }, [tasksPerHour, sessionDurationMinutes, burstMode, fillRate]);
 
     const safety = 1.25;
-    const lambda = Number.isFinite(acquisitionRate) && acquisitionRate > 0 ? acquisitionRate : 0;
+    const burstMultiplier = burstMode === 'bursty' ? 2 : 1;
+    const tasks = Number.isFinite(tasksPerHour) && tasksPerHour > 0 ? tasksPerHour : 0;
     const duration = Number.isFinite(sessionDurationMinutes) && sessionDurationMinutes > 0 ? sessionDurationMinutes : 0;
     const rate = Number.isFinite(fillRate) && fillRate > 0 ? Math.min(fillRate, 25) : 1;
 
+    const lambda = (tasks / 60) * burstMultiplier;
     const refillFloor = Math.ceil((100 * lambda) / rate);
     const concurrencyFloor = Math.ceil(lambda * duration * safety);
     const poolSize = Math.max(refillFloor, concurrencyFloor);
@@ -46,6 +51,17 @@ export const PoolSizingCalculator = () => {
     const inputStyle = { minWidth: 0, flex: 1, maxWidth: '100%', boxSizing: 'border-box', background: 'transparent' };
     const numberInputStyle = { borderBottom: '1px solid #81b300', textAlign: 'right' };
     const flashStyle = { background: flash ? '#81b300' : 'transparent', transition: 'background 0.5s ease', marginLeft: 'auto' };
+    const btnStyle = (active) => ({
+        padding: '0.25rem 0.5rem',
+        borderRadius: '0.375rem',
+        border: `1px solid ${active ? '#81b300' : 'var(--btn-border)'}`,
+        fontSize: '0.875rem',
+        background: active ? 'var(--btn-selected-bg)' : undefined,
+    });
+    const disclosureStyle = {
+        background: 'none', border: 'none', padding: 0, fontSize: '0.8rem',
+        color: '#81b300', cursor: 'pointer', textAlign: 'left',
+    };
 
     const setRate = (v) => {
         hasInteracted.current = true;
@@ -58,23 +74,37 @@ export const PoolSizingCalculator = () => {
         <Columns cols={2}>
             <Card title="Workload" icon="calculator">
                 <div style={rowStyle}>
-                    <label style={labelStyle}>Acquisitions / minute</label>
-                    <input type="number" min="0" style={{...inputStyle, ...numberInputStyle}} value={acquisitionRate}
-                        onChange={(e) => { hasInteracted.current = true; setAcquisitionRate(parseFloat(e.target.value)); }} />
+                    <label style={labelStyle}>Tasks per hour</label>
+                    <input type="number" min="0" style={{...inputStyle, ...numberInputStyle}} value={tasksPerHour}
+                        onChange={(e) => { hasInteracted.current = true; setTasksPerHour(parseFloat(e.target.value)); }} />
                 </div>
                 <div style={rowStyle}>
-                    <label style={labelStyle}>Avg acquired duration (min)</label>
+                    <label style={labelStyle}>Avg session duration (min)</label>
                     <input type="number" min="0" step="0.5" style={{...inputStyle, ...numberInputStyle}} value={sessionDurationMinutes}
                         onChange={(e) => { hasInteracted.current = true; setSessionDurationMinutes(parseFloat(e.target.value)); }} />
                 </div>
                 <div style={rowStyle}>
-                    <label style={labelStyle}>Fill rate (% / min, max 25)</label>
-                    <input type="number" min="1" max="25" style={{...inputStyle, ...numberInputStyle}} value={fillRate}
-                        onChange={(e) => setRate(e.target.value)} />
+                    <label style={labelStyle}>Traffic pattern</label>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(burstMode === 'steady')}
+                        onClick={() => { hasInteracted.current = true; setBurstMode('steady'); }}>Steady</button>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(burstMode === 'bursty')}
+                        onClick={() => { hasInteracted.current = true; setBurstMode('bursty'); }}>Bursty (2×)</button>
                 </div>
                 <div style={rowStyle}>
+                    <button style={disclosureStyle} onClick={() => setShowAdvanced(!showAdvanced)}>
+                        {showAdvanced ? '▾' : '▸'} Advanced
+                    </button>
+                </div>
+                {showAdvanced && (
+                    <div style={rowStyle}>
+                        <label style={labelStyle}>Fill rate (% / min, max 25)</label>
+                        <input type="number" min="1" max="25" style={{...inputStyle, ...numberInputStyle}} value={fillRate}
+                            onChange={(e) => setRate(e.target.value)} />
+                    </div>
+                )}
+                <div style={rowStyle}>
                     <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
-                        Assumes <code>reuse: false</code> on release (every acquisition triggers a refill). Safety factor 1.25× covers the recommended 10–20% headroom.
+                        Assumes <code>reuse: false</code> on release. Bursty mode applies a 2× multiplier to handle peaks above the hourly average.
                     </span>
                 </div>
             </Card>
@@ -95,8 +125,8 @@ export const PoolSizingCalculator = () => {
                     <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
                         Binding constraint: <strong>{bindingConstraint}</strong>.
                         {bindingConstraint === 'refill'
-                            ? ' Shorter sessions or higher acquisition rates push refill above concurrency — the 25% fill ceiling sets the floor.'
-                            : ' Longer-held browsers dominate — pool size scales with acquisitions × duration.'}
+                            ? ' Shorter sessions or higher throughput push refill above concurrency — the 25% fill ceiling sets the floor.'
+                            : ' Longer-held browsers dominate — pool size scales with throughput × duration.'}
                     </span>
                 </div>
             </Card>

--- a/snippets/pool-sizing-calculator.jsx
+++ b/snippets/pool-sizing-calculator.jsx
@@ -88,7 +88,7 @@ export const PoolSizingCalculator = () => {
                     <button class="btn btn-primary dark:text-white" style={btnStyle(burstMode === 'steady')}
                         onClick={() => { hasInteracted.current = true; setBurstMode('steady'); }}>Steady</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(burstMode === 'bursty')}
-                        onClick={() => { hasInteracted.current = true; setBurstMode('bursty'); }}>Bursty (2×)</button>
+                        onClick={() => { hasInteracted.current = true; setBurstMode('bursty'); }}>Bursty</button>
                 </div>
                 <div style={rowStyle}>
                     <button style={disclosureStyle} onClick={() => setShowAdvanced(!showAdvanced)}>


### PR DESCRIPTION
## Summary
- New interactive calculator at the bottom of `browsers/pools/overview.mdx` that recommends a reserved pool size from acquisition rate, average acquired duration, and fill rate.
- Calculator assumes `reuse: false` on release (every acquisition triggers a refill). It computes both the concurrency floor (Little's Law with a 1.25× safety factor to match the FAQ's 10–20% headroom guidance) and the refill floor (driven by the 25%-per-minute fill ceiling), and returns the larger of the two with a "binding constraint" indicator.
- Docs section explains the equation, the ~3.2-minute crossover between the two constraints, and a small worked-examples table.

## Formula
```
concurrency_floor = ceil(λ × d × 1.25)
refill_floor      = ceil(100 × λ / fill_rate)
N                 = max(concurrency_floor, refill_floor)
```

## Test plan
- [ ] Mintlify preview renders the calculator inside the overview page
- [ ] Inputs update the recommended size live and flash on change
- [ ] Fill rate clamps to 1–25
- [ ] Worked-examples table values match the calculator output
- [ ] URL query params (`acquisitionRate`, `sessionDuration`, `fillRate`) update on interaction, matching the existing pricing calculator pattern