### PR TITLE
Rename Introduction 'prod setup' heading to App Platform

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -56,7 +56,7 @@ import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
   </div>
 </div>
 
-## prod setup
+## App Platform
 
 Our [app platform](/apps/develop) is a serverless compute service for running agent loops triggered on demand or by scheduled events without having to provision or manage sandboxes. Your agent runs co-located with its browser to minimize network latency.
 


### PR DESCRIPTION
## Summary

Renames the `## prod setup` heading on the Introduction (home) page to `## App Platform`. The section already links to and describes the [app platform](/apps/develop), so the heading now names the product directly.

Note: the page otherwise uses lowercase headings ("start here", "scaling"); I used the requested "App Platform" casing. Easy to switch to "app platform" if you'd rather match that style.

## Test plan

- [ ] Confirm the home page section renders as "App Platform".
- [ ] No internal links targeted the old `#prod-setup` anchor (verified none exist in the repo).