### PR TITLE
Document audit log search and export

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -290,6 +290,7 @@
               "reference/cli/managed-auth",
               "reference/cli/projects",
               "reference/cli/api-keys",
+              "reference/cli/audit-logs",
               "reference/cli/mcp"
             ]
           }

--- a/docs.json
+++ b/docs.json
@@ -116,6 +116,7 @@
                     ]
                   },
                   "info/api-keys",
+                  "info/audit-logs",
                   "browsers/file-io",
                   "browsers/curl",
                   "browsers/ssh",

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -22,13 +22,13 @@ The API and SDKs use the same filters for search and export:
 
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
-- `method` includes one HTTP method. In the CLI, passing any method disables the default GET exclusion.
-- `exclude_method` excludes one or more HTTP methods in addition to the default CLI exclusion, with up to 10 values.
+- `method` includes one HTTP method.
+- `exclude_method` excludes up to 10 HTTP methods.
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
 
 <Note>
-The CLI excludes `GET` by default to reduce noise; the API and SDKs include all methods unless you filter. Use `--include-get` in the CLI or omit `exclude_method: ["GET"]` in SDKs to include them.
+The API and SDKs include all methods unless you filter. Only the CLI excludes `GET` by default to reduce noise. Pass `--include-get` to include GET requests, or pass `--method GET` to return only GET requests.
 </Note>
 
 ## Search audit logs
@@ -106,36 +106,40 @@ See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-aud
 
 The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
