### PR TITLE
Distinguish docs sidebar section headings from page links

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,10 +28,29 @@ kbd {
   --btn-selected-bg: #CAB168;
   --btn-border: #000;
 }
-/* style sidebar titles */
-#navigation-items .sidebar-group-header #sidebar-title{
-  font-weight: bold;
-  font-size: 15px;
+/* sidebar section headings — recede to a quiet "eyebrow" so they read as
+   structure, distinct from the clickable page links below them. mintlify
+   renders the group title as .sidebar-group-header (the old #sidebar-title id
+   no longer exists), and the inner h3 inherits font/size/color from it. */
+#navigation-items .sidebar-group-header {
+  font-size: 11px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.09em;
+  color: #60646c !important;
+}
+html.dark #navigation-items .sidebar-group-header {
+  color: rgba(237, 238, 240, 0.55) !important;
+}
+
+/* divider + breathing room above each section after the first (non-first
+   sections are wrapped by mintlify in a margin-top div) */
+#navigation-items div[class*="mt-"] > .sidebar-group-header {
+  margin-top: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(33, 34, 37, 0.1);
+}
+html.dark #navigation-items div[class*="mt-"] > .sidebar-group-header {
+  border-top-color: rgba(237, 238, 240, 0.1);
 }
 
 /* move nested nav arrows to the right */


### PR DESCRIPTION
## Summary

Sidebar section headings (Overview, Working with your browser, Integrations, etc.) rendered at the same size and weight as the clickable page links beneath them, so the hierarchy didn't read — a heading looked just like a link.

This restyles the section headings into a quiet, muted **eyebrow** (smaller, lighter, letter-spaced) with a hairline divider between sections, so headings read as *structure* and the page links stand out as *destinations*.

## Why the old rule was a no-op

The previous rule targeted `#sidebar-title`, an id Mintlify no longer emits. The group title is now `.sidebar-group-header` containing an inner `h3.sidebar-title` that inherits font/size/color. So the existing "bold 15px" rule matched nothing — which is why headings looked like links. The new rule targets `.sidebar-group-header` directly.

- Active-page and page-link styling are **unchanged** (active stays charcoal + bold).
- All colors come from the palette (`grey-light-11` for muted text, `grey-dark-12`/`charcoal` for dividers).

## Scope

Sidebar hierarchy only. Making the expandable toggles (Basics, Intermediate, Computer Use, etc.) clickable with card-based landing pages is a separate follow-up.

## Test plan

- [x] Verified `.sidebar-group-header` is the correct target against the live rendered DOM (the old `#sidebar-title` id is gone).
- [x] Confirmed rendering in a local `mintlify dev` build: section headings recede to muted eyebrows with dividers; page links and the active/bold state are unchanged.
- [ ] Spot-check dark mode on the Mintlify branch preview (dark overrides mirror the existing pattern in `style.css`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only navigation presentation in `style.css`; no auth, data, or application logic changes.
> 
> **Overview**
> Replaces a **no-op** sidebar rule that targeted Mintlify’s removed `#sidebar-title` id with styles on **`.sidebar-group-header`**, so section labels (Overview, Integrations, etc.) read as structure instead of looking like page links.
> 
> Section headings are restyled as muted **eyebrows** (11px, normal weight, letter-spacing, grey text) with **dark-mode** color overrides matching existing `style.css` patterns. Non-first sections get extra spacing and a **hairline top border** via `div[class*="mt-"] > .sidebar-group-header`. Active page link styling is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686f5ae3eec43f06cd5ff9281392706bf462f207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->