### PR TITLE
docs: add Common use cases to chrome_policy page

### DIFF
--- a/browsers/pools/policy-json.mdx
+++ b/browsers/pools/policy-json.mdx
@@ -174,6 +174,72 @@ The example above demonstrates setting a default homepage and managed bookmarks.
 | `BookmarkBarEnabled` | `boolean` | Shows the bookmark bar |
 | `ManagedBookmarks` | `array` | Pre-configured bookmarks. Supports folders via nested `children` arrays |
 
+## Common use cases
+
+`chrome_policy` is also accepted directly on `browsers.create()` when you don't need a reserved pool. The examples below use that path.
+
+### Allow pop-ups
+
+Chrome's default blocks pop-ups, which breaks sites that open download dialogs or OAuth windows in a new window. Set `DefaultPopupsSetting` to `1` to allow them (`2` blocks).
+
+<CodeGroup>
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+browser = kernel.browsers.create(
+    chrome_policy={
+        "DefaultPopupsSetting": 1,
+    }
+)
+```
+
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const browser = await kernel.browsers.create({
+  chrome_policy: {
+    DefaultPopupsSetting: 1,
+  },
+});
+```
+</CodeGroup>
+
+### Control file download behavior
+
+When automating file downloads that trigger permission prompts, combine `DefaultPopupsSetting: 1` with `DownloadRestrictions: 0` to allow all downloads.
+
+<CodeGroup>
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+browser = kernel.browsers.create(
+    chrome_policy={
+        "DefaultPopupsSetting": 1,
+        "DownloadRestrictions": 0,
+    }
+)
+```
+
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const browser = await kernel.browsers.create({
+  chrome_policy: {
+    DefaultPopupsSetting: 1,
+    DownloadRestrictions: 0,
+  },
+});
+```
+</CodeGroup>
+
 ## Available policies
 
 Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object. Refer to the official docs for the full list of supported policy names, types, and values.


### PR DESCRIPTION
## Summary

Adds a "Common use cases" section to `browsers/pools/policy-json.mdx` before "Available policies", documenting the non-pool path (`chrome_policy` on `browsers.create()`) with two recipes:

- **Allow pop-ups** — `DefaultPopupsSetting: 1` for sites that open download dialogs or OAuth windows.
- **Control file download behavior** — `DefaultPopupsSetting: 1` + `DownloadRestrictions: 0` for download-permission prompts.

Each use case has Python + TypeScript tabs in a `CodeGroup`, matching the existing style on the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX additions with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Common use cases** section to the custom Chrome policies doc (before **Available policies**), clarifying that `chrome_policy` works on `browsers.create()` as well as pools.
> 
> Documents two automation-focused recipes with Python/TypeScript `CodeGroup` examples: allowing pop-ups via `DefaultPopupsSetting: 1`, and relaxing download prompts with `DefaultPopupsSetting: 1` plus `DownloadRestrictions: 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407a36e86fcdaae5dd68ffaf52903d27a09be9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->