### PR TITLE
Add browser telemetry guide

### DIFF
--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -16,7 +16,11 @@ These categories report what's happening in the page. Capturing any of them atta
 | `console` | Console output from the page | `console_log`, `console_error` |
 | `network` | Network requests, responses, and failures | `network_request`, `network_response`, `network_loading_failed`, `network_idle` |
 | `page` | Navigation and page lifecycle, including performance signals | `page_navigation`, `page_dom_content_loaded`, `page_load`, `page_tab_opened`, `page_layout_shift`, `page_lcp`, `page_layout_settled`, `page_navigation_settled` |
-| `interaction` | Input driven into the page | `interaction_click`, `interaction_key`, `interaction_scroll_settled` |
+| `interaction` | Browser-native input in the page (clicks, keys, scroll) | `interaction_click`, `interaction_key`, `interaction_scroll_settled` |
+
+<Note>
+`interaction` events are browser-native DOM events observed in the page, not calls to the [computer-control](/browsers/computer-controls) API (those are reported by the `control` category). Input into sensitive fields such as passwords is suppressed: `interaction_key` isn't emitted for them, and `interaction_click` omits the element text.
+</Note>
 
 ## Operational
 
@@ -31,12 +35,12 @@ These categories report on the session itself rather than page content. They're 
 | `screenshot` | Periodic screenshots of the session | `monitor_screenshot` |
 
 <Warning>
-`screenshot` is the most expensive category to capture — each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
+`screenshot` is the most expensive category to capture - each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
 </Warning>
 
 ## The default set
 
-When you enable telemetry without naming any categories (`telemetry: { enabled: true }`, or `--telemetry=all`), the session captures the default set — a lightweight bundle of operational signals:
+When you enable telemetry without naming any categories (`telemetry: { enabled: true }`, or `--telemetry=all`), the session captures the default set - a lightweight bundle of operational signals:
 
 `control`, `connection`, `system`, `captcha`
 
@@ -46,4 +50,4 @@ These are inexpensive to leave on and give you a baseline view of session health
 
 `monitor` reports the health of the CDP collector itself: `monitor_disconnected`, `monitor_reconnected`, `monitor_reconnect_failed`, and `monitor_init_failed`.
 
-It isn't directly settable. It flows automatically whenever any browser-activity category (`console`, `network`, `page`, `interaction`) is captured — since those are what attach the collector — and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.
+It isn't directly settable. It flows automatically whenever any browser-activity category (`console`, `network`, `page`, `interaction`) is captured - since those are what attach the collector - and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -29,7 +29,7 @@ These categories report what's happening in the page. Capturing any of them atta
 
 ## Operational
 
-These categories report on the session itself rather than page content, and they're cheap to capture. Together they make up the **default set** - what a session captures when you enable telemetry without naming any categories (`telemetry: { enabled: true }` or `--telemetry=all`), giving you a baseline view of session health and control activity.
+These categories report on the session itself rather than page content, and they're cheap to capture. Together they make up the default set - what a session captures when you enable telemetry without naming any categories (`telemetry: { enabled: true }` or `--telemetry=all`), giving you a baseline view of session health and control activity.
 
 | Category | Captures | Event types |
 | --- | --- | --- |
