### PR TITLE
docs: pooled browsers don't persist profile changes (save_changes)

### DIFF
--- a/auth/profiles.mdx
+++ b/auth/profiles.mdx
@@ -484,4 +484,5 @@ _ = browser
 - Profiles store cookies and local storage. Start the session with `save_changes: true` to write changes back when the browser is closed.
 - To keep a profile immutable for a run, omit `save_changes` (default) when creating the browser.
 - Multiple browsers in parallel can use the same profile, but only one browser should write (`save_changes: true`) to it at a time. Parallel browsers with `save_changes: true` may cause profile corruption and unpredictable behavior.
+- `save_changes` applies only to single browser sessions (`kernel.browsers.create()`). [Browser pools](/browsers/pools/overview) load a profile read-only and never persist changes back to it; `save_changes` sent on a pool's profile is silently ignored.
 - Profile data is encrypted end to end using a per-organization key.

--- a/browsers/pools/faq.mdx
+++ b/browsers/pools/faq.mdx
@@ -30,6 +30,10 @@ No. Idle browsers in a pool are pre-loaded with the profile's contents at the ti
 
 To force the pool to pick up new profile contents, either call `kernel.browserPools.flush()` to destroy idle browsers (the pool refills automatically), or call `kernel.browserPools.update()` with `discard_all_idle: true`.
 
+### Can pooled browsers save changes back to a profile?
+
+No. A profile attached to a pool is loaded read-only — pooled browsers never persist changes back to the profile, so `save_changes` does not apply to pools. Sending `save_changes` on a pool's profile is silently ignored (it is not rejected), so reusing a single-session profile object won't error. To capture profile state, use a single browser session instead: `kernel.browsers.create({ profile: { name, save_changes: true } })`.
+
 ### Should I set `reuse: true` or `reuse: false` when releasing?
 
 Use `reuse: true` (default) for efficiency. Only use `reuse: false` when you suspect browser state corruption or need a guaranteed clean browser session.

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -123,6 +123,8 @@ func main() {
 
 Pools can be pre-configured with options like start url, custom extensions, supported viewports, residential proxies, profiles, and more. See the [API reference](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool) for more details.
 
+A profile attached to a pool is loaded read-only: pooled browsers never persist changes back to the profile, so `save_changes` does not apply to pools (it is silently ignored if sent). To capture profile state, use a single browser session with `save_changes` instead — see [Profiles](/auth/profiles).
+
 ## Acquire a browser
 
 Acquire a browser from the pool. The request returns immediately if a browser is available, or waits until one becomes available. The `acquire_timeout_seconds` parameter controls how long to wait; it defaults to the calculated time it would take to fill the pool at the pool's configured [fill rate](https://kernel.sh/docs/api-reference/browser-pools/create-a-browser-pool#body-fill-rate-per-minute).


### PR DESCRIPTION
## What

Documents that **browser pools load a profile read-only** — pooled browsers never persist changes back to the profile, so `save_changes` does not apply to pools.

## Why

Per Sayan's review note on [kernel/kernel#2484](https://github.com/kernel/kernel/pull/2484#pullrequestreview-4581417476): `save_changes: true` on a pool used to return `400` ("not supported for browser pools") and is now **silently ignored**. That's friendlier for SDK users, but raw-HTTP callers lose the explicit signal — so the behavior needs a line in the pool docs "so nobody expects pooled browsers to persist changes."

## Changes

- **`browsers/pools/faq.mdx`** — new Q&A: *"Can pooled browsers save changes back to a profile?"* (sits next to the existing profile-update Q&A).
- **`auth/profiles.mdx`** — Notes bullet scoping `save_changes` to single sessions, with a pool exception.
- **`browsers/pools/overview.mdx`** — read-only-profile caveat under *Pool configuration options*.

The OpenAPI-generated API reference (`api-reference/browser-pools/*`) is pulled from the Stainless documented spec and is already updated by #2484 — no manual edit here.

## Sequencing

⚠️ **Merge after [kernel/kernel#2484](https://github.com/kernel/kernel/pull/2484) deploys** — this documents the new (ignored, not rejected) behavior, which goes live with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Documents that **browser pools load profiles read-only** and never write session state back, so **`save_changes` only applies to** `kernel.browsers.create()` **single sessions**.
> 
> Adds a **Profiles** Notes bullet and short caveats under **pool overview** (pool configuration) and **pool FAQ** (new Q&A). All three explain that **`save_changes` on a pool profile is silently ignored** (not rejected), and point readers to a one-off browser with `save_changes: true` when they need to persist profile state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da99431d6f6a652088524eab8f1768e31ab749a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->