-Each chunk is a complete gzip stream, so appending each response body as-is produces one valid file. Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`. This matches the CLI download behavior, which verifies `X-Content-Sha256` and retries transient failures:
+Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`. With the `jsonl.gz` format, each chunk is an independent gzip member, and appending the members produces a valid gzip file. With `jsonl`, each chunk contains raw JSON Lines that you can also append.
+
+The following minimal examples write all chunks to one file. For a hardened export with checksum verification and retries, use the [CLI](/reference/cli/audit-logs#kernel-audit-logs-download).
 
 <CodeGroup>
 ```typescript TypeScript
-import { appendFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import Kernel from '@onkernel/sdk';
 
 const kernel = new Kernel({
   apiKey: process.env.KERNEL_API_KEY,
 });
 
-let cursor: string | undefined;
-while (true) {
-  const response = await kernel.auditLogs.exportChunk({
-    start: '2026-06-01T00:00:00Z',
-    end: '2026-06-02T00:00:00Z',
-    format: 'jsonl.gz',
-    exclude_method: ['GET'],
-    cursor,
-  });
+const file = await open('audit-logs.jsonl.gz', 'w');
+try {
+  let cursor: string | undefined;
+  while (true) {
+    const response = await kernel.auditLogs.exportChunk({
+      start: '2026-06-01T00:00:00Z',
+      end: '2026-06-02T00:00:00Z',
+      format: 'jsonl.gz',
+      exclude_method: ['GET'],
+      cursor,
+    });
 
-  await appendFile(
-    'audit-logs.jsonl.gz',
-    Buffer.from(await response.arrayBuffer()),
-  );
+    await file.write(Buffer.from(await response.arrayBuffer()));
 
-  if (response.headers.get('x-has-more') !== 'true') {
-    break;
+    if (response.headers.get('x-has-more') !== 'true') {
+      break;
+    }
+    cursor = response.headers.get('x-next-cursor') ?? undefined;
   }
-  cursor = response.headers.get('x-next-cursor') ?? undefined;
+} finally {
+  await file.close();
 }
 ```
 
@@ -156,9 +160,9 @@ with open("audit-logs.jsonl.gz", "wb") as file:
     while True:
         response = client.audit_logs.export_chunk(**params)
         file.write(response.read())
-        if response.http_response.headers.get("x-has-more") != "true":
+        if response.headers.get("x-has-more") != "true":
             break
-        params["cursor"] = response.http_response.headers.get("x-next-cursor")
+        params["cursor"] = response.headers.get("x-next-cursor")
 ```
 
 ```go Go
@@ -195,10 +199,14 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		if _, err := io.Copy(file, response.Body); err != nil {
-			panic(err)
+		_, copyErr := io.Copy(file, response.Body)
+		closeErr := response.Body.Close()
+		if copyErr != nil {
+			panic(copyErr)
 		}
-		response.Body.Close()
+		if closeErr != nil {
+			panic(closeErr)
+		}
 
 		if response.Header.Get("X-Has-More") != "true" {
 			break
@@ -210,7 +218,7 @@ func main() {
 </CodeGroup>
 
 <Warning>
-  A production exporter should persist the cursor only after safely writing a chunk and verify `X-Content-Sha256` against the exact response bytes.
+  Don't use these minimal loops for a production export without adding integrity checks and durable cursor storage. For each chunk, buffer the exact response bytes, compare their SHA-256 hash with `X-Content-Sha256`, write the verified bytes, and then validate the cursor. When `X-Has-More` is `true`, require a non-empty `X-Next-Cursor` that differs from the current cursor. Persist that cursor only after the verified chunk is safely written. You must also retry transient failures. The [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) implements this hardened path.
 </Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -1,0 +1,130 @@
+---
+title: "Audit Logs"
+description: "List organization API request audit events"
+---
+
+Audit logs record authenticated API requests for your organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.
+
+Audit logs are ordered newest first. The `start` timestamp is inclusive, the `end` timestamp is exclusive, and each request can cover up to 30 days. Each page returns up to 100 events.
+
+## List audit logs
+
+Use the SDKs to page through logs for a time window.
+
+<CodeGroup>
+```typescript TypeScript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel({
+  apiKey: process.env.KERNEL_API_KEY,
+});
+
+for await (const event of kernel.auditLogs.list({
+  start: '2026-06-01T00:00:00Z',
+  end: '2026-06-02T00:00:00Z',
+  limit: 100,
+  method: 'POST',
+})) {
+  console.log(event.timestamp, event.method, event.path, event.status);
+}
+```
+
+```python Python
+import os
+from kernel import Kernel
+
+client = Kernel(api_key=os.environ["KERNEL_API_KEY"])
+
+for event in client.audit_logs.list(
+    start="2026-06-01T00:00:00Z",
+    end="2026-06-02T00:00:00Z",
+    limit=100,
+    method="POST",
+):
+    print(event.timestamp, event.method, event.path, event.status)
+```
+</CodeGroup>
+
+## Filter audit logs
+
+Use filters to narrow the time window to the events you need:
+
+- `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
+- `service` filters by the service that emitted the audit event.
+- `method` filters by HTTP method.
+- `exclude_method` excludes a single HTTP method.
+- `search` matches path, user ID, email, client IP, and status.
+- `search_user_id` adds one or more user IDs to the search.
+
+<CodeGroup>
+```typescript TypeScript
+const logs = kernel.auditLogs.list({
+  start: '2026-06-01T00:00:00Z',
+  end: '2026-06-08T00:00:00Z',
+  limit: 50,
+  auth_strategy: 'api_key',
+  exclude_method: 'GET',
+  search: '/browsers',
+});
+
+for await (const event of logs) {
+  console.log(event.email, event.client_ip, event.user_agent);
+}
+```
+
+```python Python
+logs = client.audit_logs.list(
+    start="2026-06-01T00:00:00Z",
+    end="2026-06-08T00:00:00Z",
+    limit=50,
+    auth_strategy="api_key",
+    exclude_method="GET",
+    search="/browsers",
+)
+
+for event in logs:
+    print(event.email, event.client_ip, event.user_agent)
+```
+</CodeGroup>
+
+## Page with HTTP
+
+The API returns the next cursor in the `X-Next-Page-Token` response header. Pass it back as `page_token` to read the next page.
+
+```bash
+curl --get https://api.onkernel.com/audit-logs \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "limit=100"
+```
+
+```bash
+curl --get https://api.onkernel.com/audit-logs \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "limit=100" \
+  --data-urlencode "page_token=eyJ0IjoiMjAyNi0wNi0wMVQyMzo1OTo1OS43NDUxMjNaIn0"
+```
+
+Use `X-Has-More: true` to decide whether to continue paging. Page tokens are opaque; store and pass them exactly as returned.
+
+## Response fields
+
+Each audit log entry includes:
+
+- `timestamp`
+- `auth_strategy`
+- `user_id`
+- `email`
+- `status`
+- `method`
+- `path`
+- `route`
+- `domain`
+- `duration_ms`
+- `client_ip`
+- `user_agent`
+
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the full request and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -131,7 +131,7 @@ try {
       cursor,
     });
 
-    await file.write(Buffer.from(await response.arrayBuffer()));
+    await file.writeFile(Buffer.from(await response.arrayBuffer()));
 
     if (response.headers.get('x-has-more') !== 'true') {
       break;

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -14,7 +14,7 @@ Choose the workflow that matches the amount of data you need:
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
 
-Working from the terminal? Both workflows are also available in the CLI — see the [audit log CLI reference](/reference/cli/audit-logs).
+Both workflows are also available in the [CLI](/reference/cli/audit-logs), and the API reference documents the raw HTTP contract for [search](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) and [export](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk).
 
 ## Filter audit logs
 
@@ -27,7 +27,7 @@ The API and SDKs use the same filters for search and export:
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
 
-## Search with an SDK
+## Search audit logs
 
 Each API page contains up to 100 events. The SDK pagination helpers request older pages as you iterate.
 
@@ -96,40 +96,9 @@ func main() {
 ```
 </CodeGroup>
 
-## Search with HTTP
-
-Search over raw HTTP with a `GET` request. The response carries pagination state in these headers:
-
-- `X-Limit` is the page size applied to the request.
-- `X-Has-More` indicates whether older records remain.
-- `X-Next-Page-Token` contains the opaque token for the next page.
-
-Request the first page:
-
-```bash
-curl --include --get https://api.onkernel.com/audit-logs \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "limit=100"
-```
-
-If `X-Has-More` is `true`, copy the `X-Next-Page-Token` value and pass it unchanged:
-
-```bash
-curl --include --get https://api.onkernel.com/audit-logs \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "limit=100" \
-  --data-urlencode "page_token=<value from X-Next-Page-Token>"
-```
-
-Page tokens are opaque. Don't decode, construct, or modify them.
-
 See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.
 
-## Export with an SDK
+## Export audit logs
 
 The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
@@ -239,35 +208,6 @@ func main() {
 <Warning>
   A production exporter should persist the cursor only after safely writing a chunk and verify `X-Content-Sha256` against the exact response bytes.
 </Warning>
-
-## Export with HTTP
-
-Save the response headers separately from the binary body:
-
-```bash
-curl --fail-with-body --silent --show-error --get \
-  https://api.onkernel.com/audit-logs/export/chunk \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "format=jsonl.gz" \
-  --dump-header audit-logs-chunk.headers \
-  --output audit-logs-chunk.jsonl.gz
-```
-
-When `X-Has-More` is `true`, copy `X-Next-Cursor` and pass it unchanged to download the next chunk:
-
-```bash
-curl --fail-with-body --silent --show-error --get \
-  https://api.onkernel.com/audit-logs/export/chunk \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "format=jsonl.gz" \
-  --data-urlencode "cursor=<value from X-Next-Cursor>" \
-  --dump-header audit-logs-next-chunk.headers \
-  --output audit-logs-next-chunk.jsonl.gz
-```
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -24,7 +24,7 @@ The API and SDKs use the same filters for search and export:
 - `service` filters by the service that emitted the audit event.
 - `method` returns only requests that use the specified HTTP method.
 - `exclude_method` omits requests that use any of the specified HTTP methods.
-- `search` matches path, user ID, email, client IP, and status.
+- `search` matches path, user ID, email, client IP, or status.
 - `search_user_id` matches requests from the specified user IDs in addition to any free-text matches.
 
 ## Search audit logs

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -27,10 +27,6 @@ The API and SDKs use the same filters for search and export:
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` matches requests from the specified user IDs in addition to any free-text matches.
 
-<Note>
-The API and SDKs include all methods unless you filter. Only the CLI excludes `GET` by default to reduce noise. Pass `--include-get` to remove that default exclusion, or pass `--method GET` to return only GET requests.
-</Note>
-
 ## Search audit logs
 
 Each API page contains up to 100 events. The SDK pagination helpers request older pages as you iterate.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -22,13 +22,13 @@ The API and SDKs use the same filters for search and export:
 
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
-- `method` includes one HTTP method.
-- `exclude_method` excludes up to 10 HTTP methods.
+- `method` returns only requests that use the specified HTTP method.
+- `exclude_method` removes requests that use any of up to 10 specified HTTP methods.
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
 
 <Note>
-The API and SDKs include all methods unless you filter. Only the CLI excludes `GET` by default to reduce noise. Pass `--include-get` to include GET requests, or pass `--method GET` to return only GET requests.
+The API and SDKs include all methods unless you filter. Only the CLI excludes `GET` by default to reduce noise. Pass `--include-get` to remove that default exclusion, or pass `--method GET` to return only GET requests.
 </Note>
 
 ## Search audit logs

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -178,10 +178,6 @@ func main() {
 ```
 </CodeGroup>
 
-<Warning>
-If a download fails, the destination may contain a partial export. To publish only completed exports, write to a temporary file and atomically rename it after the download succeeds.
-</Warning>
-
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 
 For direct HTTP integrations, see the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for pagination headers, formats, and the full request and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -3,7 +3,7 @@ title: "Audit Logs"
 description: "Search and export organization API request audit events"
 ---
 
-Audit logs record authenticated API requests for your organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.
+Audit logs record authenticated API requests across your entire organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.
 
 Choose the workflow that matches the amount of data you need:
 
@@ -13,11 +13,6 @@ Choose the workflow that matches the amount of data you need:
 | Export | Archival, compliance, and offline analysis | JSON Lines (`.jsonl`) or gzip-compressed JSON Lines (`.jsonl.gz`) |
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
-
-## Before you start
-
-- Audit logs cover your entire organization, not a single project.
-- Set `KERNEL_API_KEY` before running the examples. Any credential that authenticates to your organization can read its audit logs.
 
 ## Filter audit logs
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -215,7 +215,14 @@ func main() {
 </CodeGroup>
 
 <Warning>
-  Don't use these minimal loops for a production export without adding integrity checks and durable cursor storage. For each chunk, buffer the exact response bytes, compare their SHA-256 hash with `X-Content-Sha256`, write the verified bytes, and then validate the cursor. When `X-Has-More` is `true`, require a non-empty `X-Next-Cursor` that differs from the current cursor. Persist that cursor only after the verified chunk is safely written. You must also retry transient failures. The [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) implements this hardened path.
+Don't use these minimal loops for production exports without these safeguards:
+
+- Buffer each chunk's exact response bytes and verify their SHA-256 hash against `X-Content-Sha256` before writing.
+- When `X-Has-More` is `true`, require a non-empty `X-Next-Cursor` that differs from the current cursor.
+- Persist the cursor only after the verified chunk is safely written.
+- Retry transient failures.
+
+The [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) implements these safeguards.
 </Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -7,6 +7,8 @@ Audit logs record authenticated API requests for your organization. Use them to 
 
 Audit logs are ordered newest first. The `start` timestamp is inclusive, the `end` timestamp is exclusive, and each request can cover up to 30 days. Each page returns up to 100 events.
 
+<Info>Keep each audit log request to a 30-day range or less. For longer investigations, split the query into multiple time windows.</Info>
+
 ## List audit logs
 
 Use the SDKs to page through logs for a time window.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Audit Logs"
-description: "Search and export organization API request audit events"
+description: "Search and export audit logs for API requests across your organization"
 ---
 
 Audit logs record authenticated API requests across your entire organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -10,7 +10,7 @@ Choose the workflow that matches the amount of data you need:
 | Workflow | Best for | Output |
 |----------|----------|--------|
 | Search | Interactive investigation and recent activity | Paginated JSON events |
-| Export | Archival, compliance, and offline analysis | JSON Lines (`.jsonl`) or gzip-compressed JSON Lines (`.jsonl.gz`) |
+| Export | Archival, compliance, and offline analysis | Gzip-compressed JSON Lines (`.jsonl.gz`) |
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -101,7 +101,7 @@ See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-aud
 
 ## Export audit logs
 
-The SDK download helpers write a complete export to a destination you provide. They:
+The SDK download helpers default to `jsonl.gz` and write a complete export to a destination you provide. They:
 
 - request every chunk until the export is complete
 - validate pagination metadata and each chunk's SHA-256 checksum before writing
@@ -125,7 +125,6 @@ try {
     {
       start: '2026-06-01T00:00:00Z',
       end: '2026-06-02T00:00:00Z',
-      format: 'jsonl.gz',
       exclude_method: ['GET'],
     },
     file,
@@ -146,7 +145,6 @@ with open("audit-logs.jsonl.gz", "wb") as file:
         to=file,
         start="2026-06-01T00:00:00Z",
         end="2026-06-02T00:00:00Z",
-        format="jsonl.gz",
         exclude_method=["GET"],
     )
 ```
@@ -175,7 +173,6 @@ func main() {
 	_, err = client.AuditLogs.Download(ctx, kernel.AuditLogDownloadParams{
 		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
 		End:           time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
-		Format:        kernel.AuditLogExportChunkParamsFormatJSONLGz,
 		ExcludeMethod: []string{"GET"},
 	}, file)
 	if err != nil {

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -8,11 +8,29 @@ Audit logs record authenticated API requests for your organization. Use them to 
 Choose the workflow that matches the amount of data you need:
 
 | Workflow | Best for | Output |
-|---|---|---|
+|----------|----------|--------|
 | Search | Interactive investigation and recent activity | A table, JSON array, or paginated SDK results |
 | Export | Archival, compliance, and offline analysis | JSON Lines (`.jsonl`) or gzip-compressed JSON Lines (`.jsonl.gz`) |
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
+
+## Before you start
+
+- Audit logs cover your entire organization, not a single project.
+- Set `KERNEL_API_KEY` before running the examples. Any credential that authenticates to your organization can read its audit logs.
+
+## Filter audit logs
+
+The API and SDKs use the same filters for search and export:
+
+- `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
+- `service` filters by the service that emitted the audit event.
+- `method` includes one HTTP method.
+- `exclude_method` excludes one or more HTTP methods, with up to 10 values.
+- `search` matches path, user ID, email, client IP, and status.
+- `search_user_id` adds up to 100 user IDs to the free-text search.
+
+The CLI exposes the same filters as flags. See the [audit log CLI reference](/reference/cli/audit-logs) for the full list.
 
 ## Search with the CLI
 
@@ -110,84 +128,9 @@ func main() {
 ```
 </CodeGroup>
 
-## Filter audit logs
+## Search with HTTP
 
-The API and SDKs use the same filters for search and export:
-
-- `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
-- `service` filters by the service that emitted the audit event.
-- `method` includes one HTTP method.
-- `exclude_method` excludes one or more HTTP methods, with up to 10 values.
-- `search` matches path, user ID, email, client IP, and status.
-- `search_user_id` adds up to 100 user IDs to the free-text search.
-
-<CodeGroup>
-```typescript TypeScript
-const logs = kernel.auditLogs.list({
-  start: '2026-06-01T00:00:00Z',
-  end: '2026-06-08T00:00:00Z',
-  limit: 50,
-  auth_strategy: 'api_key',
-  exclude_method: ['GET'],
-  search: '/browsers',
-});
-
-for await (const event of logs) {
-  console.log(event.email, event.client_ip, event.user_agent);
-}
-```
-
-```python Python
-logs = client.audit_logs.list(
-    start="2026-06-01T00:00:00Z",
-    end="2026-06-08T00:00:00Z",
-    limit=50,
-    auth_strategy="api_key",
-    exclude_method=["GET"],
-    search="/browsers",
-)
-
-for event in logs:
-    print(event.email, event.client_ip, event.user_agent)
-```
-
-```go Go
-package main
-
-import (
-	"context"
-	"fmt"
-	"time"
-
-	"github.com/kernel/kernel-go-sdk"
-)
-
-func main() {
-	ctx := context.Background()
-	client := kernel.NewClient()
-
-	pager := client.AuditLogs.ListAutoPaging(ctx, kernel.AuditLogListParams{
-		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
-		End:           time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
-		Limit:         kernel.Int(50),
-		AuthStrategy:  kernel.String("api_key"),
-		ExcludeMethod: []string{"GET"},
-		Search:        kernel.String("/browsers"),
-	})
-	for pager.Next() {
-		event := pager.Current()
-		fmt.Println(event.Email, event.ClientIP, event.UserAgent)
-	}
-	if err := pager.Err(); err != nil {
-		panic(err)
-	}
-}
-```
-</CodeGroup>
-
-## Page with HTTP
-
-The REST API returns pagination state in these response headers:
+Search over raw HTTP with a `GET` request. The response carries pagination state in these headers:
 
 - `X-Limit` is the page size applied to the request.
 - `X-Has-More` indicates whether older records remain.
@@ -211,14 +154,16 @@ curl --include --get https://api.onkernel.com/audit-logs \
   --data-urlencode "start=2026-06-01T00:00:00Z" \
   --data-urlencode "end=2026-06-02T00:00:00Z" \
   --data-urlencode "limit=100" \
-  --data-urlencode "page_token=$NEXT_PAGE_TOKEN"
+  --data-urlencode "page_token=<value from X-Next-Page-Token>"
 ```
 
 Page tokens are opaque. Don't decode, construct, or modify them.
 
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.
+
 ## Download an export with the CLI
 
-Use the CLI to download every chunk in a time window into one verified gzip-compressed JSONL file:
+The export workflow is exposed through the `kernel audit-logs download` command and the export-chunk API endpoint. Use the CLI to download every chunk in a time window into one verified gzip-compressed JSONL file:
 
 ```bash
 kernel audit-logs download \
@@ -227,48 +172,13 @@ kernel audit-logs download \
   --to audit-june.jsonl.gz
 ```
 
-The CLI:
-
-1. downloads up to 50,000 records per chunk,
-2. verifies each chunk against its `X-Content-Sha256` checksum,
-3. retries transient and integrity failures,
-4. writes to a temporary `.partial` file, and
-5. publishes the final file only after every chunk succeeds.
-
-Incomplete downloads are removed and don't resume across CLI runs. Rerunning the command starts the export again. Use `--force` to replace an existing output file.
+The download is all-or-nothing: the CLI verifies every chunk it receives and writes the output file only after the whole export succeeds. Incomplete downloads are removed and don't resume across CLI runs; rerunning the command starts the export again. Use `--force` to replace an existing output file. See the [audit log CLI reference](/reference/cli/audit-logs#download-behavior) for chunk sizes, checksums, and retry behavior.
 
 Like CLI search, CLI download excludes `GET` by default. Search and download accept the same filters.
 
-## Download an export chunk with HTTP
-
-The export API returns one chunk per request. Save the response headers separately from the binary body:
-
-```bash
-curl --fail-with-body --silent --show-error --get \
-  https://api.onkernel.com/audit-logs/export/chunk \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "format=jsonl.gz" \
-  --dump-header audit-logs-chunk.headers \
-  --output audit-logs-chunk.jsonl.gz
-```
-
-When `X-Has-More` is `true`, copy `X-Next-Cursor` and pass it unchanged to download the next chunk:
-
-```bash
-curl --fail-with-body --silent --show-error --get \
-  https://api.onkernel.com/audit-logs/export/chunk \
-  --header "Authorization: Bearer $KERNEL_API_KEY" \
-  --data-urlencode "start=2026-06-01T00:00:00Z" \
-  --data-urlencode "end=2026-06-02T00:00:00Z" \
-  --data-urlencode "format=jsonl.gz" \
-  --data-urlencode "cursor=$NEXT_CURSOR" \
-  --dump-header audit-logs-next-chunk.headers \
-  --output audit-logs-next-chunk.jsonl.gz
-```
-
 ## Download an export chunk with an SDK
+
+The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
 Save the response body exactly as returned, then inspect `X-Has-More`. When it is `true`, pass `X-Next-Cursor` as `cursor` on the next request.
 
@@ -358,10 +268,39 @@ func main() {
 ```
 </CodeGroup>
 
+## Download an export chunk with HTTP
+
+Save the response headers separately from the binary body:
+
+```bash
+curl --fail-with-body --silent --show-error --get \
+  https://api.onkernel.com/audit-logs/export/chunk \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "format=jsonl.gz" \
+  --dump-header audit-logs-chunk.headers \
+  --output audit-logs-chunk.jsonl.gz
+```
+
+When `X-Has-More` is `true`, copy `X-Next-Cursor` and pass it unchanged to download the next chunk:
+
+```bash
+curl --fail-with-body --silent --show-error --get \
+  https://api.onkernel.com/audit-logs/export/chunk \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "format=jsonl.gz" \
+  --data-urlencode "cursor=<value from X-Next-Cursor>" \
+  --dump-header audit-logs-next-chunk.headers \
+  --output audit-logs-next-chunk.jsonl.gz
+```
+
 <Warning>
-  SDK examples above download one chunk. A complete custom exporter must repeat requests until `X-Has-More` is `false`, persist the cursor only after safely writing a chunk, and verify `X-Content-Sha256` against the exact response bytes. Use the CLI when you don't need custom storage or processing.
+  The SDK and HTTP examples above download one chunk. A complete custom exporter must repeat requests until `X-Has-More` is `false`, persist the cursor only after safely writing a chunk, and verify `X-Content-Sha256` against the exact response bytes. Use the CLI when you don't need custom storage or processing.
 </Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 
-See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for the complete export contract and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -179,7 +179,7 @@ func main() {
 </CodeGroup>
 
 <Warning>
-If a download fails, the destination may contain a partial export. Write to a temporary file and rename it after success, or use the [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) for automatic cleanup and atomic replacement.
+If a download fails, the destination may contain a partial export. To publish only completed exports, write to a temporary file and atomically rename it after the download succeeds.
 </Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -5,16 +5,16 @@ description: "Search and export audit logs for API requests across your organiza
 
 Audit logs record authenticated API requests across your entire organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.
 
-Choose the workflow that matches the amount of data you need:
+Choose the endpoint that matches the amount of data you need:
 
-| Workflow | Best for | Output |
+| Endpoint | Best for | Output |
 |----------|----------|--------|
-| Search | Interactive investigation and recent activity | Paginated JSON events |
-| Export | Archival, compliance, and offline analysis | Gzip-compressed JSON Lines (`.jsonl.gz`) |
+| [Search](#search-audit-logs) | Interactive investigation and recent activity | Paginated JSON events |
+| [Export](#export-audit-logs) | Archival, compliance, and offline analysis | Gzip-compressed JSON Lines (`.jsonl.gz`) |
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
 
-Both workflows are also available from the [CLI](/reference/cli/audit-logs). For the underlying HTTP API, see [search](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) and [export](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) in the API reference.
+Both endpoints are also available from the [CLI](/reference/cli/audit-logs). For the underlying HTTP API, see [search](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) and [export](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) in the API reference.
 
 ## Filter audit logs
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -175,31 +175,37 @@ Like CLI search, CLI download excludes `GET` by default. Search and download acc
 
 The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
-Save the response body exactly as returned, then inspect `X-Has-More`. When it is `true`, pass `X-Next-Cursor` as `cursor` on the next request.
+Each chunk is a complete gzip stream, so appending each response body as-is produces one valid file. Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`:
 
 <CodeGroup>
 ```typescript TypeScript
-import { writeFile } from 'node:fs/promises';
+import { appendFile } from 'node:fs/promises';
 import Kernel from '@onkernel/sdk';
 
 const kernel = new Kernel({
   apiKey: process.env.KERNEL_API_KEY,
 });
 
-const response = await kernel.auditLogs.exportChunk({
-  start: '2026-06-01T00:00:00Z',
-  end: '2026-06-02T00:00:00Z',
-  format: 'jsonl.gz',
-  exclude_method: ['GET'],
-});
+let cursor: string | undefined;
+while (true) {
+  const response = await kernel.auditLogs.exportChunk({
+    start: '2026-06-01T00:00:00Z',
+    end: '2026-06-02T00:00:00Z',
+    format: 'jsonl.gz',
+    exclude_method: ['GET'],
+    cursor,
+  });
 
-await writeFile(
-  'audit-logs-chunk.jsonl.gz',
-  Buffer.from(await response.arrayBuffer()),
-);
+  await appendFile(
+    'audit-logs.jsonl.gz',
+    Buffer.from(await response.arrayBuffer()),
+  );
 
-console.log(response.headers.get('x-has-more'));
-console.log(response.headers.get('x-next-cursor'));
+  if (response.headers.get('x-has-more') !== 'true') {
+    break;
+  }
+  cursor = response.headers.get('x-next-cursor') ?? undefined;
+}
 ```
 
 ```python Python
@@ -208,16 +214,20 @@ from kernel import Kernel
 
 client = Kernel(api_key=os.environ["KERNEL_API_KEY"])
 
-response = client.audit_logs.export_chunk(
-    start="2026-06-01T00:00:00Z",
-    end="2026-06-02T00:00:00Z",
-    format="jsonl.gz",
-    exclude_method=["GET"],
-)
-response.write_to_file("audit-logs-chunk.jsonl.gz")
+params = {
+    "start": "2026-06-01T00:00:00Z",
+    "end": "2026-06-02T00:00:00Z",
+    "format": "jsonl.gz",
+    "exclude_method": ["GET"],
+}
 
-print(response.http_response.headers.get("x-has-more"))
-print(response.http_response.headers.get("x-next-cursor"))
+with open("audit-logs.jsonl.gz", "wb") as file:
+    while True:
+        response = client.audit_logs.export_chunk(**params)
+        file.write(response.read())
+        if response.http_response.headers.get("x-has-more") != "true":
+            break
+        params["cursor"] = response.http_response.headers.get("x-next-cursor")
 ```
 
 ```go Go
@@ -236,32 +246,41 @@ func main() {
 	ctx := context.Background()
 	client := kernel.NewClient()
 
-	response, err := client.AuditLogs.ExportChunk(ctx, kernel.AuditLogExportChunkParams{
-		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
-		End:           time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
-		Format:        kernel.AuditLogExportChunkParamsFormatJSONLGz,
-		ExcludeMethod: []string{"GET"},
-	})
-	if err != nil {
-		panic(err)
-	}
-	defer response.Body.Close()
-
-	file, err := os.Create("audit-logs-chunk.jsonl.gz")
+	file, err := os.Create("audit-logs.jsonl.gz")
 	if err != nil {
 		panic(err)
 	}
 	defer file.Close()
 
-	if _, err := io.Copy(file, response.Body); err != nil {
-		panic(err)
+	params := kernel.AuditLogExportChunkParams{
+		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:           time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
+		Format:        kernel.AuditLogExportChunkParamsFormatJSONLGz,
+		ExcludeMethod: []string{"GET"},
 	}
 
-	println(response.Header.Get("X-Has-More"))
-	println(response.Header.Get("X-Next-Cursor"))
+	for {
+		response, err := client.AuditLogs.ExportChunk(ctx, params)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.Copy(file, response.Body); err != nil {
+			panic(err)
+		}
+		response.Body.Close()
+
+		if response.Header.Get("X-Has-More") != "true" {
+			break
+		}
+		params.Cursor = kernel.String(response.Header.Get("X-Next-Cursor"))
+	}
 }
 ```
 </CodeGroup>
+
+<Warning>
+  A production exporter should persist the cursor only after safely writing a chunk and verify `X-Content-Sha256` against the exact response bytes.
+</Warning>
 
 ## Download an export chunk with HTTP
 
@@ -291,10 +310,6 @@ curl --fail-with-body --silent --show-error --get \
   --dump-header audit-logs-next-chunk.headers \
   --output audit-logs-next-chunk.jsonl.gz
 ```
-
-<Warning>
-  The SDK and HTTP examples above download one chunk. A complete custom exporter must repeat requests until `X-Has-More` is `false`, persist the cursor only after safely writing a chunk, and verify `X-Content-Sha256` against the exact response bytes. Use the CLI when you don't need custom storage or processing.
-</Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -78,7 +78,7 @@ func main() {
 
 ## Filter audit logs
 
-Use filters to narrow the time window to the events you need:
+Use filters to narrow results to the events you need:
 
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
@@ -156,7 +156,7 @@ func main() {
 The API returns the next cursor in the `X-Next-Page-Token` response header. Pass it back as `page_token` to read the next page.
 
 ```bash
-curl --get https://api.onkernel.com/audit-logs \
+curl --include --get https://api.onkernel.com/audit-logs \
   --header "Authorization: Bearer $KERNEL_API_KEY" \
   --data-urlencode "start=2026-06-01T00:00:00Z" \
   --data-urlencode "end=2026-06-02T00:00:00Z" \
@@ -164,7 +164,7 @@ curl --get https://api.onkernel.com/audit-logs \
 ```
 
 ```bash
-curl --get https://api.onkernel.com/audit-logs \
+curl --include --get https://api.onkernel.com/audit-logs \
   --header "Authorization: Bearer $KERNEL_API_KEY" \
   --data-urlencode "start=2026-06-01T00:00:00Z" \
   --data-urlencode "end=2026-06-02T00:00:00Z" \

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -46,7 +46,6 @@ const kernel = new Kernel({
 for await (const event of kernel.auditLogs.list({
   start: '2026-06-01T00:00:00Z',
   end: '2026-06-02T00:00:00Z',
-  limit: 100,
   method: 'POST',
 })) {
   console.log(event.timestamp, event.method, event.path, event.status);
@@ -62,7 +61,6 @@ client = Kernel(api_key=os.environ["KERNEL_API_KEY"])
 for event in client.audit_logs.list(
     start="2026-06-01T00:00:00Z",
     end="2026-06-02T00:00:00Z",
-    limit=100,
     method="POST",
 ):
     print(event.timestamp, event.method, event.path, event.status)
@@ -86,7 +84,6 @@ func main() {
 	pager := client.AuditLogs.ListAutoPaging(ctx, kernel.AuditLogListParams{
 		Start:  time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
 		End:    time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
-		Limit:  kernel.Int(100),
 		Method: kernel.String("POST"),
 	})
 	for pager.Next() {

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -105,7 +105,7 @@ The export API returns one chunk per request. Export paging uses a cursor rather
 
 Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`. With the `jsonl.gz` format, each chunk is an independent gzip member, and appending the members produces a valid gzip file. With `jsonl`, each chunk contains raw JSON Lines that you can also append.
 
-The following minimal examples write all chunks to one file. For a hardened export with checksum verification and retries, use the [CLI](/reference/cli/audit-logs#kernel-audit-logs-download).
+The SDK download helpers verify each chunk, retry transient transfer failures, and write the complete export to a destination you provide. They don't close the destination.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -118,23 +118,15 @@ const kernel = new Kernel({
 
 const file = await open('audit-logs.jsonl.gz', 'w');
 try {
-  let cursor: string | undefined;
-  while (true) {
-    const response = await kernel.auditLogs.exportChunk({
+  await kernel.auditLogs.download(
+    {
       start: '2026-06-01T00:00:00Z',
       end: '2026-06-02T00:00:00Z',
       format: 'jsonl.gz',
       exclude_method: ['GET'],
-      cursor,
-    });
-
-    await file.writeFile(Buffer.from(await response.arrayBuffer()));
-
-    if (response.headers.get('x-has-more') !== 'true') {
-      break;
-    }
-    cursor = response.headers.get('x-next-cursor') ?? undefined;
-  }
+    },
+    file,
+  );
 } finally {
   await file.close();
 }
@@ -146,20 +138,14 @@ from kernel import Kernel
 
 client = Kernel(api_key=os.environ["KERNEL_API_KEY"])
 
-params = {
-    "start": "2026-06-01T00:00:00Z",
-    "end": "2026-06-02T00:00:00Z",
-    "format": "jsonl.gz",
-    "exclude_method": ["GET"],
-}
-
 with open("audit-logs.jsonl.gz", "wb") as file:
-    while True:
-        response = client.audit_logs.export_chunk(**params)
-        file.write(response.read())
-        if response.headers.get("x-has-more") != "true":
-            break
-        params["cursor"] = response.headers.get("x-next-cursor")
+    client.audit_logs.download(
+        to=file,
+        start="2026-06-01T00:00:00Z",
+        end="2026-06-02T00:00:00Z",
+        format="jsonl.gz",
+        exclude_method=["GET"],
+    )
 ```
 
 ```go Go
@@ -167,7 +153,6 @@ package main
 
 import (
 	"context"
-	"io"
 	"os"
 	"time"
 
@@ -184,46 +169,20 @@ func main() {
 	}
 	defer file.Close()
 
-	params := kernel.AuditLogExportChunkParams{
+	_, err = client.AuditLogs.Download(ctx, kernel.AuditLogDownloadParams{
 		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
 		End:           time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
 		Format:        kernel.AuditLogExportChunkParamsFormatJSONLGz,
 		ExcludeMethod: []string{"GET"},
-	}
-
-	for {
-		response, err := client.AuditLogs.ExportChunk(ctx, params)
-		if err != nil {
-			panic(err)
-		}
-		_, copyErr := io.Copy(file, response.Body)
-		closeErr := response.Body.Close()
-		if copyErr != nil {
-			panic(copyErr)
-		}
-		if closeErr != nil {
-			panic(closeErr)
-		}
-
-		if response.Header.Get("X-Has-More") != "true" {
-			break
-		}
-		params.Cursor = kernel.String(response.Header.Get("X-Next-Cursor"))
+	}, file)
+	if err != nil {
+		panic(err)
 	}
 }
 ```
 </CodeGroup>
 
-<Warning>
-Don't use these minimal loops for production exports without these safeguards:
-
-- Buffer each chunk's exact response bytes and verify their SHA-256 hash against `X-Content-Sha256` before writing.
-- When `X-Has-More` is `true`, require a non-empty `X-Next-Cursor` that differs from the current cursor.
-- Persist the cursor only after the verified chunk is safely written.
-- Retry transient failures.
-
-The [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) implements these safeguards.
-</Warning>
+For atomic file replacement and cleanup after failed downloads, use the [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download).
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -23,7 +23,7 @@ The API and SDKs use the same filters for search and export:
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
 - `method` returns only requests that use the specified HTTP method.
-- `exclude_method` removes requests that use any of up to 10 specified HTTP methods.
+- `exclude_method` omits requests that use any of the specified HTTP methods.
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -9,10 +9,12 @@ Choose the workflow that matches the amount of data you need:
 
 | Workflow | Best for | Output |
 |----------|----------|--------|
-| Search | Interactive investigation and recent activity | A table, JSON array, or paginated SDK results |
+| Search | Interactive investigation and recent activity | Paginated JSON events |
 | Export | Archival, compliance, and offline analysis | JSON Lines (`.jsonl`) or gzip-compressed JSON Lines (`.jsonl.gz`) |
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
+
+Working from the terminal? Both workflows are also available in the CLI — see the [audit log CLI reference](/reference/cli/audit-logs).
 
 ## Filter audit logs
 
@@ -24,35 +26,6 @@ The API and SDKs use the same filters for search and export:
 - `exclude_method` excludes one or more HTTP methods, with up to 10 values.
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
-
-The CLI exposes the same filters as flags. See the [audit log CLI reference](/reference/cli/audit-logs) for the full list.
-
-## Search with the CLI
-
-Search the previous 24 hours:
-
-```bash
-kernel audit-logs search
-```
-
-Add a time window and filters:
-
-```bash
-kernel audit-logs search \
-  --start 2026-06-01 \
-  --end 2026-06-08 \
-  --search /browsers \
-  --limit 500 \
-  --output json
-```
-
-The CLI accepts RFC 3339 timestamps or `YYYY-MM-DD` dates. Date-only values represent midnight UTC.
-
-<Note>
-  The CLI excludes `GET` requests by default to reduce noise. Pass `--include-get` to include them, or `--method GET` to return only `GET` requests. The API and SDKs don't exclude `GET` unless you set `exclude_method`.
-</Note>
-
-See the [audit log CLI reference](/reference/cli/audit-logs) for all flags and defaults.
 
 ## Search with an SDK
 
@@ -156,22 +129,7 @@ Page tokens are opaque. Don't decode, construct, or modify them.
 
 See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.
 
-## Download an export with the CLI
-
-The export workflow is exposed through the `kernel audit-logs download` command and the export-chunk API endpoint. Use the CLI to download every chunk in a time window into one verified gzip-compressed JSONL file:
-
-```bash
-kernel audit-logs download \
-  --start 2026-06-01 \
-  --end 2026-07-01 \
-  --to audit-june.jsonl.gz
-```
-
-The download is all-or-nothing: the CLI verifies every chunk it receives and writes the output file only after the whole export succeeds. Incomplete downloads are removed and don't resume across CLI runs; rerunning the command starts the export again. Use `--force` to replace an existing output file. See the [audit log CLI reference](/reference/cli/audit-logs#download-behavior) for chunk sizes, checksums, and retry behavior.
-
-Like CLI search, CLI download excludes `GET` by default. Search and download accept the same filters.
-
-## Download an export chunk with an SDK
+## Export with an SDK
 
 The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
@@ -282,7 +240,7 @@ func main() {
   A production exporter should persist the cursor only after safely writing a chunk and verify `X-Content-Sha256` against the exact response bytes.
 </Warning>
 
-## Download an export chunk with HTTP
+## Export with HTTP
 
 Save the response headers separately from the binary body:
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -178,6 +178,6 @@ func main() {
 ```
 </CodeGroup>
 
-Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
+Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`.
 
 For direct HTTP integrations, see the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for pagination headers, formats, and the full request and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -25,7 +25,7 @@ The API and SDKs use the same filters for search and export:
 - `method` returns only requests that use the specified HTTP method.
 - `exclude_method` omits requests that use any of the specified HTTP methods.
 - `search` matches path, user ID, email, client IP, and status.
-- `search_user_id` adds up to 100 user IDs to the free-text search.
+- `search_user_id` matches requests from the specified user IDs in addition to any free-text matches.
 
 <Note>
 The API and SDKs include all methods unless you filter. Only the CLI excludes `GET` by default to reduce noise. Pass `--include-get` to remove that default exclusion, or pass `--method GET` to return only GET requests.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -43,6 +43,37 @@ for event in client.audit_logs.list(
 ):
     print(event.timestamp, event.method, event.path, event.status)
 ```
+
+```go Go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kernel/kernel-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+	client := kernel.NewClient()
+
+	pager := client.AuditLogs.ListAutoPaging(ctx, kernel.AuditLogListParams{
+		Start:  time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:    time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
+		Limit:  kernel.Int(100),
+		Method: kernel.String("POST"),
+	})
+	for pager.Next() {
+		event := pager.Current()
+		fmt.Println(event.Timestamp, event.Method, event.Path, event.Status)
+	}
+	if err := pager.Err(); err != nil {
+		panic(err)
+	}
+}
+```
 </CodeGroup>
 
 ## Filter audit logs
@@ -84,6 +115,39 @@ logs = client.audit_logs.list(
 
 for event in logs:
     print(event.email, event.client_ip, event.user_agent)
+```
+
+```go Go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kernel/kernel-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+	client := kernel.NewClient()
+
+	pager := client.AuditLogs.ListAutoPaging(ctx, kernel.AuditLogListParams{
+		Start:        time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:          time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
+		Limit:        kernel.Int(50),
+		AuthStrategy: kernel.String("api_key"),
+		ExcludeMethod: kernel.String("GET"),
+		Search:       kernel.String("/browsers"),
+	})
+	for pager.Next() {
+		event := pager.Current()
+		fmt.Println(event.Email, event.ClientIP, event.UserAgent)
+	}
+	if err := pager.Err(); err != nil {
+		panic(err)
+	}
+}
 ```
 </CodeGroup>
 

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -14,7 +14,7 @@ Choose the workflow that matches the amount of data you need:
 
 Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
 
-Both workflows are also available in the [CLI](/reference/cli/audit-logs), and the API reference documents the raw HTTP contract for [search](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) and [export](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk).
+Both workflows are also available from the [CLI](/reference/cli/audit-logs). For the underlying HTTP API, see [search](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) and [export](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) in the API reference.
 
 ## Filter audit logs
 
@@ -22,10 +22,14 @@ The API and SDKs use the same filters for search and export:
 
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
-- `method` includes one HTTP method.
-- `exclude_method` excludes one or more HTTP methods, with up to 10 values.
+- `method` includes one HTTP method. In the CLI, passing any method disables the default GET exclusion.
+- `exclude_method` excludes one or more HTTP methods in addition to the default CLI exclusion, with up to 10 values.
 - `search` matches path, user ID, email, client IP, and status.
 - `search_user_id` adds up to 100 user IDs to the free-text search.
+
+<Note>
+The CLI excludes `GET` by default to reduce noise; the API and SDKs include all methods unless you filter. Use `--include-get` in the CLI or omit `exclude_method: ["GET"]` in SDKs to include them.
+</Note>
 
 ## Search audit logs
 
@@ -96,13 +100,13 @@ func main() {
 ```
 </CodeGroup>
 
-See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the full request and response schema.
 
 ## Export audit logs
 
 The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
 
-Each chunk is a complete gzip stream, so appending each response body as-is produces one valid file. Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`:
+Each chunk is a complete gzip stream, so appending each response body as-is produces one valid file. Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`. This matches the CLI download behavior, which verifies `X-Content-Sha256` and retries transient failures:
 
 <CodeGroup>
 ```typescript TypeScript
@@ -211,4 +215,4 @@ func main() {
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 
-See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for the complete export contract and response schema.
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for the full request and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -101,11 +101,14 @@ See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-aud
 
 ## Export audit logs
 
-The export API returns one chunk per request. Export paging uses a cursor rather than the page token used by search; both are opaque values you pass back unchanged.
+The SDK download helpers write a complete export to a destination you provide. They:
 
-Repeat requests until `X-Has-More` is `false`, passing `X-Next-Cursor` back as `cursor`. With the `jsonl.gz` format, each chunk is an independent gzip member, and appending the members produces a valid gzip file. With `jsonl`, each chunk contains raw JSON Lines that you can also append.
+- request every chunk until the export is complete
+- validate pagination metadata and each chunk's SHA-256 checksum before writing
+- retry transient HTTP and transfer failures
+- append verified chunks in order
 
-The SDK download helpers verify each chunk, retry transient transfer failures, and write the complete export to a destination you provide. They don't close the destination.
+The helpers don't close the destination. Python provides equivalent sync and async methods; both accept a synchronous binary destination.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -182,8 +185,10 @@ func main() {
 ```
 </CodeGroup>
 
-For atomic file replacement and cleanup after failed downloads, use the [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download).
+<Warning>
+If a download fails, the destination may contain a partial export. Write to a temporary file and rename it after success, or use the [CLI download command](/reference/cli/audit-logs#kernel-audit-logs-download) for automatic cleanup and atomic replacement.
+</Warning>
 
 Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
 
-See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for the full request and response schema.
+For direct HTTP integrations, see the [API reference](https://kernel.sh/docs/api-reference/audit-logs/download-an-audit-log-export-chunk) for pagination headers, formats, and the full request and response schema.

--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -1,17 +1,49 @@
 ---
 title: "Audit Logs"
-description: "List organization API request audit events"
+description: "Search and export organization API request audit events"
 ---
 
 Audit logs record authenticated API requests for your organization. Use them to review who called Kernel, which endpoint they called, when the request happened, and how the request completed.
 
-Audit logs are ordered newest first. The `start` timestamp is inclusive, the `end` timestamp is exclusive, and each request can cover up to 30 days. Each page returns up to 100 events.
+Choose the workflow that matches the amount of data you need:
 
-<Info>Keep each audit log request to a 30-day range or less. For longer investigations, split the query into multiple time windows.</Info>
+| Workflow | Best for | Output |
+|---|---|---|
+| Search | Interactive investigation and recent activity | A table, JSON array, or paginated SDK results |
+| Export | Archival, compliance, and offline analysis | JSON Lines (`.jsonl`) or gzip-compressed JSON Lines (`.jsonl.gz`) |
 
-## List audit logs
+Audit logs are ordered newest first. Time windows use an inclusive `start` and exclusive `end`: `[start, end)`. A search or export can cover up to 30 days. Split longer periods into multiple time windows.
 
-Use the SDKs to page through logs for a time window.
+## Search with the CLI
+
+Search the previous 24 hours:
+
+```bash
+kernel audit-logs search
+```
+
+Add a time window and filters:
+
+```bash
+kernel audit-logs search \
+  --start 2026-06-01 \
+  --end 2026-06-08 \
+  --search /browsers \
+  --limit 500 \
+  --output json
+```
+
+The CLI accepts RFC 3339 timestamps or `YYYY-MM-DD` dates. Date-only values represent midnight UTC.
+
+<Note>
+  The CLI excludes `GET` requests by default to reduce noise. Pass `--include-get` to include them, or `--method GET` to return only `GET` requests. The API and SDKs don't exclude `GET` unless you set `exclude_method`.
+</Note>
+
+See the [audit log CLI reference](/reference/cli/audit-logs) for all flags and defaults.
+
+## Search with an SDK
+
+Each API page contains up to 100 events. The SDK pagination helpers request older pages as you iterate.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -80,14 +112,14 @@ func main() {
 
 ## Filter audit logs
 
-Use filters to narrow results to the events you need:
+The API and SDKs use the same filters for search and export:
 
 - `auth_strategy` filters by authentication method, such as `api_key`, `dashboard`, or `oauth`.
 - `service` filters by the service that emitted the audit event.
-- `method` filters by HTTP method.
-- `exclude_method` excludes a single HTTP method.
+- `method` includes one HTTP method.
+- `exclude_method` excludes one or more HTTP methods, with up to 10 values.
 - `search` matches path, user ID, email, client IP, and status.
-- `search_user_id` adds one or more user IDs to the search.
+- `search_user_id` adds up to 100 user IDs to the free-text search.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -96,7 +128,7 @@ const logs = kernel.auditLogs.list({
   end: '2026-06-08T00:00:00Z',
   limit: 50,
   auth_strategy: 'api_key',
-  exclude_method: 'GET',
+  exclude_method: ['GET'],
   search: '/browsers',
 });
 
@@ -111,7 +143,7 @@ logs = client.audit_logs.list(
     end="2026-06-08T00:00:00Z",
     limit=50,
     auth_strategy="api_key",
-    exclude_method="GET",
+    exclude_method=["GET"],
     search="/browsers",
 )
 
@@ -135,12 +167,12 @@ func main() {
 	client := kernel.NewClient()
 
 	pager := client.AuditLogs.ListAutoPaging(ctx, kernel.AuditLogListParams{
-		Start:        time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
-		End:          time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
-		Limit:        kernel.Int(50),
-		AuthStrategy: kernel.String("api_key"),
-		ExcludeMethod: kernel.String("GET"),
-		Search:       kernel.String("/browsers"),
+		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:           time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC),
+		Limit:         kernel.Int(50),
+		AuthStrategy:  kernel.String("api_key"),
+		ExcludeMethod: []string{"GET"},
+		Search:        kernel.String("/browsers"),
 	})
 	for pager.Next() {
 		event := pager.Current()
@@ -155,7 +187,13 @@ func main() {
 
 ## Page with HTTP
 
-The API returns the next cursor in the `X-Next-Page-Token` response header. Pass it back as `page_token` to read the next page.
+The REST API returns pagination state in these response headers:
+
+- `X-Limit` is the page size applied to the request.
+- `X-Has-More` indicates whether older records remain.
+- `X-Next-Page-Token` contains the opaque token for the next page.
+
+Request the first page:
 
 ```bash
 curl --include --get https://api.onkernel.com/audit-logs \
@@ -165,32 +203,165 @@ curl --include --get https://api.onkernel.com/audit-logs \
   --data-urlencode "limit=100"
 ```
 
+If `X-Has-More` is `true`, copy the `X-Next-Page-Token` value and pass it unchanged:
+
 ```bash
 curl --include --get https://api.onkernel.com/audit-logs \
   --header "Authorization: Bearer $KERNEL_API_KEY" \
   --data-urlencode "start=2026-06-01T00:00:00Z" \
   --data-urlencode "end=2026-06-02T00:00:00Z" \
   --data-urlencode "limit=100" \
-  --data-urlencode "page_token=eyJ0IjoiMjAyNi0wNi0wMVQyMzo1OTo1OS43NDUxMjNaIn0"
+  --data-urlencode "page_token=$NEXT_PAGE_TOKEN"
 ```
 
-Use `X-Has-More: true` to decide whether to continue paging. Page tokens are opaque; store and pass them exactly as returned.
+Page tokens are opaque. Don't decode, construct, or modify them.
 
-## Response fields
+## Download an export with the CLI
 
-Each audit log entry includes:
+Use the CLI to download every chunk in a time window into one verified gzip-compressed JSONL file:
 
-- `timestamp`
-- `auth_strategy`
-- `user_id`
-- `email`
-- `status`
-- `method`
-- `path`
-- `route`
-- `domain`
-- `duration_ms`
-- `client_ip`
-- `user_agent`
+```bash
+kernel audit-logs download \
+  --start 2026-06-01 \
+  --end 2026-07-01 \
+  --to audit-june.jsonl.gz
+```
 
-See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the full request and response schema.
+The CLI:
+
+1. downloads up to 50,000 records per chunk,
+2. verifies each chunk against its `X-Content-Sha256` checksum,
+3. retries transient and integrity failures,
+4. writes to a temporary `.partial` file, and
+5. publishes the final file only after every chunk succeeds.
+
+Incomplete downloads are removed and don't resume across CLI runs. Rerunning the command starts the export again. Use `--force` to replace an existing output file.
+
+Like CLI search, CLI download excludes `GET` by default. Search and download accept the same filters.
+
+## Download an export chunk with HTTP
+
+The export API returns one chunk per request. Save the response headers separately from the binary body:
+
+```bash
+curl --fail-with-body --silent --show-error --get \
+  https://api.onkernel.com/audit-logs/export/chunk \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "format=jsonl.gz" \
+  --dump-header audit-logs-chunk.headers \
+  --output audit-logs-chunk.jsonl.gz
+```
+
+When `X-Has-More` is `true`, copy `X-Next-Cursor` and pass it unchanged to download the next chunk:
+
+```bash
+curl --fail-with-body --silent --show-error --get \
+  https://api.onkernel.com/audit-logs/export/chunk \
+  --header "Authorization: Bearer $KERNEL_API_KEY" \
+  --data-urlencode "start=2026-06-01T00:00:00Z" \
+  --data-urlencode "end=2026-06-02T00:00:00Z" \
+  --data-urlencode "format=jsonl.gz" \
+  --data-urlencode "cursor=$NEXT_CURSOR" \
+  --dump-header audit-logs-next-chunk.headers \
+  --output audit-logs-next-chunk.jsonl.gz
+```
+
+## Download an export chunk with an SDK
+
+Save the response body exactly as returned, then inspect `X-Has-More`. When it is `true`, pass `X-Next-Cursor` as `cursor` on the next request.
+
+<CodeGroup>
+```typescript TypeScript
+import { writeFile } from 'node:fs/promises';
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel({
+  apiKey: process.env.KERNEL_API_KEY,
+});
+
+const response = await kernel.auditLogs.exportChunk({
+  start: '2026-06-01T00:00:00Z',
+  end: '2026-06-02T00:00:00Z',
+  format: 'jsonl.gz',
+  exclude_method: ['GET'],
+});
+
+await writeFile(
+  'audit-logs-chunk.jsonl.gz',
+  Buffer.from(await response.arrayBuffer()),
+);
+
+console.log(response.headers.get('x-has-more'));
+console.log(response.headers.get('x-next-cursor'));
+```
+
+```python Python
+import os
+from kernel import Kernel
+
+client = Kernel(api_key=os.environ["KERNEL_API_KEY"])
+
+response = client.audit_logs.export_chunk(
+    start="2026-06-01T00:00:00Z",
+    end="2026-06-02T00:00:00Z",
+    format="jsonl.gz",
+    exclude_method=["GET"],
+)
+response.write_to_file("audit-logs-chunk.jsonl.gz")
+
+print(response.http_response.headers.get("x-has-more"))
+print(response.http_response.headers.get("x-next-cursor"))
+```
+
+```go Go
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kernel/kernel-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+	client := kernel.NewClient()
+
+	response, err := client.AuditLogs.ExportChunk(ctx, kernel.AuditLogExportChunkParams{
+		Start:         time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:           time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
+		Format:        kernel.AuditLogExportChunkParamsFormatJSONLGz,
+		ExcludeMethod: []string{"GET"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	file, err := os.Create("audit-logs-chunk.jsonl.gz")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, response.Body); err != nil {
+		panic(err)
+	}
+
+	println(response.Header.Get("X-Has-More"))
+	println(response.Header.Get("X-Next-Cursor"))
+}
+```
+</CodeGroup>
+
+<Warning>
+  SDK examples above download one chunk. A complete custom exporter must repeat requests until `X-Has-More` is `false`, persist the cursor only after safely writing a chunk, and verify `X-Content-Sha256` against the exact response bytes. Use the CLI when you don't need custom storage or processing.
+</Warning>
+
+Export chunks contain one JSON object per line. They use the same fields as search results and add `event_id`, which provides a stable tie-breaker when multiple events share a timestamp.
+
+See the [API reference](https://kernel.sh/docs/api-reference/audit-logs/list-audit-logs) for the complete search contract and response schema.

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -61,6 +61,9 @@ kernel --version
   <Card icon="key" title="API Keys" href="/reference/cli/api-keys">
     Create, list, rename, and delete API keys.
   </Card>
+  <Card icon="clock-rotate-left" title="Audit Logs" href="/reference/cli/audit-logs">
+    Search and download organization audit logs.
+  </Card>
 </Columns>
 
 ## Quick Start

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -51,7 +51,7 @@ kernel audit-logs search --method GET
 
 ## `kernel audit-logs download`
 
-Download every audit log in a time window as one gzip-compressed JSONL file.
+Download matching audit logs in a time window as one gzip-compressed JSONL file.
 
 ```bash
 kernel audit-logs download \
@@ -84,7 +84,7 @@ The command downloads up to 50,000 records at a time and appends each chunk to `
 
 A chunk is attempted up to seven times when a network error, HTTP `429`, HTTP `5xx`, truncated response, or checksum mismatch occurs. Retries use exponential backoff capped at eight seconds.
 
-The CLI renames the temporary file to the requested output only after every chunk succeeds. If the download fails, it removes the incomplete temporary file. Downloads don't resume across CLI runs; rerunning the command starts again from the beginning.
+The CLI renames the temporary file to the requested output only after every chunk transfers successfully. If a transfer fails, it removes the incomplete temporary file. If the final rename fails, the completed download remains at `<output>.partial`. Downloads don't resume across CLI runs; rerunning the command starts again from the beginning.
 
 The command refuses to replace an existing output unless you pass `--force`.
 

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -4,6 +4,8 @@ title: "Audit Logs"
 
 Search and download [organization audit logs](/info/audit-logs) from the CLI.
 
+Time values can be dates (`2026-06-01`) or timestamps (`2026-06-01T15:04:05Z`). Dates begin at midnight UTC.
+
 ## `kernel audit-logs search`
 
 Search audit logs within a time window. Results are ordered newest first.
@@ -18,8 +20,6 @@ kernel audit-logs search \
 ```
 
 If you omit the time flags, the command searches from 24 hours ago through now. The start is inclusive and the end is exclusive. Each time window can cover up to 30 days.
-
-For time values, use a date like `2026-06-01`, a UTC timestamp like `2026-06-01T15:04:05Z`, or a timestamp with an offset like `2026-06-01T11:04:05-04:00`. Dates begin at midnight UTC.
 
 | Flag | Description |
 |------|-------------|
@@ -63,8 +63,6 @@ kernel audit-logs download \
 ```
 
 `--start` and `--end` are required. The start is inclusive and the end is exclusive, and the time window can cover up to 30 days.
-
-For time values, use a date like `2026-06-01`, a UTC timestamp like `2026-06-01T15:04:05Z`, or a timestamp with an offset like `2026-06-01T11:04:05-04:00`. Dates begin at midnight UTC.
 
 | Flag | Description |
 |------|-------------|

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -80,13 +80,11 @@ Date-only values represent midnight UTC. For example, `--start 2026-06-01 --end 
 
 ### Download behavior
 
-The command downloads up to 50,000 records at a time and appends each chunk to `<output>.partial`. Before writing a chunk, it verifies the SHA-256 checksum returned by the API.
+The CLI downloads up to 50,000 records per batch, verifies each batch's SHA-256 checksum, and automatically retries transient failures.
 
-A chunk is attempted up to seven times when a network error, HTTP `429`, HTTP `5xx`, truncated response, or checksum mismatch occurs. Retries use exponential backoff capped at eight seconds.
+The requested output appears only after the full download succeeds. Failed downloads are removed, though a completed download may remain at `<output>.partial` if it can't be moved to the requested path.
 
-The CLI renames the temporary file to the requested output only after every chunk transfers successfully. If a transfer fails, it removes the incomplete temporary file. If the final rename fails, the completed download remains at `<output>.partial`. Downloads don't resume across CLI runs; rerunning the command starts again from the beginning.
-
-The command refuses to replace an existing output unless you pass `--force`.
+Downloads don't resume: rerunning the command starts over. Existing files are replaced only when you pass `--force`.
 
 ## Aliases
 

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -24,9 +24,9 @@ If you omit the time flags, the command searches from 24 hours ago through now. 
 | `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Defaults to 24 hours ago. |
 | `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Defaults to now. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
-| `--method <method>` | Return one HTTP method. Passing any method disables the default GET exclusion. |
-| `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
-| `--include-get` | Include GET requests, which are excluded by default. |
+| `--method <method>` | Return only requests that use this HTTP method. |
+| `--exclude-method <method>` | Exclude requests that use this HTTP method. GET remains excluded unless you pass `--include-get`. |
+| `--include-get` | Remove the default GET exclusion when `--method` is not set. |
 | `--service <service>` | Filter by service. |
 | `--auth-strategy <strategy>` | Filter by authentication strategy. |
 | `--user-id <id>` | Add a user ID to the search. Repeat the flag for multiple IDs. |
@@ -39,10 +39,10 @@ If you omit the time flags, the command searches from 24 hours ago through now. 
 
 ### Include GET requests
 
-GET requests are excluded by default to reduce noise:
+By default, the CLI returns matching requests for every HTTP method except GET. `--include-get` removes that default exclusion. `--method` selects exactly one method, so `--method GET` returns only GET requests.
 
 ```bash
-# Include GET alongside every other method
+# Return all matching methods, including GET
 kernel audit-logs search --include-get
 
 # Return only GET requests
@@ -67,9 +67,9 @@ kernel audit-logs download \
 | `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Required. |
 | `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Required. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
-| `--method <method>` | Return one HTTP method. Passing any method disables the default GET exclusion. |
-| `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
-| `--include-get` | Include GET requests, which are excluded by default. |
+| `--method <method>` | Return only requests that use this HTTP method. |
+| `--exclude-method <method>` | Exclude requests that use this HTTP method. GET remains excluded unless you pass `--include-get`. |
+| `--include-get` | Remove the default GET exclusion when `--method` is not set. |
 | `--service <service>` | Filter by service. |
 | `--auth-strategy <strategy>` | Filter by authentication strategy. |
 | `--user-id <id>` | Add a user ID to the search. Repeat the flag for multiple IDs. |

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -31,7 +31,7 @@ If you omit the time flags, the command searches from 24 hours ago through now. 
 | `--auth-strategy <strategy>` | Filter by authentication strategy. |
 | `--user-id <id>` | Add a user ID to the search. Repeat the flag for multiple IDs. |
 | `--limit <n>` | Maximum total number of results. Defaults to `100`. |
-| `--output json`, `-o json` | Return a JSON array instead of a table. |
+| `--output json`, `-o json` | Output raw JSON array. |
 
 <Note>
   `--limit` controls the total number of CLI results. The CLI automatically requests API pages of up to 100 records until it reaches that limit or runs out of results.

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -1,0 +1,93 @@
+---
+title: "Audit Logs"
+---
+
+Search and download [organization audit logs](/info/audit-logs) from the CLI.
+
+## `kernel audit-logs search`
+
+Search audit logs within a time window. Results are ordered newest first.
+
+```bash
+kernel audit-logs search \
+  --start 2026-06-01 \
+  --end 2026-06-08 \
+  --search /browsers \
+  --limit 500 \
+  --output json
+```
+
+If you omit the time flags, the command searches from 24 hours ago through now. The start is inclusive and the end is exclusive. Each time window can cover up to 30 days.
+
+| Flag | Description |
+|---|---|
+| `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Defaults to 24 hours ago. |
+| `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Defaults to now. |
+| `--search <text>` | Search path, user ID, email, client IP, and status. |
+| `--method <method>` | Return one HTTP method. Passing `GET` also overrides the default GET exclusion. |
+| `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
+| `--include-get` | Include GET requests, which are excluded by default. |
+| `--service <service>` | Filter by service. |
+| `--auth-strategy <strategy>` | Filter by authentication strategy. |
+| `--user-id <id>` | Add a user ID to the search. Repeat the flag for multiple IDs. |
+| `--limit <n>` | Maximum total number of results. Defaults to `100`. |
+| `--output json`, `-o json` | Return a JSON array instead of a table. |
+
+<Note>
+  `--limit` controls the total number of CLI results. The CLI automatically requests API pages of up to 100 records until it reaches that limit or runs out of results.
+</Note>
+
+### Include GET requests
+
+GET requests are excluded by default to reduce noise:
+
+```bash
+# Include GET alongside every other method
+kernel audit-logs search --include-get
+
+# Return only GET requests
+kernel audit-logs search --method GET
+```
+
+## `kernel audit-logs download`
+
+Download every audit log in a time window as one gzip-compressed JSONL file.
+
+```bash
+kernel audit-logs download \
+  --start 2026-06-01 \
+  --end 2026-07-01 \
+  --to audit-june.jsonl.gz
+```
+
+`--start` and `--end` are required. The start is inclusive and the end is exclusive, and the time window can cover up to 30 days.
+
+| Flag | Description |
+|---|---|
+| `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Required. |
+| `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Required. |
+| `--search <text>` | Search path, user ID, email, client IP, and status. |
+| `--method <method>` | Return one HTTP method. Passing `GET` also overrides the default GET exclusion. |
+| `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
+| `--include-get` | Include GET requests, which are excluded by default. |
+| `--service <service>` | Filter by service. |
+| `--auth-strategy <strategy>` | Filter by authentication strategy. |
+| `--user-id <id>` | Add a user ID to the search. Repeat the flag for multiple IDs. |
+| `--to <path>` | Output `.jsonl.gz` path. For the example above, the default is `audit-logs-20260601-20260701.jsonl.gz`. |
+| `--force` | Replace an existing output file. |
+
+Date-only values represent midnight UTC. For example, `--start 2026-06-01 --end 2026-07-01` covers all of June in UTC.
+
+### Download behavior
+
+The command downloads up to 50,000 records at a time and appends each chunk to `<output>.partial`. Before writing a chunk, it verifies the SHA-256 checksum returned by the API.
+
+A chunk is attempted up to seven times when a network error, HTTP `429`, HTTP `5xx`, truncated response, or checksum mismatch occurs. Retries use exponential backoff capped at eight seconds.
+
+The CLI renames the temporary file to the requested output only after every chunk succeeds. If the download fails, it removes the incomplete temporary file. Downloads don't resume across CLI runs; rerunning the command starts again from the beginning.
+
+The command refuses to replace an existing output unless you pass `--force`.
+
+## Aliases
+
+You can also use `kernel audit-log`, `kernel auditlogs`, or `kernel auditlog`.

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -19,10 +19,12 @@ kernel audit-logs search \
 
 If you omit the time flags, the command searches from 24 hours ago through now. The start is inclusive and the end is exclusive. Each time window can cover up to 30 days.
 
+For time values, use a date like `2026-06-01`, a UTC timestamp like `2026-06-01T15:04:05Z`, or a timestamp with an offset like `2026-06-01T11:04:05-04:00`. Dates begin at midnight UTC.
+
 | Flag | Description |
 |------|-------------|
-| `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Defaults to 24 hours ago. |
-| `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Defaults to now. |
+| `--start <time>` | Inclusive start. Defaults to 24 hours ago. |
+| `--end <time>` | Exclusive end. Defaults to now. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
 | `--method <method>` | Return only requests that use this HTTP method. |
 | `--exclude-method <method>` | Exclude requests that use this HTTP method. GET remains excluded unless you pass `--include-get`. |
@@ -62,10 +64,12 @@ kernel audit-logs download \
 
 `--start` and `--end` are required. The start is inclusive and the end is exclusive, and the time window can cover up to 30 days.
 
+For time values, use a date like `2026-06-01`, a UTC timestamp like `2026-06-01T15:04:05Z`, or a timestamp with an offset like `2026-06-01T11:04:05-04:00`. Dates begin at midnight UTC.
+
 | Flag | Description |
 |------|-------------|
-| `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Required. |
-| `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Required. |
+| `--start <time>` | Inclusive start. Required. |
+| `--end <time>` | Exclusive end. Required. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
 | `--method <method>` | Return only requests that use this HTTP method. |
 | `--exclude-method <method>` | Exclude requests that use this HTTP method. GET remains excluded unless you pass `--include-get`. |
@@ -76,7 +80,7 @@ kernel audit-logs download \
 | `--to <path>` | Output `.jsonl.gz` path. For the example above, the default is `audit-logs-20260601-20260701.jsonl.gz`. |
 | `--force` | Replace an existing output file. |
 
-Date-only values represent midnight UTC. For example, `--start 2026-06-01 --end 2026-07-01` covers all of June in UTC.
+For example, `--start 2026-06-01 --end 2026-07-01` covers all of June in UTC.
 
 ### Download behavior
 

--- a/reference/cli/audit-logs.mdx
+++ b/reference/cli/audit-logs.mdx
@@ -20,11 +20,11 @@ kernel audit-logs search \
 If you omit the time flags, the command searches from 24 hours ago through now. The start is inclusive and the end is exclusive. Each time window can cover up to 30 days.
 
 | Flag | Description |
-|---|---|
+|------|-------------|
 | `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Defaults to 24 hours ago. |
 | `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Defaults to now. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
-| `--method <method>` | Return one HTTP method. Passing `GET` also overrides the default GET exclusion. |
+| `--method <method>` | Return one HTTP method. Passing any method disables the default GET exclusion. |
 | `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
 | `--include-get` | Include GET requests, which are excluded by default. |
 | `--service <service>` | Filter by service. |
@@ -63,11 +63,11 @@ kernel audit-logs download \
 `--start` and `--end` are required. The start is inclusive and the end is exclusive, and the time window can cover up to 30 days.
 
 | Flag | Description |
-|---|---|
+|------|-------------|
 | `--start <time>` | Inclusive start, as RFC 3339 or `YYYY-MM-DD`. Required. |
 | `--end <time>` | Exclusive end, as RFC 3339 or `YYYY-MM-DD`. Required. |
 | `--search <text>` | Search path, user ID, email, client IP, and status. |
-| `--method <method>` | Return one HTTP method. Passing `GET` also overrides the default GET exclusion. |
+| `--method <method>` | Return one HTTP method. Passing any method disables the default GET exclusion. |
 | `--exclude-method <method>` | Exclude an HTTP method in addition to the default GET exclusion. |
 | `--include-get` | Include GET requests, which are excluded by default. |
 | `--service <service>` | Filter by service. |


### PR DESCRIPTION
## Summary

- add a task-oriented audit log guide for CLI, SDK, and HTTP search and export workflows
- add a complete `kernel audit-logs` CLI command reference and navigation entry
- document search pagination, export cursors, time-window semantics, filters, chunk limits, checksums, retries, and partial-file behavior
- correct SDK `exclude_method` examples and replace the fabricated page token with an opaque response token

## Rollout

Merge after a published CLI release contains `kernel audit-logs download` and published SDK releases include the complete download helpers:

- [Go SDK #138](https://github.com/kernel/kernel-go-sdk/pull/138)
- [TypeScript SDK #144](https://github.com/kernel/kernel-node-sdk/pull/144)
- [Python SDK #133](https://github.com/kernel/kernel-python-sdk/pull/133)

The CLI behavior is unchanged.

## Testing

- `mint broken-links`
- rendered `/info/audit-logs` and `/reference/cli/audit-logs` with the local Mintlify preview
- `go test ./cmd -run AuditLogs` in the CLI repository
- compiled the Go SDK download example against the helper branch
- ran the TypeScript and Python download examples through their SDK test suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and navigation only; no runtime, auth, or API behavior changes in this repo.
> 
> **Overview**
> Adds **audit log documentation** for org-wide API request history: a new **Guides** page at `/info/audit-logs` and a **CLI reference** at `/reference/cli/audit-logs`, wired into `docs.json` and the CLI overview card grid.
> 
> The guide contrasts **search** (paginated JSON, SDK `list` / auto-paging) vs **export** (`.jsonl.gz`, SDK `download` with chunking, SHA-256 verification, and retries). It documents shared filters, `[start, end)` time windows (max 30 days), and TypeScript/Python/Go examples—including **`exclude_method`** on export.
> 
> The CLI reference covers **`kernel audit-logs search`** (default last 24h, GET excluded unless `--include-get`, `--limit` with internal paging) and **`kernel audit-logs download`** (required window, batch limits, checksums, `.partial` on move failure, no resume, `--force`), plus command aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3c3aefd6ec4e8596425bd2a558ac4dbcc32b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

