### PR TITLE
Add Computer Use overview page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,6 +11,7 @@
     { "source": "/auth/agent/programmatic", "destination": "/auth/programmatic" },
     { "source": "/auth/agent/faq", "destination": "/auth/faq" },
     { "source": "/browsers/hardware-acceleration", "destination": "/browsers/gpu-acceleration" },
+    { "source": "/integrations/computer-use", "destination": "/integrations/computer-use/overview" },
     { "source": "/browsers/create-a-browser", "destination": "/introduction/create" },
     { "source": "/introduction", "destination": "/" },
     { "source": "/quickstart", "destination": "/" },
@@ -206,6 +207,7 @@
               {
                 "group": "Computer Use",
                 "pages": [
+                  "integrations/computer-use/overview",
                   "integrations/computer-use/anthropic",
                   "integrations/computer-use/gemini",
                   "integrations/computer-use/openagi",

--- a/integrations/computer-use/anthropic.mdx
+++ b/integrations/computer-use/anthropic.mdx
@@ -18,6 +18,8 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
+Building your own agent? Drive Claude from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `anthropic:claude-opus-4-7`.
+
 ## Benefits of using Kernel with Computer Use
 
 - **No local browser management**: Run Computer Use automations without installing or maintaining browsers locally

--- a/integrations/computer-use/anthropic.mdx
+++ b/integrations/computer-use/anthropic.mdx
@@ -18,7 +18,28 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
-Building your own agent? Drive Claude from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `anthropic:claude-opus-4-7`.
+## Build your own agent
+
+For full control over the loop, drive Claude from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent):
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "anthropic:claude-opus-4-7",
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
 
 ## Benefits of using Kernel with Computer Use
 

--- a/integrations/computer-use/gemini.mdx
+++ b/integrations/computer-use/gemini.mdx
@@ -16,7 +16,28 @@ kernel create --name my-computer-use-app --language typescript --template gemini
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
-Building your own agent? Drive Gemini from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `google:gemini-3-flash-preview`.
+## Build your own agent
+
+For full control over the loop, drive Gemini from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent):
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "google:gemini-3-flash-preview",
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
 
 ## Benefits of using Kernel with Computer Use
 

--- a/integrations/computer-use/gemini.mdx
+++ b/integrations/computer-use/gemini.mdx
@@ -2,7 +2,7 @@
 title: "Gemini"
 ---
 
