### PR TITLE
Link Claude Managed Agents docs to public cookbook

### DIFF
--- a/integrations/claude-managed-agents.mdx
+++ b/integrations/claude-managed-agents.mdx
@@ -57,6 +57,10 @@ The example code below is TypeScript. The same API is exposed through the Anthro
 
 ## Quickstart
 
+<Tip>
+The complete, runnable version of this quickstart lives in the [Claude Managed Agents + Kernel cookbook](https://github.com/kernel/claude-managed-agents-kernel), alongside more recipes for parallel computer-use agent swarms.
+</Tip>
+
 <Steps>
 <Step title="Create the environment">
 The environment is the sandbox your agent runs in. Preinstall the Kernel CLI so workers can run `kernel …` immediately, and apply the environment-networking firewall from above.


### PR DESCRIPTION
## Summary

Adds a link from the Claude Managed Agents integration docs to the public [cookbook repo](https://github.com/kernel/claude-managed-agents-kernel) — the runnable version of the page's quickstart.

Placed as a `<Tip>` callout at the top of the **Quickstart** section, so readers who'd rather clone-and-run than copy each step can jump straight to the full example.

Single-line docs change; renders as a standard Mintlify tip callout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **Mintlify `<Tip>` callout** at the start of the **Quickstart** section on `integrations/claude-managed-agents.mdx`, linking to the public [Claude Managed Agents + Kernel cookbook](https://github.com/kernel/claude-managed-agents-kernel) for a clone-and-run version of the in-page steps and extra parallel computer-use swarm recipes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584dd3a541af356389ec47bcbd21104abb7f1cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->