### PR TITLE
fix dark mode tinker-bot swap path

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -42,7 +42,8 @@ import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
   <h3 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600 }}>fast setup</h3>
   <div className="tinker-box-row">
     <div style={{ flexShrink: 0 }}>
-      <img src="/images/tinker-bot.svg" alt="" style={{ width: '146px', height: 'auto' }} />
+      <img src="/images/tinker-bot.svg" alt="" className="block dark:hidden" style={{ width: '146px', height: 'auto' }} />
+      <img src="/images/tinker-bot-dark.svg" alt="" className="hidden dark:block" style={{ width: '146px', height: 'auto' }} />
     </div>
     <div className="tinker-box-content">
       <p style={{ margin: 0, fontSize: '0.9375rem', lineHeight: 1.6, opacity: 0.8 }}>

--- a/style.css
+++ b/style.css
@@ -216,9 +216,6 @@ html.dark {
   --btn-border: #EDEEF0;
 }
 
-/* hero bot dark recolor */
-html.dark img[src*="/images/tinker-bot.svg"] { content: url("images/tinker-bot-dark.svg"); }
-
 /* warning callout — selector depends on mintlify's yellow-* classes; renames silently break this */
 html.dark .callout[class*="yellow"] {
   background-color: rgba(237, 238, 240, 0.03) !important;

--- a/style.css
+++ b/style.css
@@ -217,7 +217,7 @@ html.dark {
 }
 
 /* hero bot dark recolor */
-html.dark img[src*="/images/tinker-bot.svg"] { content: url("/images/tinker-bot-dark.svg"); }
+html.dark img[src*="/images/tinker-bot.svg"] { content: url("images/tinker-bot-dark.svg"); }
 
 /* warning callout — selector depends on mintlify's yellow-* classes; renames silently break this */
 html.dark .callout[class*="yellow"] {


### PR DESCRIPTION
## Summary

Dark-mode tinker-bot was invisible on prod. The previous fix used a CSS `content: url()` swap, which silently failed because:

1. Mintlify inlines `style.css` as a `<style>` tag — not a `<link>` — so relative `url()` resolves against the **document URL**, not a stylesheet URL
2. Prod docs canonical is `https://kernel.sh/docs` (no trailing slash), so the absolute path `/images/tinker-bot-dark.svg` resolved to `kernel.sh/images/…` (outside the docs subpath) and 404'd
3. The mintlify preview happened to serve docs at root, so this was invisible during PR review

Switched to mintlify's standard dual-`<img>` pattern, gated by tailwind `block` / `dark:block`. Mintlify's CDN rewriter handles both asset paths, so it works in prod, preview, and dev.

## Changes

- `index.mdx` — one `<img>` becomes two, gated by visibility classes
- `style.css` — drop the unused `/* hero bot dark recolor */` block

## Test plan

- [ ] Toggle dark on `/` (preview): cream tinker-bot renders
- [ ] After merge, toggle dark on prod `/`: cream tinker-bot renders
- [ ] Light mode unchanged