### PR TITLE
Inset sidebar toggle chevrons so they clear the collapse button

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,12 +53,15 @@ html.dark #navigation-items div[class*="mt-"] > .sidebar-group-header {
   border-top-color: rgba(237, 238, 240, 0.1);
 }
 
-/* move nested nav arrows to the right */
+/* move nested nav arrows to the right, and inset them from the edge so they
+   clear the collapse-sidebar button (sticky in the top-right corner), which
+   otherwise crowds the toggle chevron of whatever row scrolls beneath it */
 #navigation-items li[data-title] > button.group,
 #navigation-items li[data-title] > div.group {
   width: 100% !important;
   flex-direction: row-reverse !important;
   justify-content: space-between !important;
+  padding-right: 1.75rem !important;
 }
 
 #navigation-items li[data-title] > button.group > svg,


### PR DESCRIPTION
## Summary

The collapse-sidebar control (`←|`) is sticky in the top-right corner of the nav. The right-aligned toggle chevrons sit in that same column, so when a toggle row scrolls beneath the collapse button, its chevron is crammed right up against it.

This adds right padding to the toggle rows so the chevrons are inset from the edge and clear the collapse button — while staying clearly right-aligned.

- Only affects expandable toggle rows (`button.group` / `div.group`); leaf page links are unchanged.
- Follow-up polish to the sidebar hierarchy change in #426.

## Test plan

- [x] Verified in a local `mintlify dev` render: toggle chevrons now sit clear of the collapse button, still right-aligned; leaf items and the section-heading eyebrows are unaffected.