### PR TITLE
ci: redeploy website on changelog updates

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,21 @@
+name: Redeploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - changelog.mdx
+
+jobs:
+  deploy-hook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deploy hook
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "WEBSITE_VERCEL_DEPLOY_HOOK secret is not set; skipping."
+            exit 1
+          fi
+          curl -fsS -X POST "$DEPLOY_HOOK_URL"


### PR DESCRIPTION
## Summary
The website's `/changelog` page prerenders content fetched at runtime from this repo's `changelog.mdx`, but merging a changelog entry here never triggers a website deploy — the page only updates via ISR, which has been silently not regenerating. As a result new changelog entries don't appear until the website is independently redeployed.

This adds a GitHub Actions workflow that fires a Vercel deploy hook for the website whenever `changelog.mdx` changes on `main`, so changelog edits show up without a manual redeploy.

## Manual step required before this works
1. In the website's Vercel project, create a **Deploy Hook** (Settings → Git → Deploy Hooks) targeting the production branch.
2. Add the hook URL as a repo secret here named `WEBSITE_VERCEL_DEPLOY_HOOK`.

Until the secret exists, the job will fail fast with a clear message rather than silently no-op.

## Notes
- Scoped to `changelog.mdx` only, since that's the file the website fetches at runtime — avoids redeploying the site on unrelated docs edits.
- Does not address the separate question of why ISR background regen stopped firing on that route; this is a reliable trigger regardless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no application code; deploy only runs when the secret is configured and changelog file changes.
> 
> **Overview**
> Adds a GitHub Actions workflow that runs on pushes to `main` when **`changelog.mdx`** changes and POSTs to a Vercel deploy hook so the marketing site picks up changelog content without a manual deploy.
> 
> The job reads **`WEBSITE_VERCEL_DEPLOY_HOOK`**; if the secret is missing it exits with an error instead of no-oping. Path filtering limits runs to changelog edits only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a895bea7f49f6138f3a0e905e70abab246fc0125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->