@@ -44,7 +44,7 @@ Telemetry is off by default, and the [default set](#operational) carries operati
 
 | Category | Can contain sensitive data |
 | --- | --- |
-| `network` | Request and response **headers (including `Authorization` and `Cookie`), request bodies, and truncated response bodies**, plus full URLs. A common place for session tokens, credentials, and personal data. |
+| `network` | Request and response headers (including `Authorization` and `Cookie`), request bodies, and truncated response bodies, plus full URLs. A common place for session tokens, credentials, and personal data. |
 | `console` | Anything the page logs. Applications often log access tokens, request or response bodies, and personal data through `console.log`. |
 | `page` | Page URLs and titles, which can embed tokens or identifiers in query strings or fragments. |
 | `interaction` | Text of clicked elements and typed keys, which can include personal data entered into forms. |

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -1,0 +1,49 @@
+---
+title: "Telemetry Categories"
+description: "The categories a browser session can capture, what each contains, and their cost"
+---
+
+A category groups related telemetry events and is the unit you enable or disable. Selection is opt-in: a session captures a category only when you turn it on (see [Overview](/browsers/telemetry/overview)). This page lists every category, the event types it carries, and what it costs to capture.
+
+For the full payload schema of any event type, see the [Stream telemetry events](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) endpoint in the API reference.
+
+## Browser activity
+
+These categories report what's happening in the page. Capturing any of them attaches a Chrome DevTools Protocol (CDP) collector to the session, so enable only the ones you need. None are in the default set.
+
+| Category | Captures | Event types |
+| --- | --- | --- |
+| `console` | Console output from the page | `console_log`, `console_error` |
+| `network` | Network requests, responses, and failures | `network_request`, `network_response`, `network_loading_failed`, `network_idle` |
+| `page` | Navigation and page lifecycle, including performance signals | `page_navigation`, `page_dom_content_loaded`, `page_load`, `page_tab_opened`, `page_layout_shift`, `page_lcp`, `page_layout_settled`, `page_navigation_settled` |
+| `interaction` | Input driven into the page | `interaction_click`, `interaction_key`, `interaction_scroll_settled` |
+
+## Operational
+
+These categories report on the session itself rather than page content. They're cheap to capture, and the first four make up the [default set](#the-default-set).
+
+| Category | Captures | Event types |
+| --- | --- | --- |
+| `control` | Computer-control API calls against the session | `api_call` |
+| `connection` | CDP and live view connect/disconnect activity | `cdp_connect`, `cdp_disconnect`, `live_view_connect`, `live_view_disconnect` |
+| `system` | VM-level failures | `system_oom_kill`, `service_crashed` |
+| `captcha` | Results of automated captcha solves | `captcha_solve_result` |
+| `screenshot` | Periodic screenshots of the session | `monitor_screenshot` |
+
+<Warning>
+`screenshot` is the most expensive category to capture — each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
+</Warning>
+
+## The default set
+
+When you enable telemetry without naming any categories (`telemetry: { enabled: true }`, or `--telemetry=all`), the session captures the default set — a lightweight bundle of operational signals:
+
+`control`, `connection`, `system`, `captcha`
+
+These are inexpensive to leave on and give you a baseline view of session health and control activity without the volume of the browser-activity categories.
+
+## The monitor category
+
+`monitor` reports the health of the CDP collector itself: `monitor_disconnected`, `monitor_reconnected`, `monitor_reconnect_failed`, and `monitor_init_failed`.
+
+It isn't directly settable. It flows automatically whenever any browser-activity category (`console`, `network`, `page`, `interaction`) is captured — since those are what attach the collector — and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -9,7 +9,7 @@ For the full payload schema of any event type, see the [Stream telemetry events]
 
 ## Browser activity
 
-These categories report what's happening in the page. Capturing any of them attaches a Chrome DevTools Protocol (CDP) collector to the session, so enable only the ones you need. None are in the default set.
+These categories report what's happening in the page. Capturing any of them attaches a Chrome DevTools Protocol (CDP) collector to the session and produces far more events than the operational categories, so enable only the ones you need. None are in the default set.
 
 | Category | Captures | Event types |
 | --- | --- | --- |
@@ -51,7 +51,7 @@ Telemetry is off by default, and the [default set](#operational) carries operati
 | `screenshot` | A full rendered image of the page - the broadest exposure, capturing anything visible on screen. |
 | `control`, `connection`, `system`, `captcha`, `monitor` | Session metadata only (control calls, connection and health events). No page content. |
 
-Captured events are stored and retrievable through the API, so this sensitivity applies to the data at rest, not just the live stream. Treat captured telemetry - and anywhere you forward or store it - with the same care as the underlying content.
+Captured events are persisted and can be replayed by [resuming the stream](/browsers/telemetry/streaming#resuming-after-a-disconnect), so this sensitivity applies to the data at rest, not just the live stream. Treat captured telemetry - and anywhere you forward or store it - with the same care as the underlying content. For how Kernel encrypts, retains, and processes data overall, see [Security](/security) and the [Data Processing Addendum](/dpa).
 
 Some exposure is reduced for you automatically: input into sensitive fields such as passwords is suppressed (`interaction_key` isn't emitted for them, and `interaction_click` omits the element text). Beyond that, because selection is opt-in, the most effective control is to capture only the categories you need - enable `network`, `console`, `page`, `interaction`, or `screenshot` deliberately, and prefer the operational categories when you only need session health.
 

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -17,14 +17,19 @@ These categories report what's happening in the page. Capturing any of them atta
 | `network` | Network requests, responses, and failures | `network_request`, `network_response`, `network_loading_failed`, `network_idle` |
 | `page` | Navigation and page lifecycle, including performance signals | `page_navigation`, `page_dom_content_loaded`, `page_load`, `page_tab_opened`, `page_layout_shift`, `page_lcp`, `page_layout_settled`, `page_navigation_settled` |
 | `interaction` | Browser-native input in the page (clicks, keys, scroll) | `interaction_click`, `interaction_key`, `interaction_scroll_settled` |
+| `screenshot` | Periodic screenshots of the session | `monitor_screenshot` |
 
 <Note>
-`interaction` events are browser-native DOM events observed in the page, not calls to the [computer-control](/browsers/computer-controls) API (those are reported by the `control` category). Input into sensitive fields such as passwords is suppressed: `interaction_key` isn't emitted for them, and `interaction_click` omits the element text.
+`interaction` events are browser-native DOM events observed in the page, not calls to the [computer-control](/browsers/computer-controls) API (those are reported by the `control` category).
 </Note>
+
+<Warning>
+`screenshot` is the most expensive category to capture - each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
+</Warning>
 
 ## Operational
 
-These categories report on the session itself rather than page content. They're cheap to capture, and the first four make up the [default set](#the-default-set).
+These categories report on the session itself rather than page content, and they're cheap to capture. Together they make up the **default set** - what a session captures when you enable telemetry without naming any categories (`telemetry: { enabled: true }` or `--telemetry=all`), giving you a baseline view of session health and control activity.
 
 | Category | Captures | Event types |
 | --- | --- | --- |
@@ -32,15 +37,10 @@ These categories report on the session itself rather than page content. They're 
 | `connection` | CDP and live view connect/disconnect activity | `cdp_connect`, `cdp_disconnect`, `live_view_connect`, `live_view_disconnect` |
 | `system` | VM-level failures | `system_oom_kill`, `service_crashed` |
 | `captcha` | Results of automated captcha solves | `captcha_solve_result` |
-| `screenshot` | Periodic screenshots of the session | `monitor_screenshot` |
-
-<Warning>
-`screenshot` is the most expensive category to capture - each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
-</Warning>
 
 ## Data sensitivity
 
-Telemetry is off by default, and the [default set](#the-default-set) carries operational metadata only - no page content. The browser-activity categories are different: they capture what actually flows through the session, which is your own browser's data and can include credentials and personal information.
+Telemetry is off by default, and the [default set](#operational) carries operational metadata only - no page content. The browser-activity categories are different: they capture what actually flows through the session, which is your own browser's data and can include credentials and personal information.
 
 | Category | Can contain sensitive data |
 | --- | --- |
@@ -59,16 +59,8 @@ Some exposure is reduced for you automatically: input into sensitive fields such
 If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
 </Warning>
 
-## The default set
-
-When you enable telemetry without naming any categories (`telemetry: { enabled: true }`, or `--telemetry=all`), the session captures the default set - a lightweight bundle of operational signals:
-
-`control`, `connection`, `system`, `captcha`
-
-These are inexpensive to leave on and give you a baseline view of session health and control activity without the volume of the browser-activity categories.
-
 ## The monitor category
 
 `monitor` reports the health of the CDP collector itself: `monitor_disconnected`, `monitor_reconnected`, `monitor_reconnect_failed`, and `monitor_init_failed`.
 
-It isn't directly settable. It flows automatically whenever any browser-activity category (`console`, `network`, `page`, `interaction`) is captured - since those are what attach the collector - and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.
+It isn't directly settable. It flows automatically whenever any [browser-activity category](#browser-activity) is captured - since those are what attach the collector - and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -38,6 +38,21 @@ These categories report on the session itself rather than page content. They're 
 `screenshot` is the most expensive category to capture - each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
 </Warning>
 
+## Data sensitivity
+
+Telemetry reflects real activity inside the session, so some categories can carry secrets or personal data. You receive your own session's data, but you should treat the stream - and anywhere you forward or store it - with the same care as the underlying content.
+
+| Category | Can contain sensitive data |
+| --- | --- |
+| `console` | Anything the page logs. Applications often log access tokens, request or response bodies, and personal data through `console.log`. |
+| `network` | Request and response **URLs, headers (including `Authorization` and cookies), and bodies** - a common place for credentials, session tokens, and personal data. |
+| `page` | Page URLs and titles, which can embed tokens or identifiers in query strings or fragments. |
+| `interaction` | Text of clicked elements and typed keys, which can include personal data entered into forms. |
+| `screenshot` | A full rendered image of the page - the broadest exposure, capturing anything visible on screen. |
+| `control`, `connection`, `system`, `captcha`, `monitor` | Session metadata only (control calls, connection and health events). No page content. |
+
+Some exposure is reduced for you automatically: input into sensitive fields such as passwords is suppressed (`interaction_key` isn't emitted for them, and `interaction_click` omits the element text). Beyond that, because selection is opt-in, the most effective control is to capture only the categories you need - enable `console`, `network`, `page`, `interaction`, or `screenshot` deliberately, and prefer the operational categories when you only need session health.
+
 ## The default set
 
 When you enable telemetry without naming any categories (`telemetry: { enabled: true }`, or `--telemetry=all`), the session captures the default set - a lightweight bundle of operational signals:

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -3,13 +3,24 @@ title: "Telemetry Categories"
 description: "The categories a browser session can capture, what each contains, and their cost"
 ---
 
-A category groups related telemetry events and is the unit you enable or disable. Selection is opt-in: a session captures a category only when you turn it on (see [Overview](/browsers/telemetry/overview)). This page lists every category, the event types it carries, and what it costs to capture.
+A category groups related telemetry events and is the unit you enable or disable. Selection is opt-in: a session captures a category only when you turn it on.
 
 For the full payload schema of any event type, see the [Stream telemetry events](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) endpoint in the API reference.
 
+## Operational
+
+These categories report on the session itself rather than page content.
+
+| Category | Captures | Event types |
+| --- | --- | --- |
+| `control` | Computer-control API calls against the session | `api_call` |
+| `connection` | CDP and live view connect/disconnect activity | `cdp_connect`, `cdp_disconnect`, `live_view_connect`, `live_view_disconnect` |
+| `system` | VM-level failures | `system_oom_kill`, `service_crashed` |
+| `captcha` | Results of automated captcha solves | `captcha_solve_result` |
+
 ## Browser activity
 
-These categories report what's happening in the page. Capturing any of them attaches a Chrome DevTools Protocol (CDP) collector to the session and produces far more events than the operational categories, so enable only the ones you need. None are in the default set.
+These categories report what's happening in the page. Capturing any of them attaches a Chrome DevTools Protocol (CDP) collector to the session and produces highly granular page-level events. Capturing them adds overhead, so enable only the ones you need.
 
 | Category | Captures | Event types |
 | --- | --- | --- |
@@ -23,24 +34,15 @@ These categories report what's happening in the page. Capturing any of them atta
 `interaction` events are browser-native DOM events observed in the page, not calls to the [computer-control](/browsers/computer-controls) API (those are reported by the `control` category).
 </Note>
 
-<Warning>
-`screenshot` is the most expensive category to capture - each event carries an encoded image. Enable it only when you need visual snapshots, and prefer [live view](/browsers/live-view) or [replays](/browsers/replays) for continuous visibility.
-</Warning>
+### The monitor category
 
-## Operational
+`monitor` reports the health of the CDP collector itself: `monitor_disconnected`, `monitor_reconnected`, `monitor_reconnect_failed`, and `monitor_init_failed`.
 
-These categories report on the session itself rather than page content, and they're cheap to capture. Together they make up the default set - what a session captures when you enable telemetry without naming any categories (`telemetry: { enabled: true }` or `--telemetry=all`), giving you a baseline view of session health and control activity.
-
-| Category | Captures | Event types |
-| --- | --- | --- |
-| `control` | Computer-control API calls against the session | `api_call` |
-| `connection` | CDP and live view connect/disconnect activity | `cdp_connect`, `cdp_disconnect`, `live_view_connect`, `live_view_disconnect` |
-| `system` | VM-level failures | `system_oom_kill`, `service_crashed` |
-| `captcha` | Results of automated captcha solves | `captcha_solve_result` |
+It isn't directly settable. It flows automatically whenever any of the browser-activity categories are captured. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.
 
 ## Data sensitivity
 
-Telemetry is off by default, and the [default set](#operational) carries operational metadata only - no page content. The browser-activity categories are different: they capture what actually flows through the session, which is your own browser's data and can include credentials and personal information.
+Telemetry is off by default and the default set carries operational metadata only. The browser-activity categories are different: they capture what actually flows through the session, which is your own browser's data and can include credentials and personal information.
 
 | Category | Can contain sensitive data |
 | --- | --- |
@@ -58,9 +60,3 @@ Some exposure is reduced for you automatically: input into sensitive fields such
 <Warning>
 If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
 </Warning>
-
-## The monitor category
-
-`monitor` reports the health of the CDP collector itself: `monitor_disconnected`, `monitor_reconnected`, `monitor_reconnect_failed`, and `monitor_init_failed`.
-
-It isn't directly settable. It flows automatically whenever any [browser-activity category](#browser-activity) is captured - since those are what attach the collector - and is silent otherwise. You can still [filter the stream](/browsers/telemetry/streaming) by `monitor` to isolate these events.

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -40,18 +40,24 @@ These categories report on the session itself rather than page content. They're 
 
 ## Data sensitivity
 
-Telemetry reflects real activity inside the session, so some categories can carry secrets or personal data. You receive your own session's data, but you should treat the stream - and anywhere you forward or store it - with the same care as the underlying content.
+Telemetry is off by default, and the [default set](#the-default-set) carries operational metadata only - no page content. The browser-activity categories are different: they capture what actually flows through the session, which is your own browser's data and can include credentials and personal information.
 
 | Category | Can contain sensitive data |
 | --- | --- |
+| `network` | Request and response **headers (including `Authorization` and `Cookie`), request bodies, and truncated response bodies**, plus full URLs. A common place for session tokens, credentials, and personal data. |
 | `console` | Anything the page logs. Applications often log access tokens, request or response bodies, and personal data through `console.log`. |
-| `network` | Request and response **URLs, headers (including `Authorization` and cookies), and bodies** - a common place for credentials, session tokens, and personal data. |
 | `page` | Page URLs and titles, which can embed tokens or identifiers in query strings or fragments. |
 | `interaction` | Text of clicked elements and typed keys, which can include personal data entered into forms. |
 | `screenshot` | A full rendered image of the page - the broadest exposure, capturing anything visible on screen. |
 | `control`, `connection`, `system`, `captcha`, `monitor` | Session metadata only (control calls, connection and health events). No page content. |
 
-Some exposure is reduced for you automatically: input into sensitive fields such as passwords is suppressed (`interaction_key` isn't emitted for them, and `interaction_click` omits the element text). Beyond that, because selection is opt-in, the most effective control is to capture only the categories you need - enable `console`, `network`, `page`, `interaction`, or `screenshot` deliberately, and prefer the operational categories when you only need session health.
+Captured events are stored and retrievable through the API, so this sensitivity applies to the data at rest, not just the live stream. Treat captured telemetry - and anywhere you forward or store it - with the same care as the underlying content.
+
+Some exposure is reduced for you automatically: input into sensitive fields such as passwords is suppressed (`interaction_key` isn't emitted for them, and `interaction_click` omits the element text). Beyond that, because selection is opt-in, the most effective control is to capture only the categories you need - enable `network`, `console`, `page`, `interaction`, or `screenshot` deliberately, and prefer the operational categories when you only need session health.
+
+<Warning>
+If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
+</Warning>
 
 ## The default set
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -13,7 +13,7 @@ Selection is **opt-in**. A session captures a category only if you explicitly tu
 
 ## Enabling telemetry
 
-You configure telemetry when you [create a browser](/introduction/create) (and can change it later on update). There are exactly three shapes.
+You configure telemetry when you [create a browser](/introduction/create) (and can change it later on update). There are three ways to configure it.
 
 ### Enable the default set
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -1,0 +1,112 @@
+---
+title: "Telemetry Overview"
+description: "Capture a real-time, categorized stream of what happens inside a browser session"
+---
+
+Telemetry gives you a real-time stream of events from inside a browser session — console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Events are delivered over [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), so you can react to them live or pipe them into your own observability stack.
+
+## The model
+
+Every telemetry event belongs to a **category** (`console`, `network`, `page`, and so on). Categories are the unit of control: you choose which categories a session captures, and the stream only carries events from those categories.
+
+Selection is **opt-in**. A session captures a category only if you explicitly turn it on; anything you don't list stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
+
+## Enabling telemetry
+
+You configure telemetry when you [create a browser](/introduction/create) (and can change it later on update). There are exactly three shapes.
+
+### Enable the default set
+
+Set `enabled: true` with no per-category settings to capture the default set — a lightweight bundle of operational signals (`control`, `connection`, `system`, `captcha`) that's cheap to leave on:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const browser = await kernel.browsers.create({
+  telemetry: { enabled: true },
+});
+```
+
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+browser = kernel.browsers.create(
+    telemetry={"enabled": True},
+)
+```
+
+```bash CLI
+kernel browsers create --telemetry=all
+```
+</CodeGroup>
+
+### Capture specific categories
+
+List exactly the categories you want under `telemetry.browser`. Only those are captured; everything else stays off. Don't set the top-level `enabled` flag in this case — the presence of category settings is what turns telemetry on:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const browser = await kernel.browsers.create({
+  telemetry: {
+    browser: {
+      console: { enabled: true },
+      network: { enabled: true },
+    },
+  },
+});
+```
+
+```python Python
+browser = kernel.browsers.create(
+    telemetry={
+        "browser": {
+            "console": {"enabled": True},
+            "network": {"enabled": True},
+        },
+    },
+)
+```
+
+```bash CLI
+kernel browsers create --telemetry=console,network
+```
+</CodeGroup>
+
+This session captures `console` and `network` only — no page, interaction, or operational events.
+
+### Disable telemetry
+
+Set `enabled: false` to capture nothing. This can't be combined with category settings:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const browser = await kernel.browsers.create({
+  telemetry: { enabled: false },
+});
+```
+
+```python Python
+browser = kernel.browsers.create(
+    telemetry={"enabled": False},
+)
+```
+
+```bash CLI
+kernel browsers create --telemetry=off
+```
+</CodeGroup>
+
+<Info>
+Updating a session's telemetry **replaces** its category selection — it isn't merged with the previous one. Send the complete set of categories you want captured.
+</Info>
+
+## What's next
+
+- [Categories](/browsers/telemetry/categories) — every category, what it captures, the default set, and cost characteristics.
+- [Stream telemetry](/browsers/telemetry/streaming) — consume the live stream from the SDK, CLI, or raw SSE, with filtering and reconnection.
+- For event payload schemas, see the [Stream telemetry events](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) endpoint in the API reference.

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -5,7 +5,7 @@ description: "Capture a real-time, categorized stream of what happens inside a b
 
 Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Once enabled, you can [stream them](/browsers/telemetry/streaming) live or pull them later for analysis.
 
-Events are grouped into categories (`console`, `network`, `page`, and so on), and categories are the unit of control. Selection is opt-in: a session captures only the categories you turn on, and anything you don't stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
+Events are grouped into categories (`console`, `network`, `page`, and so on), and categories are the unit of control. Selection is opt-in: a session captures only the categories you turn on, and anything you don't stays off. See [Categories](/browsers/telemetry/categories) for the full list and what each one captures.
 
 ## Enabling telemetry
 
@@ -98,7 +98,7 @@ kernel browsers create --telemetry=off
 </CodeGroup>
 
 <Info>
-Updating a session's telemetry replaces its category selection - it isn't merged with the previous one. Send the complete set of categories you want captured.
+On update, a category list patches the current selection - categories you don't include keep their current state. To reset the selection instead, send `enabled: true` (it replaces the selection with the categories you provide, or the default set if you provide none); send `enabled: false` to turn telemetry off.
 </Info>
 
 ## What's next

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -3,7 +3,7 @@ title: "Telemetry Overview"
 description: "Capture a real-time, categorized stream of what happens inside a browser session"
 ---
 
-Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. You choose which categories of events a session records; once enabled, you can [stream them](/browsers/telemetry/streaming) live or pull them later for analysis.
+Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Once enabled, you can [stream them](/browsers/telemetry/streaming) live or pull them later for analysis.
 
 Events are grouped into categories (`console`, `network`, `page`, and so on), and categories are the unit of control. Selection is opt-in: a session captures only the categories you turn on, and anything you don't stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -3,7 +3,7 @@ title: "Telemetry Overview"
 description: "Capture a real-time, categorized stream of what happens inside a browser session"
 ---
 
-Telemetry gives you a real-time stream of events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Events are delivered over [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), so you can react to them live or pipe them into your own observability stack.
+Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. You choose which categories of events a session records; once enabled, you can [stream them](/browsers/telemetry/streaming) live or feed them into your own observability stack.
 
 ## The model
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -3,13 +3,9 @@ title: "Telemetry Overview"
 description: "Capture a real-time, categorized stream of what happens inside a browser session"
 ---
 
-Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. You choose which categories of events a session records; once enabled, you can [stream them](/browsers/telemetry/streaming) live or feed them into your own observability stack.
+Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. You choose which categories of events a session records; once enabled, you can [stream them](/browsers/telemetry/streaming) live or pull them later for analysis.
 
-## The model
-
-Every telemetry event belongs to a category (`console`, `network`, `page`, and so on). Categories are the unit of control: you choose which categories a session captures, and the stream only carries events from those categories.
-
-Selection is opt-in. A session captures a category only if you explicitly turn it on; anything you don't list stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
+Events are grouped into categories (`console`, `network`, `page`, and so on), and categories are the unit of control. Selection is opt-in: a session captures only the categories you turn on, and anything you don't stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
 
 ## Enabling telemetry
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -7,9 +7,9 @@ Telemetry gives you a real-time stream of events from inside a browser session -
 
 ## The model
 
-Every telemetry event belongs to a **category** (`console`, `network`, `page`, and so on). Categories are the unit of control: you choose which categories a session captures, and the stream only carries events from those categories.
+Every telemetry event belongs to a category (`console`, `network`, `page`, and so on). Categories are the unit of control: you choose which categories a session captures, and the stream only carries events from those categories.
 
-Selection is **opt-in**. A session captures a category only if you explicitly turn it on; anything you don't list stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
+Selection is opt-in. A session captures a category only if you explicitly turn it on; anything you don't list stays off. See [Categories](/browsers/telemetry/categories) for the full list, what each one captures, and its cost.
 
 ## Enabling telemetry
 
@@ -102,7 +102,7 @@ kernel browsers create --telemetry=off
 </CodeGroup>
 
 <Info>
-Updating a session's telemetry **replaces** its category selection - it isn't merged with the previous one. Send the complete set of categories you want captured.
+Updating a session's telemetry replaces its category selection - it isn't merged with the previous one. Send the complete set of categories you want captured.
 </Info>
 
 ## What's next

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telemetry Overview"
-description: "Capture a real-time, categorized stream of what happens inside a browser session"
+description: "Capture what happens inside a browser session"
 ---
 
 Telemetry captures events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Once enabled, you can [stream them](/browsers/telemetry/streaming) live or pull them later for analysis.
@@ -43,7 +43,7 @@ kernel browsers create --telemetry=all
 
 ### Capture specific categories
 
-List exactly the categories you want under `telemetry.browser`. Only those are captured; everything else stays off. Don't set the top-level `enabled` flag in this case - the presence of category settings is what turns telemetry on:
+List the categories you want under `telemetry.browser`. For example, this session captures `console` and `network` only:
 
 <CodeGroup>
 ```typescript Typescript/Javascript
@@ -73,27 +73,30 @@ kernel browsers create --telemetry=console,network
 ```
 </CodeGroup>
 
-This session captures `console` and `network` only - no page, interaction, or operational events.
-
 ### Disable telemetry
 
-Set `enabled: false` to capture nothing. This can't be combined with category settings:
+<Info>
+Telemetry is disabled by default. Use this only when updating a session to turn previously enabled telemetry back off.
+</Info>
+
+Set `enabled: false` on an existing session to turn telemetry off:
 
 <CodeGroup>
 ```typescript Typescript/Javascript
-const browser = await kernel.browsers.create({
+await kernel.browsers.update(browser.session_id, {
   telemetry: { enabled: false },
 });
 ```
 
 ```python Python
-browser = kernel.browsers.create(
+kernel.browsers.update(
+    browser.session_id,
     telemetry={"enabled": False},
 )
 ```
 
 ```bash CLI
-kernel browsers create --telemetry=off
+kernel browsers update <session-id> --telemetry=off
 ```
 </CodeGroup>
 

--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -3,7 +3,7 @@ title: "Telemetry Overview"
 description: "Capture a real-time, categorized stream of what happens inside a browser session"
 ---
 
-Telemetry gives you a real-time stream of events from inside a browser session — console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Events are delivered over [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), so you can react to them live or pipe them into your own observability stack.
+Telemetry gives you a real-time stream of events from inside a browser session - console output, network activity, page lifecycle, user interactions, captcha solves, and operational signals like crashes or connection changes. Events are delivered over [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), so you can react to them live or pipe them into your own observability stack.
 
 ## The model
 
@@ -17,7 +17,7 @@ You configure telemetry when you [create a browser](/introduction/create) (and c
 
 ### Enable the default set
 
-Set `enabled: true` with no per-category settings to capture the default set — a lightweight bundle of operational signals (`control`, `connection`, `system`, `captcha`) that's cheap to leave on:
+Set `enabled: true` with no per-category settings to capture the default set - a lightweight bundle of operational signals (`control`, `connection`, `system`, `captcha`) that's cheap to leave on:
 
 <CodeGroup>
 ```typescript Typescript/Javascript
@@ -47,7 +47,7 @@ kernel browsers create --telemetry=all
 
 ### Capture specific categories
 
-List exactly the categories you want under `telemetry.browser`. Only those are captured; everything else stays off. Don't set the top-level `enabled` flag in this case — the presence of category settings is what turns telemetry on:
+List exactly the categories you want under `telemetry.browser`. Only those are captured; everything else stays off. Don't set the top-level `enabled` flag in this case - the presence of category settings is what turns telemetry on:
 
 <CodeGroup>
 ```typescript Typescript/Javascript
@@ -77,7 +77,7 @@ kernel browsers create --telemetry=console,network
 ```
 </CodeGroup>
 
-This session captures `console` and `network` only — no page, interaction, or operational events.
+This session captures `console` and `network` only - no page, interaction, or operational events.
 
 ### Disable telemetry
 
@@ -102,11 +102,11 @@ kernel browsers create --telemetry=off
 </CodeGroup>
 
 <Info>
-Updating a session's telemetry **replaces** its category selection — it isn't merged with the previous one. Send the complete set of categories you want captured.
+Updating a session's telemetry **replaces** its category selection - it isn't merged with the previous one. Send the complete set of categories you want captured.
 </Info>
 
 ## What's next
 
-- [Categories](/browsers/telemetry/categories) — every category, what it captures, the default set, and cost characteristics.
-- [Stream telemetry](/browsers/telemetry/streaming) — consume the live stream from the SDK, CLI, or raw SSE, with filtering and reconnection.
+- [Categories](/browsers/telemetry/categories) - every category, what it captures, the default set, and cost characteristics.
+- [Stream telemetry](/browsers/telemetry/streaming) - consume the live stream from the SDK, CLI, or raw SSE, with filtering and reconnection.
 - For event payload schemas, see the [Stream telemetry events](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) endpoint in the API reference.

--- a/browsers/telemetry/streaming.mdx
+++ b/browsers/telemetry/streaming.mdx
@@ -1,23 +1,9 @@
 ---
 title: "Stream Telemetry"
-description: "Consume a session's live telemetry stream from the SDK, CLI, or raw SSE"
+description: "Consume a session's live telemetry stream from the SDK or CLI"
 ---
 
-Once a session has telemetry [enabled](/browsers/telemetry/overview), you can stream its events in real time. The stream stays open until the session terminates, and each event is wrapped in an envelope with a monotonic `seq` number you can use to reconnect without gaps:
-
-```json
-{
-  "seq": 42,
-  "event": {
-    "ts": 1746123456789000,
-    "type": "network_response",
-    "category": "network",
-    "data": { "method": "GET", "url": "https://example.com/api", "status": 200 }
-  }
-}
-```
-
-The `data` payload differs per event type; see the [API reference](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) for each type's schema. An event whose payload exceeds 1 MB is dropped and the envelope is flagged `truncated: true`.
+Once a session has telemetry [enabled](/browsers/telemetry/overview), you can stream its events in real time. The stream stays open until the session terminates.
 
 ## Via SDK
 
@@ -48,6 +34,8 @@ with kernel.browsers.telemetry.stream(session_id) as stream:
 ```
 </CodeGroup>
 
+To filter, check `event.category` and `event.type` in your loop. If the stream drops, re-open it with the last `seq` you processed as `last_event_id` to resume without gaps.
+
 ## Via CLI
 
 Stream events to your terminal. The command runs until the session ends or you interrupt it:
@@ -56,7 +44,7 @@ Stream events to your terminal. The command runs until the session ends or you i
 kernel browsers telemetry stream <session-id>
 ```
 
-Filter the stream client-side by category or event type (repeatable or comma-separated), and use `-o json` to emit newline-delimited JSON envelopes for piping:
+### Filtering by category or event type
 
 ```bash
 # Only network and console events
@@ -66,29 +54,16 @@ kernel browsers telemetry stream <session-id> --categories=network,console
 kernel browsers telemetry stream <session-id> --types=network_response,console_error
 
 # Machine-readable output
+# -o json emits newline-delimited JSON envelopes for piping:
 kernel browsers telemetry stream <session-id> -o json
 ```
 
-<Info>
-CLI `--categories` and `--types` are applied locally to the stream - they don't change what the session captures. To change capture, update the session's [telemetry categories](/browsers/telemetry/categories).
-</Info>
+### Resuming after a disconnect
 
-## Via raw SSE
-
-The stream is a standard [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) endpoint, so any SSE-capable client works:
-
-```bash
-curl -N https://api.onkernel.com/browsers/<session-id>/telemetry/stream \
-  -H "Authorization: Bearer $KERNEL_API_KEY" \
-  -H "Accept: text/event-stream"
-```
-
-Each `data:` frame carries one JSON envelope, and the frame's `id:` field is the envelope's `seq`. A keepalive comment is sent every 15 seconds when no events arrive. The `event:` field is never set.
-
-## Resuming after a disconnect
-
-To pick up where you left off, resume from the last `seq` you processed - the server replays events after that sequence number. SDK clients reconnect automatically. For raw SSE, send the last seq as the `Last-Event-ID` header; with the CLI, pass `--seq`:
+The stream is a single connection; it does not reconnect on its own. Each event carries a monotonic `seq`, so to resume without gaps you re-open the stream and pass the last `seq` you processed.
 
 ```bash
 kernel browsers telemetry stream <session-id> --seq 1024
 ```
+
+The server then replays events after that sequence number.

--- a/browsers/telemetry/streaming.mdx
+++ b/browsers/telemetry/streaming.mdx
@@ -1,0 +1,80 @@
+---
+title: "Stream Telemetry"
+description: "Consume a session's live telemetry stream from the SDK, CLI, or raw SSE"
+---
+
+Once a session has telemetry [enabled](/browsers/telemetry/overview), you can stream its events in real time. The stream stays open until the session terminates, and each event is wrapped in an envelope with a monotonic `seq` number you can use to reconnect without gaps.
+
+## Via SDK
+
+Open the stream and iterate over it. Each item is an envelope with a `seq` and the `event` itself, which carries a `type`, a `category`, and a `ts` timestamp:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const stream = await kernel.browsers.telemetry.stream(sessionId);
+
+for await (const { seq, event } of stream) {
+  console.log(`#${seq} [${event.category}] ${event.type}`);
+}
+```
+
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+with kernel.browsers.telemetry.stream(session_id) as stream:
+    for envelope in stream:
+        event = envelope.event
+        print(f"#{envelope.seq} [{event.category}] {event.type}")
+```
+</CodeGroup>
+
+## Via CLI
+
+Stream events to your terminal. The command runs until the session ends or you interrupt it:
+
+```bash
+kernel browsers telemetry stream <session-id>
+```
+
+Filter the stream client-side by category or event type (repeatable or comma-separated), and use `-o json` to emit newline-delimited JSON envelopes for piping:
+
+```bash
+# Only network and console events
+kernel browsers telemetry stream <session-id> --categories=network,console
+
+# Only specific event types
+kernel browsers telemetry stream <session-id> --types=network_response,console_error
+
+# Machine-readable output
+kernel browsers telemetry stream <session-id> -o json
+```
+
+<Info>
+CLI `--categories` and `--types` are applied locally to the stream — they don't change what the session captures. To change capture, update the session's [telemetry categories](/browsers/telemetry/categories).
+</Info>
+
+## Via raw SSE
+
+The stream is a standard [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) endpoint, so any SSE-capable client works:
+
+```bash
+curl -N https://api.onkernel.com/v1/browsers/<session-id>/telemetry/stream \
+  -H "Authorization: Bearer $KERNEL_API_KEY" \
+  -H "Accept: text/event-stream"
+```
+
+Each `data:` frame carries one JSON envelope, and the frame's `id:` field is the envelope's `seq`. A keepalive comment is sent every 15 seconds when no events arrive. The `event:` field is never set.
+
+## Resuming after a disconnect
+
+To pick up where you left off, resume from the last `seq` you processed — the server replays events after that sequence number. SDK clients reconnect automatically. For raw SSE, send the last seq as the `Last-Event-ID` header; with the CLI, pass `--seq`:
+
+```bash
+kernel browsers telemetry stream <session-id> --seq 1024
+```

--- a/browsers/telemetry/streaming.mdx
+++ b/browsers/telemetry/streaming.mdx
@@ -3,7 +3,21 @@ title: "Stream Telemetry"
 description: "Consume a session's live telemetry stream from the SDK, CLI, or raw SSE"
 ---
 
-Once a session has telemetry [enabled](/browsers/telemetry/overview), you can stream its events in real time. The stream stays open until the session terminates, and each event is wrapped in an envelope with a monotonic `seq` number you can use to reconnect without gaps.
+Once a session has telemetry [enabled](/browsers/telemetry/overview), you can stream its events in real time. The stream stays open until the session terminates, and each event is wrapped in an envelope with a monotonic `seq` number you can use to reconnect without gaps:
+
+```json
+{
+  "seq": 42,
+  "event": {
+    "ts": 1746123456789000,
+    "type": "network_response",
+    "category": "network",
+    "data": { "method": "GET", "url": "https://example.com/api", "status": 200 }
+  }
+}
+```
+
+The `data` payload differs per event type; see the [API reference](https://kernel.sh/docs/api-reference/browser-telemetry/stream-telemetry-events-via-sse) for each type's schema. An event whose payload exceeds 1 MB is dropped and the envelope is flagged `truncated: true`.
 
 ## Via SDK
 

--- a/browsers/telemetry/streaming.mdx
+++ b/browsers/telemetry/streaming.mdx
@@ -21,7 +21,7 @@ The `data` payload differs per event type; see the [API reference](https://kerne
 
 ## Via SDK
 
-Open the stream and iterate over it. Each item is an envelope with a `seq` and the `event` itself, which carries a `type`, a `category`, and a `ts` timestamp:
+Open the stream and iterate over the envelopes:
 
 <CodeGroup>
 ```typescript Typescript/Javascript

--- a/browsers/telemetry/streaming.mdx
+++ b/browsers/telemetry/streaming.mdx
@@ -56,7 +56,7 @@ kernel browsers telemetry stream <session-id> -o json
 ```
 
 <Info>
-CLI `--categories` and `--types` are applied locally to the stream — they don't change what the session captures. To change capture, update the session's [telemetry categories](/browsers/telemetry/categories).
+CLI `--categories` and `--types` are applied locally to the stream - they don't change what the session captures. To change capture, update the session's [telemetry categories](/browsers/telemetry/categories).
 </Info>
 
 ## Via raw SSE
@@ -64,7 +64,7 @@ CLI `--categories` and `--types` are applied locally to the stream — they don'
 The stream is a standard [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) endpoint, so any SSE-capable client works:
 
 ```bash
-curl -N https://api.onkernel.com/v1/browsers/<session-id>/telemetry/stream \
+curl -N https://api.onkernel.com/browsers/<session-id>/telemetry/stream \
   -H "Authorization: Bearer $KERNEL_API_KEY" \
   -H "Accept: text/event-stream"
 ```
@@ -73,7 +73,7 @@ Each `data:` frame carries one JSON envelope, and the frame's `id:` field is the
 
 ## Resuming after a disconnect
 
-To pick up where you left off, resume from the last `seq` you processed — the server replays events after that sequence number. SDK clients reconnect automatically. For raw SSE, send the last seq as the `Last-Event-ID` header; with the CLI, pass `--seq`:
+To pick up where you left off, resume from the last `seq` you processed - the server replays events after that sequence number. SDK clients reconnect automatically. For raw SSE, send the last seq as the `Last-Event-ID` header; with the CLI, pass `--seq`:
 
 ```bash
 kernel browsers telemetry stream <session-id> --seq 1024

--- a/docs.json
+++ b/docs.json
@@ -148,6 +148,14 @@
                   },
                   "browsers/extensions",
                   {
+                    "group": "Telemetry",
+                    "pages": [
+                      "browsers/telemetry/overview",
+                      "browsers/telemetry/categories",
+                      "browsers/telemetry/streaming"
+                    ]
+                  },
+                  {
                     "group": "Reserved Browsers",
                     "pages": [
                       "browsers/pools/overview",

--- a/introduction/observe.mdx
+++ b/introduction/observe.mdx
@@ -3,7 +3,7 @@ title: "Observe"
 description: "Watch your agent work, debug what went wrong"
 ---
 
-Browser agents fail in ways that don't show up in logs. Kernel gives you several ways to see what's actually happening — live, after the fact, frame by frame, line by line, and event by event.
+Browser agents fail in ways that don't show up in logs. Kernel gives you several ways to see what's actually happening: live, after the fact, frame by frame, line by line, and event by event.
 
 ## Live view
 
@@ -60,7 +60,7 @@ Add `?readOnly=true` for a non-interactive view, or enable [kiosk mode](/browser
 
 ## Replays
 
-Replays are MP4 recordings you start and stop on demand — capture as many clips per session as you need. They're the right tool for post-hoc debugging: a failed run gives you one or more videos to scrub through, share, or attach to a bug report.
+Replays are MP4 recordings you start and stop on demand - capture as many clips per session as you need. They're the right tool for post-hoc debugging: a failed run gives you one or more videos to scrub through, share, or attach to a bug report.
 
 Replays can also be enabled on managed auth sessions, so you can [debug failed logins](https://www.kernel.sh/docs/auth/configuration#record-sessions-for-debugging) the same way.
 
@@ -119,7 +119,7 @@ Full reference: [Replays](/browsers/replays).
 
 ## Screenshots
 
-Pull a frame at any moment with computer controls — useful for snapshotting state at decision points, attaching to traces, or feeding back into a vision model.
+Pull a frame at any moment with computer controls - useful for snapshotting state at decision points, attaching to traces, or feeding back into a vision model.
 
 <CodeGroup>
 ```typescript Typescript/Javascript
@@ -194,7 +194,7 @@ Full reference: [Logs](/apps/logs).
 
 ## Telemetry
 
-Telemetry is a real-time, structured stream of what happens inside a session — console output, network activity, page lifecycle, interactions, and operational signals like crashes. Unlike a video or screenshot, it's machine-readable, so it's the right tool for feeding session activity into your own observability pipeline or reacting to events programmatically. Enable it at creation, then stream the events:
+Telemetry is a real-time, structured stream of what happens inside a session: console output, network activity, page lifecycle, interactions, and operational signals like crashes. Unlike a video or screenshot, it's machine-readable, so it's the right tool for feeding session activity into your own observability pipeline or reacting to events programmatically. Enable it at creation, then stream the events:
 
 <CodeGroup>
 ```typescript Typescript/Javascript

--- a/introduction/observe.mdx
+++ b/introduction/observe.mdx
@@ -3,7 +3,7 @@ title: "Observe"
 description: "Watch your agent work, debug what went wrong"
 ---
 
-Browser agents fail in ways that don't show up in logs. Kernel gives you four ways to see what's actually happening — live, after the fact, frame by frame, and line by line.
+Browser agents fail in ways that don't show up in logs. Kernel gives you several ways to see what's actually happening — live, after the fact, frame by frame, line by line, and event by event.
 
 ## Live view
 
@@ -192,9 +192,55 @@ if err := stream.Err(); err != nil {
 
 Full reference: [Logs](/apps/logs).
 
+## Telemetry
+
+Telemetry is a real-time, structured stream of what happens inside a session — console output, network activity, page lifecycle, interactions, and operational signals like crashes. Unlike a video or screenshot, it's machine-readable, so it's the right tool for feeding session activity into your own observability pipeline or reacting to events programmatically. Enable it at creation, then stream the events:
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const browser = await kernel.browsers.create({ telemetry: { enabled: true } });
+
+const stream = await kernel.browsers.telemetry.stream(browser.session_id);
+for await (const { seq, event } of stream) {
+  console.log(`#${seq} [${event.category}] ${event.type}`);
+}
+```
+
+```python Python
+browser = kernel.browsers.create(telemetry={"enabled": True})
+
+with kernel.browsers.telemetry.stream(browser.session_id) as stream:
+    for envelope in stream:
+        print(f"#{envelope.seq} [{envelope.event.category}] {envelope.event.type}")
+```
+
+```go Go
+stream := client.Browsers.Telemetry.StreamStreaming(
+	ctx,
+	kernelBrowser.SessionID,
+	kernel.BrowserTelemetryStreamParams{},
+)
+defer stream.Close()
+
+for stream.Next() {
+	fmt.Println(stream.Current())
+}
+if err := stream.Err(); err != nil {
+	panic(err)
+}
+```
+
+```bash CLI
+kernel browsers telemetry stream <session-id>
+```
+</CodeGroup>
+
+Full reference: [Telemetry](/browsers/telemetry/overview).
+
 ## Picking the right tool
 
 - **Building the agent?** Keep a [live view](/browsers/live-view) tab open while you iterate.
 - **Debugging a failure?** Capture a [replay](/browsers/replays) for the run, then watch the video.
 - **Instrumenting the agent itself?** Drop [screenshots](/browsers/computer-controls#take-screenshots) and [logs](/apps/logs) into your traces at the points that matter.
+- **Feeding an observability pipeline?** Stream [telemetry](/browsers/telemetry/overview) events and route them wherever you collect signals.
 - **Putting a human in the loop?** Embed the [live view](/browsers/live-view#embedding-in-an-iframe) in your own UI.

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -58,7 +58,7 @@ Update a running browser session — change or remove its proxy, load a profile,
 | `--save-changes` | Save changes back to the profile when the session ends. |
 | `--viewport <WxH@fps>` | Set viewport size (e.g. `1920x1080@25`). |
 | `--force` | Force a viewport resize even during an active live view or recording. |
-| `--telemetry <spec>` | Configure [telemetry](/browsers/telemetry/overview) (opt-in, replaces the current selection): `all` for the default set, `off` to disable, or a comma-separated category list like `console,network`. |
+| `--telemetry <spec>` | Update [telemetry](/browsers/telemetry/overview): `all` resets to the default set, `off` disables, or a comma-separated list like `console,network` to merge those categories into the current selection. |
 | `--output json`, `-o json` | Output raw API response as JSON. |
 
 ### `kernel browsers curl <session-id> <url>`

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -22,6 +22,7 @@ Create a new browser session.
 | `--headless` | Launch without GUI/VNC access. |
 | `--kiosk` | Launch in Chrome kiosk mode. |
 | `--start-url <url>` | Initial page to open on launch. |
+| `--telemetry <spec>` | Configure [telemetry](/browsers/telemetry/overview) (opt-in): `all` for the default set, `off` to disable, or a comma-separated category list like `console,network`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel browsers delete <session-id>`
@@ -57,7 +58,7 @@ Update a running browser session — change or remove its proxy, load a profile,
 | `--save-changes` | Save changes back to the profile when the session ends. |
 | `--viewport <WxH@fps>` | Set viewport size (e.g. `1920x1080@25`). |
 | `--force` | Force a viewport resize even during an active live view or recording. |
-| `--telemetry <spec>` | Toggle telemetry: `all` to enable, `off` to disable, or per-category like `network=on,page=off`. |
+| `--telemetry <spec>` | Configure [telemetry](/browsers/telemetry/overview) (opt-in, replaces the current selection): `all` for the default set, `off` to disable, or a comma-separated category list like `console,network`. |
 | `--output json`, `-o json` | Output raw API response as JSON. |
 
 ### `kernel browsers curl <session-id> <url>`
@@ -105,11 +106,11 @@ Stream browser logs from the supervisor or a file path.
 ## Telemetry
 
 ### `kernel browsers telemetry stream <session-id>`
-Stream live telemetry events (network, console, interaction, page, and system) from a browser session.
+Stream live [telemetry](/browsers/telemetry/overview) events from a browser session. Filters are applied client-side and don't change what the session captures.
 
 | Flag | Description |
 |------|-------------|
-| `--categories <list>` | Filter by category: `api`, `console`, `interaction`, `network`, `page`, `system`. |
+| `--categories <list>` | Filter by category: `console`, `network`, `page`, `interaction`, `control`, `connection`, `system`, `screenshot`, `captcha`, `monitor`. |
 | `--types <list>` | Filter by event type (e.g. `network_response,console_error`). |
 | `--seq <n>` | Resume after sequence number N; replays events with `seq > N` (default: `-1`, stream from now). |
 | `--output json`, `-o json` | Output newline-delimited JSON envelopes. |


### PR DESCRIPTION
### Overview

Documents browser telemetry (opt-in categories, lightweight default set, SSE consumption).

- New Telemetry subgroup under Working with your browser → Advanced:
  - **Overview**: the category model and the three ways to configure capture (default set, explicit categories, off).
  - **Categories**: the full taxonomy (browser-activity vs operational), the default set, the auto-managed monitor category, cost notes, and a data-sensitivity section.
  - **Streaming**: consuming via SDK, CLI, and raw SSE, with filtering and seq-based resume.
- Observe page: telemetry section + "picking the right tool" entry.
- CLI reference: synced `--telemetry` and `telemetry stream --categories` to the opt-in grammar.

## Notes
- Event payload schemas are deferred to the API reference, not duplicated here.
- The data-sensitivity section links to Security and the DPA for encryption, retention, and processing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or auth impact.
> 
> **Overview**
> Adds a **Telemetry** docs section (overview, categories, streaming) under Working with your browser → Advanced, wired in via `docs.json`.
> 
> The new pages document opt-in category capture, the lightweight default operational set, per-category cost and **data sensitivity** (with Security/DPA links), SDK/CLI streaming, filtering, and `seq`-based resume. Event schemas stay pointed at the API reference.
> 
> **Observe** gains a telemetry section and an observability-pipeline bullet in “Picking the right tool.” **CLI browsers** reference is updated for `--telemetry` on create/update and the expanded `telemetry stream --categories` list, aligned with the opt-in grammar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee78dc07546626ea1bd3c9cdc97e02f826f66dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->