### PR TITLE
Add June 12 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -13,14 +13,14 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 ## Product updates
 
 - Released the [Kernel × Claude Managed Agents cookbook](https://github.com/kernel/claude-managed-agents-kernel), a public recipe for running parallel computer-use agent swarms with [Claude Managed Agents](/integrations/claude-managed-agents) on Kernel cloud browsers, with API keys secured via Vaults.
-- Added a `kernel-browser-harness` [skill](https://github.com/kernel/skills) for setting up Kernel browser sessions inside Claude Code with persistent session IDs across calls.
-- Added `name` and `tags` parameters to `kernel browsers acquire` in the [CLI](https://github.com/kernel/cli), so pooled browsers can be labeled at acquisition time alongside `browsers create`.
+- Shipped a `kernel-browser-harness` [skill](https://github.com/kernel/skills) for setting up Kernel browser sessions inside Claude Code with persistent session IDs across calls.
+- Extended `kernel browsers acquire` in the [CLI](https://github.com/kernel/cli) with `name` and `tags` parameters, so pooled browsers can be labeled at acquisition time alongside `browsers create`.
 - Made browser [telemetry](/browsers/telemetry) categories opt-in. The `--telemetry` flag (and `telemetry` request config) now records only the categories you list; enabling telemetry without specifying categories ships a small default set instead of every category.
 
 ## Documentation updates
 
-- Added a new [browser telemetry](/browsers/telemetry) guide covering categories, the stream API, and event shapes.
-- Added a [Claude Managed Agents](/integrations/claude-managed-agents) integration guide with a link to the public cookbook.
+- Published a new [browser telemetry](/browsers/telemetry) guide covering categories, the stream API, and event shapes.
+- Wrote a [Claude Managed Agents](/integrations/claude-managed-agents) integration guide with a link to the public cookbook.
 - Documented the org-wide default [per-project concurrency cap](/info/projects) on the Projects page.
 - Expanded the [CLI reference](/reference/cli) to include several previously missing subcommands.
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,23 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="June 12" tags={["Product", "Docs"]}>
+## Product updates
+
+- Released the [Kernel × Claude Managed Agents cookbook](https://github.com/kernel/claude-managed-agents-kernel), a public recipe for running parallel computer-use agent swarms with [Claude Managed Agents](/integrations/claude-managed-agents) on Kernel cloud browsers, with API keys secured via Vaults.
+- Added a `kernel-browser-harness` [skill](https://github.com/kernel/skills) for setting up Kernel browser sessions inside Claude Code with persistent session IDs across calls.
+- Added `name` and `tags` parameters to `kernel browsers acquire` in the [CLI](https://github.com/kernel/cli), so pooled browsers can be labeled at acquisition time alongside `browsers create`.
+- Made browser [telemetry](/browsers/telemetry) categories opt-in. The `--telemetry` flag (and `telemetry` request config) now records only the categories you list; enabling telemetry without specifying categories ships a small default set instead of every category.
+- Fixed a display sizing bug where requesting certain viewport dimensions could fail or return incorrect realized screen sizes due to libxcvt rounding.
+
+## Documentation updates
+
+- Added a new [browser telemetry](/browsers/telemetry) guide covering categories, the stream API, and event shapes.
+- Added a [Claude Managed Agents](/integrations/claude-managed-agents) integration guide with a link to the public cookbook.
+- Documented the org-wide default [per-project concurrency cap](/info/projects) on the Projects page.
+- Expanded the [CLI reference](/reference/cli) to include several previously missing subcommands.
+</Update>
+
 <Update label="June 5" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -16,7 +16,6 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Added a `kernel-browser-harness` [skill](https://github.com/kernel/skills) for setting up Kernel browser sessions inside Claude Code with persistent session IDs across calls.
 - Added `name` and `tags` parameters to `kernel browsers acquire` in the [CLI](https://github.com/kernel/cli), so pooled browsers can be labeled at acquisition time alongside `browsers create`.
 - Made browser [telemetry](/browsers/telemetry) categories opt-in. The `--telemetry` flag (and `telemetry` request config) now records only the categories you list; enabling telemetry without specifying categories ships a small default set instead of every category.
-- Fixed a display sizing bug where requesting certain viewport dimensions could fail or return incorrect realized screen sizes due to libxcvt rounding.
 
 ## Documentation updates
 


### PR DESCRIPTION
## Summary

Adds the June 12 changelog entry covering the Claude Managed Agents cookbook release, the `kernel-browser-harness` skill, CLI updates (`acquire` name/tags, expanded reference), opt-in telemetry categories, the libxcvt display sizing fix, and the new telemetry/Claude Managed Agents/projects docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds a **June 12** changelog block at the top of `changelog.mdx`, in the same Product / Documentation split as prior entries.
> 
> **Product:** Claude Managed Agents cookbook, `kernel-browser-harness` skill, `kernel browsers acquire` `name`/`tags`, and **opt-in** browser telemetry categories (listed categories only; empty enable uses a small default set).
> 
> **Docs:** New telemetry and Claude Managed Agents guides, per-project concurrency cap on Projects, and expanded CLI reference subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c575cc238fbc3e0c415945cf8a6854796ecbd41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->