### PR TITLE
Add June 4 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,7 +12,6 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="June 5" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Browser sessions now play audio by default, and the browser replay recording API gained a `record_audio` option to capture that audio in replay videos.
 - Extended browser telemetry to the [CLI](https://github.com/kernel/cli): use `--telemetry=all|off|<list>` on `browsers create` and `browsers update` to configure telemetry per session, and `kernel browsers telemetry stream <id>` to tail live events with category and type filters and SSE resume support.
 - Added API key management commands to the [CLI](https://github.com/kernel/cli) for creating, listing, retrieving, updating, and deleting org API keys directly from the terminal.
 - Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,25 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="June 4" tags={["Product", "Docs"]}>
+## Product updates
+
+- Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.
+- Browser sessions now play audio by default, and the browser replay recording API gained a `record_audio` option to capture that audio in replay videos.
+- Browser sessions can now be given a custom name at create time, making them easier to identify in the dashboard and audit logs.
+- Extended browser telemetry to the [CLI](https://github.com/kernel/cli): use `--telemetry=all|off|<list>` on `browsers create` and `browsers update` to configure telemetry per session, and `kernel browsers telemetry stream <id>` to tail live events with category and type filters and SSE resume support.
+- Added API key management commands to the [CLI](https://github.com/kernel/cli) for creating, listing, retrieving, updating, and deleting org API keys directly from the terminal.
+- Improved `kernel status` to distinguish between the API being down versus unreachable.
+
+## Documentation updates
+
+- Added Go SDK code examples across the docs.
+- Added a [managed auth CLI reference](/reference/cli/auth) page.
+- Reorganized the [MCP server](/reference/mcp-server) documentation into per-page navigation for easier browsing.
+- Expanded and regrouped the [CLI reference](/reference/cli) to match the MCP docs structure.
+- Clarified that ISP proxies provide a static IP across sessions.
+</Update>
+
 <Update label="May 28" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,6 +12,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="June 5" tags={["Product", "Docs"]}>
 ## Product updates
 
+- Browser sessions now play audio by default, and the browser replay recording API gained a `record_audio` option to capture that audio in replay videos.
 - Extended browser telemetry to the [CLI](https://github.com/kernel/cli): use `--telemetry=all|off|<list>` on `browsers create` and `browsers update` to configure telemetry per session, and `kernel browsers telemetry stream <id>` to tail live events with category and type filters and SSE resume support.
 - Added API key management commands to the [CLI](https://github.com/kernel/cli) for creating, listing, retrieving, updating, and deleting org API keys directly from the terminal.
 - Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,22 +9,22 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
-<Update label="June 4" tags={["Product", "Docs"]}>
+<Update label="June 5" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.
 - Browser sessions now play audio by default, and the browser replay recording API gained a `record_audio` option to capture that audio in replay videos.
-- Browser sessions can now be given a custom name at create time, making them easier to identify in the dashboard and audit logs.
 - Extended browser telemetry to the [CLI](https://github.com/kernel/cli): use `--telemetry=all|off|<list>` on `browsers create` and `browsers update` to configure telemetry per session, and `kernel browsers telemetry stream <id>` to tail live events with category and type filters and SSE resume support.
 - Added API key management commands to the [CLI](https://github.com/kernel/cli) for creating, listing, retrieving, updating, and deleting org API keys directly from the terminal.
+- Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.
+- Browser sessions can now be given a custom name at create time, making them easier to identify in the dashboard and audit logs.
 - Improved `kernel status` to distinguish between the API being down versus unreachable.
 
 ## Documentation updates
 
-- Added Go SDK code examples across the docs.
-- Added a [managed auth CLI reference](/reference/cli/auth) page.
 - Reorganized the [MCP server](/reference/mcp-server) documentation into per-page navigation for easier browsing.
 - Expanded and regrouped the [CLI reference](/reference/cli) to match the MCP docs structure.
+- Added Go SDK code examples across the docs.
+- Added a [managed auth CLI reference](/reference/cli/auth) page.
 - Clarified that ISP proxies provide a static IP across sessions.
 </Update>
 


### PR DESCRIPTION
## Summary

Adds the June 4 changelog entry covering MCP server expansion (10 → 16 tools), audio defaults + `record_audio`, custom browser session names, CLI browser telemetry, CLI API key management, and `kernel status` improvement. Documentation section covers Go SDK examples, managed auth CLI reference, MCP per-page nav, CLI reference regrouping, and ISP proxy clarification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial changelog-only change with no runtime or API behavior in this repo.
> 
> **Overview**
> Adds a **June 5** changelog entry at the top of `changelog.mdx`, ahead of the May 28 update.
> 
> **Product** bullets cover default session audio and `record_audio` on replays, CLI browser telemetry flags and live stream, CLI org API key CRUD, MCP growth (10→16 tools) with managed auth and `browser_curl`, custom names on browser create, and clearer `kernel status` when the API is down vs unreachable.
> 
> **Docs** bullets note MCP and CLI reference reorganization, Go SDK examples, a new managed auth CLI page, and ISP proxy static-IP clarification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7009d245434bcfe6dea5a591b05312bff0ec25e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->