### PR TITLE
Add CLI/SDK version note to telemetry overview

### DIFF
--- a/browsers/telemetry/overview.mdx
+++ b/browsers/telemetry/overview.mdx
@@ -7,6 +7,10 @@ Telemetry captures events from inside a browser session - console output, networ
 
 Events are grouped into categories (`console`, `network`, `page`, and so on), and categories are the unit of control. Selection is opt-in: a session captures only the categories you turn on, and anything you don't stays off. See [Categories](/browsers/telemetry/categories) for the full list and what each one captures.
 
+<Info>
+Telemetry is a recent addition. If the `telemetry` options or `telemetry stream` command aren't available, upgrade to the latest CLI (`kernel upgrade`) and SDK (`@onkernel/sdk` for TypeScript, `kernel` for Python).
+</Info>
+
 ## Enabling telemetry
 
 You configure telemetry when you [create a browser](/introduction/create) (and can change it later on update). There are three ways to configure it.


### PR DESCRIPTION
## Summary
- Adds a small `<Info>` block to the telemetry overview noting that telemetry is a recent addition, with upgrade pointers for the CLI (`kernel upgrade`) and SDKs if the options/commands aren't yet available.

## Context
There was no note anywhere in the docs about minimum/required CLI or SDK versions for the telemetry feature. This is a discrete, generic upgrade hint (no hard version pin, consistent with the rest of the docs) placed on the feature's entry page.

## Notes
- Documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX change with no runtime, API, or security impact.
> 
> **Overview**
> Adds an **`<Info>`** callout on the telemetry overview page, right after the categories intro and before **Enabling telemetry**.
> 
> It states that telemetry is new and tells readers to upgrade the CLI (`kernel upgrade`) and SDKs (`@onkernel/sdk`, Python `kernel`) if `telemetry` options or `telemetry stream` are missing. There is no pinned minimum version—only a generic upgrade pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19925b757edb9f9ebbbafec175a9d2768ace456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->