### PR TITLE
escape $ in stripe-projects.mdx

### DIFF
--- a/integrations/stripe-projects.mdx
+++ b/integrations/stripe-projects.mdx
@@ -13,13 +13,13 @@ Stripe service slugs are prefixed with `kernel/` (from the app manifest name).
 
 | Service ID | Kind | Scope | Summary |
 |------------|------|-------|---------|
-| `kernel/plan:developer` | plan | account | Free tier — $5/mo credits, 5 concurrent browsers |
-| `kernel/plan:hobbyist` | plan | account | $30/mo, $10/mo credits, 10 concurrent browsers (email KYC) |
-| `kernel/plan:startup` | plan | account | $200/mo, $50/mo credits, 150 concurrent browsers (email KYC) |
+| `kernel/plan:developer` | plan | account | Free tier — \$5/mo credits, 5 concurrent browsers |
+| `kernel/plan:hobbyist` | plan | account | \$30/mo, \$10/mo credits, 10 concurrent browsers (email KYC) |
+| `kernel/plan:startup` | plan | account | \$200/mo, \$50/mo credits, 150 concurrent browsers (email KYC) |
 | `kernel/browser:api-access` | deployable | project | API key for launching browsers in a Stripe Project |
 
 - Only **one plan** can be active per Kernel org at a time (`allowed_updates` defines upgrade/downgrade paths).
-- `browser:api-access` is **free** when any active plan is provisioned; otherwise it is usage-based ($0.01/min standard, $0.02/min stealth).
+- `browser:api-access` is **free** when any active plan is provisioned; otherwise it is usage-based (\$0.01/min standard, \$0.02/min stealth).
 
 ## Common CLI flows
 
@@ -72,7 +72,7 @@ New accounts use the **agentic credentials** flow: after `stripe projects link` 
 Paid plans are charged through Stripe **Shared Payment Tokens** on the Metronome-managed Stripe customer.
 
 <Warning>
-The default SPT monthly spending limit is often **$50**. The Start-Up plan is **$200/mo**. Before upgrading to Start-Up, confirm the developer’s SPT limit covers the plan (`stripe projects billing show`) or ask them to raise the limit. Charges above the limit will fail.
+The default SPT monthly spending limit is often **\$50**. The Start-Up plan is **\$200/mo**. Before upgrading to Start-Up, confirm the developer’s SPT limit covers the plan (`stripe projects billing show`) or ask them to raise the limit. Charges above the limit will fail.
 </Warning>
 
 ## Full documentation


### PR DESCRIPTION
the SPT spending-limit warning callout on the stripe-projects integration page rendered as a mangled math equation — mintlify interprets paired `$` signs as latex/katex math mode, so `**$50**. The Start-Up plan is **$200/mo**` collapsed to `50**.thestart-upplanis**200/mo`.

escape `$` with `\$` so dollar amounts render literally. fixed the same issue on the plans table (lines 16–18) and the usage-based pricing bullet (line 22) — same root cause, same file.

## test plan

- [ ] preview the page on mintlify and confirm the warning callout reads "the default spt monthly spending limit is often **$50**. the start-up plan is **$200/mo**..."
- [ ] confirm the plans table renders dollar amounts
- [ ] confirm the usage-based pricing bullet renders dollar amounts

note: `info/pricing.mdx` and `integrations/stripe-projects-browser.mdx` have similar unescaped `$` patterns that may also render as math — left alone to keep this PR scoped, worth a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Markdown escaping with no runtime or billing behavior changes.
> 
> **Overview**
> Escapes dollar signs in `integrations/stripe-projects.mdx` so Mintlify stops treating price text as LaTeX/KaTeX math and garbling the copy.
> 
> **Plans table**, the usage-based pricing bullet, and the **SPT spending-limit** `<Warning>` callout now use `\$` for amounts (e.g. **\$50**, **\$200/mo**, \$0.01/min) so they render as literal currency instead of broken math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03b63ab1b5106eb604e1dffc37374afaf0ddcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->