### PR TITLE
Update Docs to include missing CLI subcommands in the reference

### DIFF
--- a/reference/cli/apps.mdx
+++ b/reference/cli/apps.mdx
@@ -15,6 +15,20 @@ Deploy an app to Kernel from the current directory. The entrypoint file and depe
 
 <Info>`package.json` (JS/TS) or `pyproject.toml` (Python) must be present next to the entrypoint.</Info>
 
+## `kernel deploy github`
+Deploy directly from a GitHub repository without cloning or pushing locally.
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | GitHub repository URL (e.g. `https://github.com/org/repo`). |
+| `--ref <ref>` | Git ref to deploy (branch, tag, or commit SHA). |
+| `--entrypoint <path>` | Entrypoint within the repo (e.g. `src/index.ts`). |
+| `--path <subdir>` | Subdirectory within the repo (e.g. `apps/api`). |
+| `--github-token <token>` | GitHub token for private repositories (PAT or installation access token). |
+| `--region <region>` | Deployment region (currently only `aws.us-east-1a`). |
+
+<Info>For private repositories, provide `--github-token` or set the `GITHUB_TOKEN` environment variable.</Info>
+
 ## `kernel deploy logs <deployment_id>`
 Stream build and runtime logs for a deployment.
 
@@ -34,6 +48,20 @@ Show deployment history for all apps or a specific app.
 | `--limit <n>` | Maximum number of deployments to return (default: 100, `0` = all). |
 | `--output json`, `-o json` | Output raw JSON array. |
 
+## `kernel deploy get <deployment_id>`
+Get details for a deployment.
+
+| Flag | Description |
+|------|-------------|
+| `--output json`, `-o json` | Output raw JSON object. |
+
+## `kernel deploy delete <deployment_id>`
+Delete a deployment.
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `-y` | Skip confirmation prompt. |
+
 ## `kernel invoke <app> <action>`
 Invoke an app action. By default the CLI returns immediately after the invocation is queued.
 
@@ -41,10 +69,53 @@ Invoke an app action. By default the CLI returns immediately after the invocatio
 |------|-------------|
 | `--version <version>`, `-v` | Target a specific app version (default: latest). |
 | `--payload <json>`, `-p` | Provide a JSON payload (stringified, max 64 KB). |
+| `--payload-file <path>`, `-f` | Read the JSON payload from a file (use `-` for stdin). |
 | `--sync`, `-s` | Wait for completion (timeout after 60 s). |
+| `--async-timeout <seconds>` | Timeout for async invocations (min 10, max 3600). Only applies in async mode. |
+| `--since <time>` | Show invocation events since the given time when following async execution. |
 | `--output json`, `-o json` | Output JSONL (one JSON object per line for each invocation event). |
 
 <Info>Press `Ctrl+C` to cancel an in-flight invocation. The associated browser sessions are cleaned up automatically.</Info>
+
+## `kernel invoke get <invocation_id>`
+Get an invocation.
+
+| Flag | Description |
+|------|-------------|
+| `--output json`, `-o json` | Output raw JSON object. |
+
+## `kernel invoke history`
+Show invocation history.
+
+| Flag | Description |
+|------|-------------|
+| `--app <name>`, `-a` | Filter by app name. |
+| `--action <name>` | Filter by action name. |
+| `--status <status>` | Filter by status: `queued`, `running`, `succeeded`, `failed`. |
+| `--deployment-id <id>` | Filter by deployment ID. |
+| `--version <version>` | Filter by invocation version. |
+| `--since <time>` | Show invocations started since the given time. |
+| `--limit <n>` | Max invocations to return (default: 100). |
+| `--offset <n>` | Number of results to skip. |
+| `--output json`, `-o json` | Output raw JSON array. |
+
+## `kernel invoke update <invocation_id>`
+Update an invocation's status or output.
+
+| Flag | Description |
+|------|-------------|
+| `--status <status>` | New status: `succeeded` or `failed`. |
+| `--output <json>` | Updated invocation output, as a JSON string. |
+
+## `kernel invoke browsers <invocation_id>`
+List browser sessions for an invocation.
+
+| Flag | Description |
+|------|-------------|
+| `--output json`, `-o json` | Output raw JSON array. |
+
+## `kernel invoke delete-browsers <invocation_id>`
+Delete browser sessions for an invocation.
 
 ## `kernel app list`
 List deployed app versions.
@@ -63,12 +134,21 @@ Show deployment history for a specific app.
 | `--limit <n>` | Maximum number of deployments to return (default: 100, `0` = all). |
 | `--output json`, `-o json` | Output raw JSON array. |
 
+## `kernel app delete <app_name>`
+Delete an app and all its deployments.
+
+| Flag | Description |
+|------|-------------|
+| `--version <version>` | Only delete deployments for this version (default: all versions). |
+| `--yes`, `-y` | Skip confirmation prompt. |
+
 ## `kernel logs <app_name>`
 Tail app logs.
 
 | Flag | Description |
 |------|-------------|
 | `--version <version>` | Select an app version (default: latest). |
+| `--invocation <id>`, `-i` | Show logs for a specific invocation/run. Accepts a full ID or unambiguous prefix; respects `--follow` if still running. |
 | `--follow`, `-f` | Stream logs continuously. |
 | `--since <duration>`, `-s` | Fetch logs from a duration or timestamp (same formats as `kernel deploy logs`). |
 | `--with-timestamps` | Include timestamps in each line. |

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -45,6 +45,39 @@ Get detailed information about a browser session.
 |------|-------------|
 | `--output json`, `-o json` | Output raw JSON object. |
 
