### PR TITLE
Rename Stripe Projects page title to Overview

### DIFF
--- a/integrations/stripe-projects.mdx
+++ b/integrations/stripe-projects.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stripe Projects"
+title: "Overview"
 description: "Provision Kernel cloud browsers and plans through the Stripe Projects CLI"
 ---
 


### PR DESCRIPTION
## Summary

Renames the `integrations/stripe-projects` page title from "Stripe Projects" to "Overview" so the first page of the **Stripe Projects** sidebar group reads "Overview", consistent with other section landing pages (Vercel, Auth, etc.).

Only the frontmatter `title` changes. The file path is untouched, so the URL stays `/integrations/stripe-projects` and existing links/redirects (including the `/llm.md` → `/integrations/stripe-projects` redirect) keep working.

## Test plan

- [ ] Confirm the page renders with H1 "Overview" and the sidebar entry under **Stripe Projects** shows "Overview".
- [ ] Confirm `/integrations/stripe-projects` still resolves (URL unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation frontmatter-only change with no routing, API, or behavior impact.
> 
> **Overview**
> Updates the frontmatter **`title`** on `integrations/stripe-projects.mdx` from **"Stripe Projects"** to **"Overview"** so the Stripe Projects sidebar group’s landing page matches other integration sections (e.g. Vercel **Overview**).
> 
> The route and file path are unchanged (`/integrations/stripe-projects`); only the displayed page title and sidebar label change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4388eb57843bb107df52cc39cceabbef68efbc27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->