### PR TITLE
docs: update Calendly booking link

### DIFF
--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -84,4 +84,4 @@ Rate-limited endpoints include these headers on every response:
 
 All Kernel SDKs automatically retry `429` responses up to 2 times, respecting the `Retry-After` header for delay timing. If retries are exhausted, the SDK throws a typed `RateLimitError` with the response headers accessible for custom backoff logic.
 
-If you need higher rate limits, [contact us](https://calendly.com/d/cs5d-5vx-qp3).
+If you need higher rate limits, [contact us](https://calendly.com/d/d3tn-5kp-5yt).

--- a/info/support.mdx
+++ b/info/support.mdx
@@ -63,4 +63,4 @@ Everything in Platinum, plus:
 
 All enterprise tiers include a Private Slack channel for direct communication with the Kernel team.
 
-To discuss enterprise plans, book a demo [here](https://calendly.com/d/cs5d-5vx-qp3).
+To discuss enterprise plans, book a demo [here](https://calendly.com/d/d3tn-5kp-5yt).


### PR DESCRIPTION
## Summary
- Replaces old Calendly link (`cs5d-5vx-qp3`) with new one (`d3tn-5kp-5yt`) in docs

## Files changed
- `info/pricing.mdx` — rate limits contact link
- `info/support.mdx` — enterprise demo booking link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation hyperlink updates only; no runtime or security impact.
> 
> **Overview**
> **Docs-only:** Replaces the shared Calendly link (`cs5d-5vx-qp3` → `d3tn-5kp-5yt`) in two places.
> 
> In `info/pricing.mdx`, the “higher rate limits” **contact us** link now points to the new booking URL. In `info/support.mdx`, the enterprise **book a demo** link is updated the same way.
> 
> No application code, APIs, or behavior changes—only where readers are sent for sales/contact scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5705f3561d27213fd12fbc2d19818359869780ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->