+### `kernel browsers update <session-id>`
+Update a running browser session — change or remove its proxy, load a profile, resize the viewport, or toggle telemetry.
+
+| Flag | Description |
+|------|-------------|
+| `--proxy-id <id>` | Set the proxy for the session. |
+| `--clear-proxy` | Remove the proxy from the session. |
+| `--profile-id <id>` | Load a profile by ID (only into a session without one). |
+| `--profile-name <name>` | Load a profile by name (mutually exclusive with `--profile-id`). |
+| `--save-changes` | Save changes back to the profile when the session ends. |
+| `--viewport <WxH@fps>` | Set viewport size (e.g. `1920x1080@25`). |
+| `--force` | Force a viewport resize even during an active live view or recording. |
+| `--telemetry <spec>` | Toggle telemetry: `all` to enable, `off` to disable, or per-category like `network=on,page=off`. |
+| `--output json`, `-o json` | Output raw API response as JSON. |
+
+### `kernel browsers curl <session-id> <url>`
+Make an HTTP request through the browser's network stack, inheriting its TLS fingerprint, cookies, proxy, and headers. Works like `curl`, but requests go through the browser session. See [Browser curl](/browsers/curl) for examples.
+
+| Flag | Description |
+|------|-------------|
+| `--request <method>`, `-X` | HTTP method (default: `GET`). |
+| `--header <"Key: Value">`, `-H` | Add a request header (repeatable). |
+| `--data <body>`, `-d` | Request body. |
+| `--data-file <path>` | Read the request body from a file. |
+| `--head`, `-I` | Fetch headers only. |
+| `--include`, `-i` | Include response headers in the output. |
+| `--dump-header <path>`, `-D` | Write received headers to a file (`-` for stdout). |
+| `--output <path>`, `-o` | Write the response body to a file. |
+| `--fail`, `-f` | Fail with no body output on HTTP errors. |
+| `--silent`, `-s` | Suppress progress output. |
+| `--max-time <seconds>` | Maximum time allowed for the request (default: 30). |
+| `--write-out <format>`, `-w` | Print text after completion (supports `%{http_code}`, `%{time_total}`, `%{size_download}`). |
+
 ### `kernel browsers ssh <session-id>`
 Open an interactive SSH session to a browser VM. Requires [websocat](https://github.com/vi/websocat) to be installed locally.
 
@@ -68,6 +101,18 @@ Stream browser logs from the supervisor or a file path.
 | `--supervisor-process <name>` | Supervisor process when `--source=supervisor` (e.g. `chromium`). |
 
 <Info>Log lines longer than 64 KiB are truncated.</Info>
+
+## Telemetry
+
+### `kernel browsers telemetry stream <session-id>`
+Stream live telemetry events (network, console, interaction, page, and system) from a browser session.
+
+| Flag | Description |
+|------|-------------|
+| `--categories <list>` | Filter by category: `api`, `console`, `interaction`, `network`, `page`, `system`. |
+| `--types <list>` | Filter by event type (e.g. `network_response,console_error`). |
+| `--seq <n>` | Resume after sequence number N; replays events with `seq > N` (default: `-1`, stream from now). |
+| `--output json`, `-o json` | Output newline-delimited JSON envelopes. |
 
 ## Replays
 

--- a/reference/cli/mcp.mdx
+++ b/reference/cli/mcp.mdx
@@ -69,3 +69,7 @@ If installation fails:
 - Check that the target tool's configuration directory exists
 - For Zed, the command handles JSON5 format (comments) automatically
 - For Goose, the command displays YAML configuration instructions (manual copy-paste required)
+
+## `kernel mcp server`
+
+Display information about the Kernel MCP server, including its endpoint and connection details for manual configuration.

--- a/reference/cli/mcp.mdx
+++ b/reference/cli/mcp.mdx
@@ -72,4 +72,4 @@ If installation fails:
 
 ## `kernel mcp server`
 
-Display information about the Kernel MCP server, including its endpoint and connection details for manual configuration.
+Display information about the Kernel MCP server.


### PR DESCRIPTION
## Summary

Follow-up to #397. Documents the subcommands and flags that exist in **CLI v0.19.3** but were still missing from the CLI reference — purely additive, no restructuring.

### What changed
- **`apps.mdx`:**
  - `deploy github`, `deploy get`, `deploy delete`
  - `app delete`
  - `invoke` subcommands: `get`, `history`, `update`, `browsers`, `delete-browsers`
  - new `invoke` flags: `--payload-file`/`-f`, `--async-timeout`, `--since`
  - `logs --invocation`/`-i`
- **`browsers.mdx`:** `browsers curl`, `browsers update`, `browsers telemetry stream`
- **`mcp.mdx`:** `mcp server`

### Validation
- All flag tables pulled from the v0.19.3 binary's `--help`.
- Internal links resolve; CI (Mintlify build + broken-links) should confirm.

With this, the CLI reference covers the full released command surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CLI reference pages; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds missing **CLI v0.19.3** commands and flags to the Mintlify reference so it matches the shipped binary—purely additive, no page restructuring.
> 
> **`reference/cli/apps.mdx`** now documents deploy-from-GitHub (`kernel deploy github`), deployment get/delete, app delete, invoke lifecycle commands (`get`, `history`, `update`, `browsers`, `delete-browsers`), extra `invoke` flags (`--payload-file`, `--async-timeout`, `--since`), and **`kernel logs --invocation`**.
> 
> **`reference/cli/browsers.mdx`** adds session **`update`** and **`curl`** (with curl-style flags), plus a **Telemetry** section for **`telemetry stream`**.
> 
> **`reference/cli/mcp.mdx`** adds **`kernel mcp server`** for MCP server info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd1c55f90beed77c88eaa764e50a2dcec157dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->