### PR TITLE
Correct X-Kernel-Project-Id: header takes a project ID, not a name

### DIFF
--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -25,7 +25,7 @@ A project must also be empty before it can be deleted — archive or remove its 
 
 ## Scoping Requests to a Project
 
-Pass the `X-Kernel-Project-Id` header — a project ID or name — on any API request to scope it to a specific project. Without the header (and without a project-scoped API key), requests act on your organization's **default project**: reads return the default project's resources, and writes create resources in it.
+Pass the `X-Kernel-Project-Id` header — a project ID — on any API request to scope it to a specific project. The header takes the project's ID, not its name; the CLI's `--project` flag and the SDKs resolve names to IDs for you. Without the header (and without a project-scoped API key), requests act on your organization's **default project**: reads return the default project's resources, and writes create resources in it.
 
 ```bash
 curl https://api.onkernel.com/browsers \

--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -25,7 +25,7 @@ A project must also be empty before it can be deleted — archive or remove its 
 
 ## Scoping Requests to a Project
 
-Pass the `X-Kernel-Project-Id` header — a project ID — on any API request to scope it to a specific project. The header takes the project's ID, not its name; the CLI's `--project` flag and the SDKs resolve names to IDs for you. Without the header (and without a project-scoped API key), requests act on your organization's **default project**: reads return the default project's resources, and writes create resources in it.
+Scope a request to a project **by name** with the CLI's `--project <name>` flag or by setting the project on an SDK client — both look the name up and send the project's ID for you, so you never handle the raw ID. When calling the REST API directly, send that ID yourself in the `X-Kernel-Project-Id` header (the header takes a project ID, not a name). Without it (and without a project-scoped API key), requests act on your organization's **default project**: reads return the default project's resources, and writes create resources in it.
 
 ```bash
 curl https://api.onkernel.com/browsers \


### PR DESCRIPTION
## What

docs#409 described the `X-Kernel-Project-Id` header as accepting "a project ID or name." It does not — the middleware resolves it by project **ID only** (`entproject.IDEQ`), so a name returns `404 project_not_found`. Verified live against a running API: the project name `testingapikeygen` 404'd, its ID resolved.

## Fix

Clarify that the header takes a project ID; name resolution is a **client-side** convenience (the CLI's `--project` flag and the SDKs resolve names to IDs before sending the header). The CLI section of this page already documents `--project <id-or-name>` correctly and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime or API behavior changes.
> 
> **Overview**
> Fixes misleading docs in **Scoping Requests to a Project** (`info/projects.mdx`): `X-Kernel-Project-Id` is documented as accepting only a **project ID**, not a name (names in the header lead to `404 project_not_found`).
> 
> The section now explains that **CLI `--project`** and **SDK project settings** resolve names to IDs before sending the header, while **direct REST** callers must set the header to the ID themselves. Default-project behavior when the header is omitted is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee5ece81b047aaf99a404822c447d3dacaa9c739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->