### PR TITLE
Document X-Kernel-Project-Id resolution rules on the Projects page

### DIFF
--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -25,13 +25,24 @@ A project must also be empty before it can be deleted — archive or remove its 
 
 ## Scoping Requests to a Project
 
-Pass the `X-Kernel-Project-Id` header on any API request to scope it to a specific project. Without the header (and without a project-scoped API key), requests operate org-wide.
+Pass the `X-Kernel-Project-Id` header — a project ID or name — on any API request to scope it to a specific project. Without the header (and without a project-scoped API key), requests act on your organization's **default project**: reads return the default project's resources, and writes create resources in it.
 
 ```bash
 curl https://api.onkernel.com/browsers \
   -H "Authorization: Bearer $KERNEL_API_KEY" \
   -H "X-Kernel-Project-Id: proj_abc123"
 ```
+
+### Resolution rules
+
+- **Unknown or archived project** — a header naming a project that doesn't exist or isn't active fails with `404 Not Found`:
+
+  ```json
+  { "code": "project_not_found", "message": "Project not found or inactive" }
+  ```
+
+- **The default project is the baseline** — naming your organization's default project is exactly equivalent to omitting the header, for both reads and writes.
+- **Scoped keys reject mismatches** — with a project-scoped API key, a header naming any other project fails with `403 Forbidden` (see [API keys](#api-keys) below).
 
 ### SDK usage
 


### PR DESCRIPTION
## What

Updates `info/projects.mdx` with the precise resolution rules for the `X-Kernel-Project-Id` header.

## Changes

1. **Corrects the unscoped-request claim.** The page said requests without the header "operate org-wide"; they actually act on the organization's **default project** (reads and writes both). This is the same stale "org-wide" framing kernel/kernel#2386 fixes in the OpenAPI descriptions.
2. **Adds a "Resolution rules" subsection**:
   - Unknown or archived project → `404` with `{"code":"project_not_found"}`
   - Naming the default project ≡ omitting the header
   - Project-scoped key + mismatched header → `403` (cross-links the existing API keys section)
3. **Notes the header accepts a project ID or name** (names already documented as the mechanism behind the CLI's `--project` flag further down the page).

Every rule here was verified live against a running build of kernel/kernel#2387 (before/after comparison on a dev org).

## Merge timing

⚠️ Hold until kernel/kernel#2387 is **deployed**: the coded `project_not_found` body and the default-project normalization land there. Today's API returns a plain-text 404 and treats an explicit default header as a strict filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `projects.mdx`; no runtime or API code in this repo.
> 
> **Overview**
> Updates **`info/projects.mdx`** so **`X-Kernel-Project-Id`** behavior matches the API (aligned with kernel/kernel#2387).
> 
> **Scoping without the header** is no longer described as “org-wide”; unscoped requests (and org-wide keys without a header) are documented as acting on the organization’s **default project** for reads and writes.
> 
> Adds a **Resolution rules** subsection: invalid or archived projects → **`404`** with `project_not_found`; naming the default project is equivalent to omitting the header; project-scoped keys that disagree with the header → **`403`** (with a link to the API keys section). The intro also states the header accepts a **project ID or name**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45abdb379bb850488f6b7ff38ffc6370690f652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->