-[Gemini 2.5 Computer Use](https://blog.google/technology/google-deepmind/gemini-computer-use-model/) is Google's groundbreaking capability that enables AI models to interact with computers the way humans do—by looking at screens, moving cursors, clicking buttons, and typing text. This powerful feature allows AI agents to control web browsers, navigate interfaces, and perform complex tasks across applications.
+[Gemini 2.5 Computer Use](https://blog.google/technology/google-deepmind/gemini-computer-use-model/) is Google's groundbreaking capability that enables AI models to interact with computers the way humans do by looking at screens, moving cursors, clicking buttons, and typing text. This powerful feature allows AI agents to control web browsers, navigate interfaces, and perform complex tasks across applications.
 
 By integrating Gemini 2.5 Computer Use with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure, eliminating the need for local browser management and enabling scalable, reliable AI agents.
 

--- a/integrations/computer-use/gemini.mdx
+++ b/integrations/computer-use/gemini.mdx
@@ -16,6 +16,8 @@ kernel create --name my-computer-use-app --language typescript --template gemini
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
+Building your own agent? Drive Gemini from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `google:gemini-3-flash-preview`.
+
 ## Benefits of using Kernel with Computer Use
 
 - **No local browser management**: Run Computer Use automations without installing or maintaining browsers locally

--- a/integrations/computer-use/openai.mdx
+++ b/integrations/computer-use/openai.mdx
@@ -18,6 +18,8 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
+Building your own agent? Drive OpenAI's CUA from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `openai:gpt-5.5`.
+
 ## Benefits of using Kernel with Computer Use
 
 - **No local browser management**: Run Computer Use automations without installing or maintaining browsers locally

--- a/integrations/computer-use/openai.mdx
+++ b/integrations/computer-use/openai.mdx
@@ -2,7 +2,7 @@
 title: "OpenAI"
 ---
 
-[Computer Use](https://openai.com/index/computer-using-agent/) is OpenAI's feature that enables AI models to interact with computers the way humans do—by looking at screens, moving cursors, clicking buttons, and typing text. This powerful feature allows AI agents to control web browsers, navigate interfaces, and perform complex tasks across applications.
+[Computer Use](https://openai.com/index/computer-using-agent/) is OpenAI's feature that enables AI models to interact with computers the way humans do by looking at screens, moving cursors, clicking buttons, and typing text. This powerful feature allows AI agents to control web browsers, navigate interfaces, and perform complex tasks across applications.
 
 By integrating Computer Use with Kernel, you can run these AI-powered browser automations on cloud-hosted infrastructure, eliminating the need for local browser management and enabling scalable, reliable AI agents.
 

--- a/integrations/computer-use/openai.mdx
+++ b/integrations/computer-use/openai.mdx
@@ -18,7 +18,28 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Computer Use automation on Kernel's infrastructure.
 
-Building your own agent? Drive OpenAI's CUA from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `openai:gpt-5.5`.
+## Build your own agent
+
+For full control over the loop, drive OpenAI's CUA from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent):
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "openai:gpt-5.5",
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
 
 ## Benefits of using Kernel with Computer Use
 

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -3,13 +3,13 @@ title: "Overview"
 description: "Run computer use agents on Kernel cloud browsers"
 ---
 
-Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action: move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls#take-screenshots) it needs to see the screen and act on it.
+Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action: move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls) it needs to see the screen and act on it.
 
 ## How computer use works on Kernel
 
 Every computer use integration runs the same action-observation loop:
 
-1. **Capture** a screenshot of the current browser state with the [Computer Controls API](/browsers/computer-controls).
+1. **Capture** a screenshot of the current browser state with the [Computer Controls API](/browsers/computer-controls#take-screenshots).
 2. **Predict** the next action by sending that screenshot to your model.
 3. **Execute** the returned action (click, type, scroll, drag, or key press) through Computer Controls.
 4. **Repeat** until the task is complete.

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -1,0 +1,71 @@
+---
+title: "Overview"
+description: "Run screenshot-driven computer use agents on Kernel cloud browsers"
+---
+
+Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action—move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls) it needs to see the screen and act on it.
+
+## How computer use works on Kernel
+
+Every computer use integration runs the same action-observation loop:
+
+1. **Capture** a screenshot of the current browser state with the [Computer Controls API](/browsers/computer-controls).
+2. **Predict** the next action by sending that screenshot to your model.
+3. **Execute** the returned action—click, type, scroll, drag, or key press—through Computer Controls.
+4. **Repeat** until the task is complete.
+
+Computer Controls emulates native keyboard and mouse input at the OS level—with human-like [Bézier curves](/browsers/computer-controls#move-the-mouse) by default—instead of driving the page over the Chrome DevTools Protocol (CDP). This keeps the loop close to real user input and reduces the automation signals that [bot detection](/browsers/bot-detection/overview) systems look for.
+
+The loop works with any VLM that predicts actions from pixels. The models below are the ones we maintain ready-to-deploy templates and guides for.
+
+## Supported models
+
+<CardGroup cols={2}>
+  <Card title="Anthropic" icon="robot" href="/integrations/computer-use/anthropic">
+    Claude's computer use tool
+  </Card>
+  <Card title="Gemini" icon="google" href="/integrations/computer-use/gemini">
+    Google's Gemini 2.5 Computer Use model
+  </Card>
+  <Card title="OpenAGI" icon="wand-magic-sparkles" href="/integrations/computer-use/openagi">
+    OpenAGI's Lux model
+  </Card>
+  <Card title="OpenAI" icon="circle-nodes" href="/integrations/computer-use/openai">
+    OpenAI's computer-using agent (CUA)
+  </Card>
+  <Card title="Tzafon" icon="bolt" href="/integrations/computer-use/tzafon">
+    Tzafon's Northstar CUA Fast model
+  </Card>
+  <Card title="Yutori" icon="location-arrow" href="/integrations/computer-use/yutori">
+    Yutori's Navigator n1.5 pixels-to-actions model
+  </Card>
+</CardGroup>
+
+Using a model that isn't listed here? Any VLM works—wire its predicted actions straight to the [Computer Controls API](/browsers/computer-controls) and run the same loop.
+
+## Get started
+
+Each model page includes a one-command template so you can deploy a working agent in minutes. For example, to scaffold the Anthropic integration:
+
+```bash
+kernel create --name my-computer-use-app --template computer-use
+```
+
+Pick a model above to get its template, then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to run your agent on Kernel.
+
+## Benefits of using Kernel for computer use
+
+- **No local browser management**: Run computer use automations without installing or maintaining browsers locally
+- **Scalability**: Launch multiple browser sessions in parallel for concurrent AI agents
+- **Stealth mode**: Built-in anti-detection features for reliable web interactions
+- **Session state**: Maintain browser state across runs via [Profiles](/auth/profiles)
+- **Live view**: Debug your agents with real-time browser viewing
+- **Cloud infrastructure**: Run computationally intensive AI agents without local resource constraints
+
+## Next steps
+
+- Read the [Computer Controls API](/browsers/computer-controls) reference for the full set of mouse, keyboard, and screenshot actions
+- Check out [live view](/browsers/live-view) for debugging your automations
+- Learn about [stealth mode](/browsers/bot-detection/stealth) for avoiding detection
+- Learn how to properly [terminate browser sessions](/browsers/termination)
+- Learn how to [deploy](/apps/deploy) your computer use app to Kernel

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Run computer use agents on Kernel cloud browsers"
 ---
 
-Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action—move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls#take-screenshots) it needs to see the screen and act on it.
+Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action: move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls#take-screenshots) it needs to see the screen and act on it.
 
 ## How computer use works on Kernel
 
@@ -11,10 +11,10 @@ Every computer use integration runs the same action-observation loop:
 
 1. **Capture** a screenshot of the current browser state with the [Computer Controls API](/browsers/computer-controls).
 2. **Predict** the next action by sending that screenshot to your model.
-3. **Execute** the returned action—click, type, scroll, drag, or key press—through Computer Controls.
+3. **Execute** the returned action (click, type, scroll, drag, or key press) through Computer Controls.
 4. **Repeat** until the task is complete.
 
-Computer Controls emulates native keyboard and mouse input at the OS level—with human-like [Bézier curves](/browsers/computer-controls#move-the-mouse) by default—instead of driving the page over the Chrome DevTools Protocol (CDP). This keeps the loop close to real user input and reduces the automation signals that [bot detection](/browsers/bot-detection/overview) systems look for.
+Computer Controls emulates native keyboard and mouse input at the OS level (with human-like [Bézier curves](/browsers/computer-controls#move-the-mouse) by default) instead of driving the page over the Chrome DevTools Protocol (CDP). This keeps the loop close to real user input and reduces the automation signals that [bot detection](/browsers/bot-detection/overview) systems look for.
 
 The loop works with any VLM that predicts actions from pixels. The models below are the ones we maintain ready-to-deploy templates and guides for.
 
@@ -41,7 +41,7 @@ The loop works with any VLM that predicts actions from pixels. The models below 
   </Card>
 </CardGroup>
 
-Using a model that isn't listed here? Any VLM works—wire its predicted actions straight to the [Computer Controls API](/browsers/computer-controls) and run the same loop.
+Using a model that isn't listed here? Any VLM works; wire its predicted actions straight to the [Computer Controls API](/browsers/computer-controls) and run the same loop.
 
 ## Get started
 

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Run screenshot-driven computer use agents on Kernel cloud browsers"
+description: "Run computer use agents on Kernel cloud browsers"
 ---
 
 Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action—move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls) it needs to see the screen and act on it.

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Run computer use agents on Kernel cloud browsers"
 ---
 
-Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action—move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls) it needs to see the screen and act on it.
+Computer use models are vision-language models (VLMs) that operate a browser the way a person does: they look at a screenshot, decide what to do next, and emit a concrete action—move the mouse, click, type, scroll, or drag. Kernel runs these agents on cloud browsers, so you don't install or maintain anything locally, and gives the model the low-level [Computer Controls API](/browsers/computer-controls#take-screenshots) it needs to see the screen and act on it.
 
 ## How computer use works on Kernel
 

--- a/integrations/computer-use/overview.mdx
+++ b/integrations/computer-use/overview.mdx
@@ -53,6 +53,45 @@ kernel create --name my-computer-use-app --template computer-use
 
 Pick a model above to get its template, then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to run your agent on Kernel.
 
+## Build your own agent
+
+For full control over the loop, [`@onkernel/cua-agent`](https://github.com/kernel/cua/tree/main/packages/agent) is a TypeScript library that runs it against a Kernel browser for you. You point it at a model, give it a task, and it handles the screenshots, actions, and follow-up turns.
+
+```bash
+npm install @onkernel/cua-agent @onkernel/cua-ai @onkernel/sdk
+```
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "anthropic:claude-opus-4-7", // swap to target another provider
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
+
+Switch providers by changing the `model` ref:
+
+| Provider | Model ref |
+| --- | --- |
+| Anthropic | `anthropic:claude-opus-4-7` |
+| OpenAI | `openai:gpt-5.5` |
+| Gemini | `google:gemini-3-flash-preview` |
+| Tzafon | `tzafon:tzafon.northstar-cua-fast` |
+| Yutori | `yutori:n1.5-latest` |
+
+Set the matching provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `TZAFON_API_KEY`, or `YUTORI_API_KEY`) alongside `KERNEL_API_KEY`.
+
 ## Benefits of using Kernel for computer use
 
 - **No local browser management**: Run computer use automations without installing or maintaining browsers locally

--- a/integrations/computer-use/tzafon.mdx
+++ b/integrations/computer-use/tzafon.mdx
@@ -18,6 +18,8 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Tzafon automation on Kernel's infrastructure.
 
+Building your own agent? Drive Northstar CUA Fast from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `tzafon:tzafon.northstar-cua-fast`.
+
 ## Benefits of using Kernel with Tzafon Northstar CUA Fast
 
 - **No local browser management**: Run Northstar CUA Fast automations without installing or maintaining browsers locally

--- a/integrations/computer-use/tzafon.mdx
+++ b/integrations/computer-use/tzafon.mdx
@@ -18,7 +18,28 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Tzafon automation on Kernel's infrastructure.
 
-Building your own agent? Drive Northstar CUA Fast from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `tzafon:tzafon.northstar-cua-fast`.
+## Build your own agent
+
+For full control over the loop, drive Northstar CUA Fast from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent):
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "tzafon:tzafon.northstar-cua-fast",
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
 
 ## Benefits of using Kernel with Tzafon Northstar CUA Fast
 

--- a/integrations/computer-use/yutori.mdx
+++ b/integrations/computer-use/yutori.mdx
@@ -18,6 +18,8 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Yutori automation on Kernel's infrastructure.
 
+Building your own agent? Drive Navigator n1.5 from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `yutori:n1.5-latest`.
+
 ## Benefits of using Kernel with Yutori n1.5
 
 - **No local browser management**: Run n1.5 automations without installing or maintaining browsers locally

--- a/integrations/computer-use/yutori.mdx
+++ b/integrations/computer-use/yutori.mdx
@@ -18,7 +18,28 @@ Choose `TypeScript` or `Python` as the programming language.
 
 Then follow the [deploy](/apps/deploy) and [invoke](/apps/invoke) guides to deploy and run your Yutori automation on Kernel's infrastructure.
 
-Building your own agent? Drive Navigator n1.5 from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent) using the model ref `yutori:n1.5-latest`.
+## Build your own agent
+
+For full control over the loop, drive Navigator n1.5 from TypeScript with [`@onkernel/cua-agent`](/integrations/computer-use/overview#build-your-own-agent):
+
+```ts
+import Kernel from "@onkernel/sdk";
+import { CuaAgent } from "@onkernel/cua-agent";
+
+const client = new Kernel({ apiKey: process.env.KERNEL_API_KEY! });
+const browser = await client.browsers.create({ stealth: true });
+
+const agent = new CuaAgent({
+  browser,
+  client,
+  initialState: {
+    model: "yutori:n1.5-latest",
+    systemPrompt: "You are a careful browser automation agent.",
+  },
+});
+
+await agent.prompt("Open news.ycombinator.com and summarize the top story.");
+```
 
 ## Benefits of using Kernel with Yutori n1.5
 


### PR DESCRIPTION
## Summary

Adds a landing/overview page for the **Computer Use** integrations group, which previously had six model pages (Anthropic, Gemini, OpenAGI, OpenAI, Tzafon, Yutori) but no entry point.

The overview page:
- Explains what computer use models are and the shared screenshot → predict → execute → repeat action-observation loop.
- Notes that the loop runs on Kernel's [Computer Controls API](/browsers/computer-controls) (OS-level input, not CDP) and how that ties into [bot detection](/browsers/bot-detection/overview).
- Links each supported model in a `CardGroup`, and notes any VLM works via Computer Controls.
- Includes a quick `kernel create` get-started, the standard Kernel benefits block, and next steps.

## Build your own agent (cua-agent)

- Adds a "Build your own agent" section to the overview documenting the `@onkernel/cua-agent` library path: the `npm install`, a starter snippet, and a provider/model-ref table (Anthropic, OpenAI, Gemini, Tzafon, Yutori).
- Each cua-supported provider page now shows a provider-specific `CuaAgent` snippet directly below its template (with that provider's model ref). The `npm install` lives once in the overview, which each snippet links to. OpenAGI is intentionally left template-only since cua-agent doesn't support it.
- Note: `@onkernel/cua-agent` is TypeScript-only (no Python package), so these snippets are TS-only by necessity; the overview labels it a TypeScript library. The `kernel create` templates remain bilingual.

## Wiring

- Added `integrations/computer-use/overview` as the first page of the **Computer Use** group in `docs.json` (matches the convention used by `integrations/vercel/overview`, `auth/overview`, etc.).
- Added a redirect from `/integrations/computer-use` → `/integrations/computer-use/overview` so the bare section URL resolves to the new page.

## Notes / test plan

- `docs.json` validated as well-formed JSON.
- Internal links verified against existing pages; provider snippets link to the overview's `#build-your-own-agent` anchor.
- cua-agent snippets, model refs, and env vars verified against `kernel/cua` (`packages/agent` README and `packages/ai` model catalog).
- The Mintlify CLI isn't available in this environment, so I couldn't run `mintlify dev` for a live preview. Recommend a quick visual check via the branch preview before merging.

Preview: `https://tbd-6fc993ce-hypeship-computer-use-overview.mintlify.app/integrations/computer-use/overview`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Computer Use** landing page and wires it into the docs nav so `/integrations/computer-use` resolves to the new overview.
> 
> The overview explains the shared screenshot → predict → execute loop on Kernel’s **Computer Controls API**, links all six model integrations, and documents the **`@onkernel/cua-agent`** TypeScript path (`npm install`, starter code, provider model refs, and env vars).
> 
> **Anthropic**, **Gemini**, **OpenAI**, **Tzafon**, and **Yutori** pages each gain a **Build your own agent** section with a provider-specific `CuaAgent` snippet pointing back to the overview anchor; **OpenAGI** stays template-only. Intro copy on a few pages drops em dashes for plain “by” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bf54b7fde9519c11e8847fbdcc1cc8c11f7e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->