### PR TITLE
docs: remove research preview language from GPU acceleration

### DIFF
--- a/browsers/gpu-acceleration.mdx
+++ b/browsers/gpu-acceleration.mdx
@@ -73,4 +73,4 @@ GPU acceleration speeds up page rendering, not screenshot capture. CDP's `Page.c
 
 ## Availability
 
-GPU acceleration is available on [Start-Up and Enterprise plans](https://kernel.sh/pricing). Due to limited capacity, GPU-enabled browsers may not always be available.
+GPU acceleration is available on [Start-Up and Enterprise plans](https://kernel.sh/pricing).

--- a/browsers/gpu-acceleration.mdx
+++ b/browsers/gpu-acceleration.mdx
@@ -73,4 +73,4 @@ GPU acceleration speeds up page rendering, not screenshot capture. CDP's `Page.c
 
 ## Availability
 
-GPU acceleration is available on [Start-Up and Enterprise plans](https://kernel.sh/pricing). Due to limited capacity during the research preview, GPU-enabled browsers may not always be available.
+GPU acceleration is available on [Start-Up and Enterprise plans](https://kernel.sh/pricing). Due to limited capacity, GPU-enabled browsers may not always be available.


### PR DESCRIPTION
## Summary

- Drops the "research preview" qualifier from the GPU acceleration availability note.

## Notes

- Left the March 20 changelog entry untouched since it's a historical record of what was shipped at the time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no product or code impact.
> 
> **Overview**
> Updates the **Availability** section on the GPU acceleration docs page so it no longer describes GPU as a research preview or warns that capacity limits may make GPU browsers unavailable.
> 
> The note now only states that GPU acceleration is available on Start-Up and Enterprise plans, with no change to pricing or feature behavior elsewhere in the doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e87e45ec1c271f71ae5cab0cd7fde0901926c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->