### PR TITLE
Add June 26 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,7 +12,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="June 26" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Released [`@onkernel/cua-agent`](https://github.com/kernel/cua), an open-source computer use agent framework with an opt-in `playwright_execute` tool for combining computer use with Playwright automation, support for Gemini 3.5 Flash, and a publishable CLI ([`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli)).
+- Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua), our open-source computer use agent framework, with an opt-in `playwright_execute` tool for combining computer use with Playwright automation and support for Gemini 3.5 Flash. The companion CLI ([`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli)) is now publishable to npm.
 - Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) with app, proxy, and extension management tools, browser pool improvements (fill rate configuration, acquire/release workflow), and MCP tool annotations across all tools for better AI agent discoverability.
 - Added `--chrome-policy` flags to browser and pool commands in the [CLI](https://github.com/kernel/cli) for configuring Chrome settings like popups, PDF behavior, and homepage directly from the terminal.
 - Added `--name` and `--tag` flags to `kernel browsers update` in the [CLI](https://github.com/kernel/cli) for modifying session metadata after creation.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,21 +12,20 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="June 26" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua), our open-source computer use agent framework, with an opt-in `playwright_execute` tool for combining computer use with Playwright automation and support for Gemini 3.5 Flash. The companion CLI ([`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli)) is now publishable to npm.
-- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) with app, proxy, and extension management tools, browser pool improvements (fill rate configuration, acquire/release workflow), and MCP tool annotations across all tools for better AI agent discoverability.
-- Added `--chrome-policy` flags to browser and pool commands in the [CLI](https://github.com/kernel/cli) for configuring Chrome settings like popups, PDF behavior, and homepage directly from the terminal.
-- Added `--name` and `--tag` flags to `kernel browsers update` in the [CLI](https://github.com/kernel/cli) for modifying session metadata after creation.
-- Browser pool acquire now accepts a `start_url` parameter, allowing each acquired browser to override the pool's default start URL.
-- Added an API key [rotation endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) for rotating keys without deleting and recreating them.
-- Simplified TypeScript computer-use templates in the [CLI](https://github.com/kernel/cli) by leveraging the new `@onkernel/cua-agent` package.
-- Added a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth MP4 videos from animated web visualizations.
+- Added an opt-in `playwright_execute` tool to [`@onkernel/cua-agent`](https://github.com/kernel/cua) for combining computer use with Playwright automation, plus support for `gemini-3.5-flash` as a CUA model. The companion CLI [`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli) is now published to npm, and the [CLI](https://github.com/kernel/cli)'s TypeScript computer-use templates have been simplified to build on the new package.
+- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server)'s browser pool tool with SDK parity fields (`start_url`, `chrome_policy`, `kiosk_mode`, profile and viewport settings, `fill_rate_per_minute`) and a structured acquire/release workflow. Added parity actions across `manage_apps` (`delete_deployment`, app/deployment search), `manage_proxies` (`get`, `check` with optional `check_url`), `manage_profiles` (`get`, paginated search), and `manage_projects` (`get_limits`, `update_limits`). Tool annotations now cover all tools.
+- Added a `start_url` parameter to browser pool `acquire`, letting each acquired session override the pool's default start URL.
+- Added `--chrome-policy` flags to `browsers create`/`update` and `browser-pools create`/`update` in the [CLI](https://github.com/kernel/cli) for setting Chrome popup, PDF, and homepage behavior from the terminal.
+- Extended `kernel browsers update` in the [CLI](https://github.com/kernel/cli) with `--name` and `--tag` parameters, so a running session's name and tags can be changed after creation alongside the existing `browsers create`/`acquire` flags.
+- Added an API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). Exposed in the Node, Python, and Go SDKs.
+- Shipped a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth, deterministic MP4 videos from a web scene — used internally for launch and explainer clips.
 
 ## Documentation updates
 
 - Enabled dark mode on the documentation site behind a theme toggle (default stays light).
-- Added a Common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples.
-- Documented [X-Kernel-Project-Id](/info/projects) resolution rules and direct project and extension lookups.
-- Documented the API key [rotation endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key).
+- Added a Common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples for popup blocking, PDF inline rendering, and homepage overrides.
+- Documented [`X-Kernel-Project-Id`](/info/projects) header resolution rules and direct project and extension lookups on the Projects page.
+- Documented the API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key), including the optional `days_to_expire` and `expire_in_days` parameters.
 </Update>
 
 <Update label="June 12" tags={["Product", "Docs"]}>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,6 +17,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Added a `start_url` parameter to browser pool `acquire`, letting each acquired session override the pool's default start URL.
 - Added `--chrome-policy` flags to `browsers create`/`update` and `browser-pools create`/`update` in the [CLI](https://github.com/kernel/cli) for setting Chrome popup, PDF, and homepage behavior from the terminal.
 - Extended `kernel browsers update` in the [CLI](https://github.com/kernel/cli) with `--name` and `--tag` parameters, so a running session's name and tags can be changed after creation alongside the existing `browsers create`/`acquire` flags.
+- Finalized session names and tags in the dashboard: sessions can be renamed and re-tagged after creation, the launch dialog accepts an initial set of tags, and entries on the sessions list are click-to-filter by tag.
 - Added an API key [rotate endpoint](/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). 
 - Shipped a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth, deterministic MP4 videos from a web scene — used internally for launch and explainer clips.
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -13,11 +13,11 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 ## Product updates
 
 - Added a `playwright_execute` tool to [`@onkernel/cua-agent`](https://github.com/kernel/cua) for combining computer use with Playwright automation, plus support for `gemini-3.5-flash` as a CUA model. 
-- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server)'s browser pool tool with SDK parity fields (`start_url`, `chrome_policy`, `kiosk_mode`, profile and viewport settings, `fill_rate_per_minute`) and a structured acquire/release workflow. Added parity for actions across `manage_apps` (`delete_deployment`, app/deployment search), `manage_proxies` (`get`, `check` with optional `check_url`), `manage_profiles` (`get`, paginated search), and `manage_projects` (`get_limits`, `update_limits`).
+- Extended the [MCP server](/reference/mcp-server)'s browser pool tool with SDK parity fields (`start_url`, `chrome_policy`, `kiosk_mode`, profile and viewport settings, `fill_rate_per_minute`) and a structured acquire/release workflow. Added parity for actions across `manage_apps` (`delete_deployment`, app/deployment search), `manage_proxies` (`get`, `check` with optional `check_url`), `manage_profiles` (`get`, paginated search), and `manage_projects` (`get_limits`, `update_limits`).
 - Added a `start_url` parameter to browser pool `acquire`, letting each acquired session override the pool's default start URL.
 - Added `--chrome-policy` flags to `browsers create`/`update` and `browser-pools create`/`update` in the [CLI](https://github.com/kernel/cli) for setting Chrome popup, PDF, and homepage behavior from the terminal.
 - Extended `kernel browsers update` in the [CLI](https://github.com/kernel/cli) with `--name` and `--tag` parameters, so a running session's name and tags can be changed after creation alongside the existing `browsers create`/`acquire` flags.
-- Added an API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). 
+- Added an API key [rotate endpoint](/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). 
 - Shipped a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth, deterministic MP4 videos from a web scene — used internally for launch and explainer clips.
 
 ## Documentation updates
@@ -25,7 +25,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Enabled dark mode on the docs.
 - Added a common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples for popup blocking, PDF inline rendering, and homepage overrides.
 - Documented [`X-Kernel-Project-Id`](/info/projects) header resolution rules and direct project and extension lookups on the Projects page.
-- Documented the API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key), including the optional `days_to_expire` and `expire_in_days` parameters.
+- Documented the API key [rotate endpoint](/api-reference/api-keys/rotate-an-api-key), including the optional `days_to_expire` and `expire_in_days` parameters.
 </Update>
 
 <Update label="June 12" tags={["Product", "Docs"]}>
@@ -50,7 +50,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Browser sessions now play audio by default, and the browser replay recording API gained a `record_audio` option to capture that audio in replay videos.
 - Extended browser telemetry to the [CLI](https://github.com/kernel/cli): use `--telemetry=all|off|<list>` on `browsers create` and `browsers update` to configure telemetry per session, and `kernel browsers telemetry stream <id>` to tail live events with category and type filters and SSE resume support.
 - Added API key management commands to the [CLI](https://github.com/kernel/cli) for creating, listing, retrieving, updating, and deleting org API keys directly from the terminal.
-- Expanded the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.
+- Expanded the [MCP server](/reference/mcp-server) from 10 to 16 tools, adding managed auth (`manage_auth_connections`, `manage_credentials`, `manage_credential_providers`), `browser_curl` for HTTP(S) through a live browser, API key management, and project management. MCP-created browser sessions also now accept the same configuration as the API.
 - Browser sessions can now be given a custom name at create time, making them easier to identify in the dashboard and audit logs.
 - Improved `kernel status` to distinguish between the API being down versus unreachable.
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,18 +12,18 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="June 26" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added an opt-in `playwright_execute` tool to [`@onkernel/cua-agent`](https://github.com/kernel/cua) for combining computer use with Playwright automation, plus support for `gemini-3.5-flash` as a CUA model. The companion CLI [`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli) is now published to npm, and the [CLI](https://github.com/kernel/cli)'s TypeScript computer-use templates have been simplified to build on the new package.
-- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server)'s browser pool tool with SDK parity fields (`start_url`, `chrome_policy`, `kiosk_mode`, profile and viewport settings, `fill_rate_per_minute`) and a structured acquire/release workflow. Added parity actions across `manage_apps` (`delete_deployment`, app/deployment search), `manage_proxies` (`get`, `check` with optional `check_url`), `manage_profiles` (`get`, paginated search), and `manage_projects` (`get_limits`, `update_limits`). Tool annotations now cover all tools.
+- Added a `playwright_execute` tool to [`@onkernel/cua-agent`](https://github.com/kernel/cua) for combining computer use with Playwright automation, plus support for `gemini-3.5-flash` as a CUA model. 
+- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server)'s browser pool tool with SDK parity fields (`start_url`, `chrome_policy`, `kiosk_mode`, profile and viewport settings, `fill_rate_per_minute`) and a structured acquire/release workflow. Added parity for actions across `manage_apps` (`delete_deployment`, app/deployment search), `manage_proxies` (`get`, `check` with optional `check_url`), `manage_profiles` (`get`, paginated search), and `manage_projects` (`get_limits`, `update_limits`).
 - Added a `start_url` parameter to browser pool `acquire`, letting each acquired session override the pool's default start URL.
 - Added `--chrome-policy` flags to `browsers create`/`update` and `browser-pools create`/`update` in the [CLI](https://github.com/kernel/cli) for setting Chrome popup, PDF, and homepage behavior from the terminal.
 - Extended `kernel browsers update` in the [CLI](https://github.com/kernel/cli) with `--name` and `--tag` parameters, so a running session's name and tags can be changed after creation alongside the existing `browsers create`/`acquire` flags.
-- Added an API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). Exposed in the Node, Python, and Go SDKs.
+- Added an API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). 
 - Shipped a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth, deterministic MP4 videos from a web scene — used internally for launch and explainer clips.
 
 ## Documentation updates
 
-- Enabled dark mode on the documentation site behind a theme toggle (default stays light).
-- Added a Common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples for popup blocking, PDF inline rendering, and homepage overrides.
+- Enabled dark mode on the docs.
+- Added a common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples for popup blocking, PDF inline rendering, and homepage overrides.
 - Documented [`X-Kernel-Project-Id`](/info/projects) header resolution rules and direct project and extension lookups on the Projects page.
 - Documented the API key [rotate endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key), including the optional `days_to_expire` and `expire_in_days` parameters.
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,26 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="June 26" tags={["Product", "Docs"]}>
+## Product updates
+
+- Released [`@onkernel/cua-agent`](https://github.com/kernel/cua), an open-source computer use agent framework with an opt-in `playwright_execute` tool for combining computer use with Playwright automation, support for Gemini 3.5 Flash, and a publishable CLI ([`@onkernel/cua-cli`](https://www.npmjs.com/package/@onkernel/cua-cli)).
+- Extended the [MCP server](https://www.kernel.sh/docs/reference/mcp-server) with app, proxy, and extension management tools, browser pool improvements (fill rate configuration, acquire/release workflow), and MCP tool annotations across all tools for better AI agent discoverability.
+- Added `--chrome-policy` flags to browser and pool commands in the [CLI](https://github.com/kernel/cli) for configuring Chrome settings like popups, PDF behavior, and homepage directly from the terminal.
+- Added `--name` and `--tag` flags to `kernel browsers update` in the [CLI](https://github.com/kernel/cli) for modifying session metadata after creation.
+- Browser pool acquire now accepts a `start_url` parameter, allowing each acquired browser to override the pool's default start URL.
+- Added an API key [rotation endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key) for rotating keys without deleting and recreating them.
+- Simplified TypeScript computer-use templates in the [CLI](https://github.com/kernel/cli) by leveraging the new `@onkernel/cua-agent` package.
+- Added a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth MP4 videos from animated web visualizations.
+
+## Documentation updates
+
+- Enabled dark mode on the documentation site behind a theme toggle (default stays light).
+- Added a Common use cases section to the [policy.json](/browsers/pools/policy-json) page with `browsers.create()` examples.
+- Documented [X-Kernel-Project-Id](/info/projects) resolution rules and direct project and extension lookups.
+- Documented the API key [rotation endpoint](https://kernel.sh/docs/api-reference/api-keys/rotate-an-api-key).
+</Update>
+
 <Update label="June 12" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,7 +17,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Added a `start_url` parameter to browser pool `acquire`, letting each acquired session override the pool's default start URL.
 - Added `--chrome-policy` flags to `browsers create`/`update` and `browser-pools create`/`update` in the [CLI](https://github.com/kernel/cli) for setting Chrome popup, PDF, and homepage behavior from the terminal.
 - Extended `kernel browsers update` in the [CLI](https://github.com/kernel/cli) with `--name` and `--tag` parameters, so a running session's name and tags can be changed after creation alongside the existing `browsers create`/`acquire` flags.
-- Finalized session names and tags in the dashboard: sessions can be renamed and re-tagged after creation, the launch dialog accepts an initial set of tags, and entries on the sessions list are click-to-filter by tag.
+- Brought custom session names and tags into the dashboard: the launch dialog now accepts an initial set of tags, sessions can be renamed and re-tagged after creation, and tag chips on the sessions list are click-to-filter — so the names and tags set via the API are actionable from the UI, making it easier to find a specific session out of many concurrent ones.
 - Added an API key [rotate endpoint](/api-reference/api-keys/rotate-an-api-key) (`POST /org/api_keys/{id}/rotate`) that issues a replacement key, copies the rotated key's name and project scope, and keeps the old key working for a configurable grace period (default 7 days). 
 - Shipped a `generate-video` [skill](https://github.com/kernel/skills) for producing smooth, deterministic MP4 videos from a web scene — used internally for launch and explainer clips.
 


### PR DESCRIPTION
## Summary

Adds the June 26, 2026 changelog entry covering the two-week window since the June 12 release.

### Notes on verification

- Fixed malformed link/parenthesis on the cua-agent bullet (the source had `cli))>` and Slack-style `<URL>` angle brackets around every URL).
- Reworded the `generate-video` skill bullet: the source draft described it as "generating browser session recording videos", but the skill actually produces smooth MP4 videos from animated web visualizations (used for launch/demo clips). Adjusted to match the skill's real purpose — please confirm or override.
- All linked endpoints/repos/pages verified to exist (cua repo, cua-cli npm, MCP server docs, CLI repo, rotate endpoint docs, skills repo, policy-json and projects internal pages).
- Two items (`--chrome-policy` CLI flags, `--name`/`--tag` on `browsers update`, generate-video skill, X-Kernel-Project-Id docs) shipped June 11 — one day outside a strict 2-week window, but were not covered by the June 12 changelog.

## Test plan

- [ ] Render the changelog page locally and confirm the June 26 `<Update>` block displays correctly
- [ ] Confirm the generate-video bullet wording matches intent
- [ ] Click through each link in the new entry on a preview deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and link fix; no runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds a new **June 26** `<Update>` block at the top of `changelog.mdx`, covering product and documentation changes since the June 12 entry.
> 
> **Product** bullets summarize CUA (`playwright_execute`, `gemini-3.5-flash`), MCP browser-pool and management-tool parity, pool `acquire` `start_url`, CLI `--chrome-policy` and `browsers update` name/tag flags, dashboard session naming/tagging/filtering, the API key rotate endpoint, and the `generate-video` skill.
> 
> **Docs** bullets call out dark mode, `policy.json` use-case examples, Projects/`X-Kernel-Project-Id` documentation, and rotate-endpoint API reference.
> 
> Also fixes the June 5 MCP server link from an absolute `kernel.sh` URL to the internal `/reference/mcp-server` path, matching newer changelog entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39646d805884ae64b9560b18b0ce3fcee89f0e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->