### PR TITLE
Document direct project and extension lookups

### DIFF
--- a/browsers/extensions.mdx
+++ b/browsers/extensions.mdx
@@ -44,6 +44,9 @@ kernel extensions upload ./my-extension --name my-extension
 Extensions uploaded to Kernel are assigned a random ID, but you can also give them a name for easier reference.
 This name must be unique within your [project](/info/projects).
 
+To retrieve an extension's metadata without downloading the archive, call `GET /extensions/{id_or_name}/metadata`.
+The response includes the extension's ID, name, size, and timestamps.
+
 ## Using extensions in a browser
 
 Passing the extension name or ID to the `create` method will load it into the browser.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,17 +9,6 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
-<Update label="June 23" tags={["Product", "Docs"]}>
-## Product updates
-
-- Project lookups now accept either ID or name on `GET /org/projects/{id}`, so you can resolve a named project without paging through the project list.
-- Added `GET /extensions/{id_or_name}/metadata` to return extension metadata by ID or name without downloading the archive.
-
-## Documentation updates
-
-- Updated the [Projects](/info/projects) page and [Extensions](/browsers/extensions) guide with the new direct lookup behavior.
-</Update>
-
 <Update label="June 12" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,17 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="June 23" tags={["Product", "Docs"]}>
+## Product updates
+
+- Project lookups now accept either ID or name on `GET /org/projects/{id}`, so you can resolve a named project without paging through the project list.
+- Added `GET /extensions/{id_or_name}/metadata` to return extension metadata by ID or name without downloading the archive.
+
+## Documentation updates
+
+- Updated the [Projects](/info/projects) page and [Extensions](/browsers/extensions) guide with the new direct lookup behavior.
+</Update>
+
 <Update label="June 12" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -165,7 +165,7 @@ Use the `/org/projects` REST endpoints (or the SDKs' `projects` resource) to man
 | --- | --- | --- |
 | `GET` | `/org/projects` | List projects in the organization |
 | `POST` | `/org/projects` | Create a project |
-| `GET` | `/org/projects/{id}` | Get a project by ID |
+| `GET` | `/org/projects/{id}` | Get a project by ID or name |
 | `PATCH` | `/org/projects/{id}` | Update a project's name or status (`active` / `archived`) |
 | `DELETE` | `/org/projects/{id}` | Delete a project (must be empty and not the last active project) |
 
@@ -241,6 +241,30 @@ for pager.Next() {
 if err := pager.Err(); err != nil {
 	panic(err)
 }
+```
+</CodeGroup>
+
+### Get a project
+
+Project names are unique within an organization. You can retrieve a project by its ID or by its name.
+
+<CodeGroup>
+```typescript TypeScript
+const project = await kernel.projects.get('staging');
+console.log(project.id); // proj_abc123
+```
+
+```python Python
+project = kernel.projects.get("staging")
+print(project.id)  # proj_abc123
+```
+
+```go Go
+project, err := client.Projects.Get(ctx, "staging")
+if err != nil {
+	panic(err)
+}
+fmt.Println(project.ID) // proj_abc123
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Summary

- update the Projects page to show project lookup by ID or name
- document the extension metadata lookup endpoint in the extensions guide

## Validation

- ran `git diff --check`
- rendered `info/projects` and `browsers/extensions` with the Mintlify local preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Updates the **Projects** and **Extensions** guides to match lookup behavior that accepts **ID or name**.
> 
> On **Projects**, the `GET /org/projects/{id}` table row now says lookup works by **ID or name**. A new **Get a project** section explains name uniqueness in the org and shows `projects.get('staging')` in TypeScript, Python, and Go.
> 
> On **Extensions**, after the upload section, the guide adds **`GET /extensions/{id_or_name}/metadata`** for reading ID, name, size, and timestamps without downloading the archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35d7cf2c305c38ee6545c9ab262572d30a97c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->