### PR TITLE
Document laptop MDM coverage

### DIFF
--- a/security.mdx
+++ b/security.mdx
@@ -163,6 +163,8 @@ All Kernel employees complete mandatory device security training that covers pro
 
 Kernel deploys endpoint detection and response (EDR) tooling across all company-managed endpoints to support continuous monitoring, threat detection, and response.
 
+Kernel uses mobile device management (MDM) to manage all employee laptops and enforce required security configurations.
+
 ### 4.6 Vendor Management
 
 Kernel requires a vendor security assessment before third-party products or services are used. The review may include gathering applicable compliance audits (SOC 1, SOC 2, PCI DSS, HITRUST, ISO 27001) or other security compliance evidence. Agreements are updated when business, legal, or regulatory requirements change.


### PR DESCRIPTION
## Summary
- Add Kernel's MDM stance to the security practices page.
- Clarify that MDM manages employee laptops and enforces required security configurations.

## Test plan
- ReadLints check passed for `docs/security.mdx`.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to security.mdx with no product, auth, or data-handling impact.
> 
> **Overview**
> Documents **mobile device management (MDM)** in the public security practices page under **Device and Workstation Security** (§4.5), immediately after the existing EDR statement.
> 
> The new copy states that Kernel uses MDM to manage all employee laptops and to enforce the required security configurations already listed for workstations (encryption, firewalls, screen lock, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e3b612bf53caa35dfeb3585b12c35c73c50a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->