### PR TITLE
Document that pool config updates skip acquired browsers

### DIFF
--- a/browsers/pools/faq.mdx
+++ b/browsers/pools/faq.mdx
@@ -30,6 +30,12 @@ No. Idle browsers in a pool are pre-loaded with the profile's contents at the ti
 
 To force the pool to pick up new profile contents, either call `kernel.browserPools.flush()` to destroy idle browsers (the pool refills automatically), or call `kernel.browserPools.update()` with `discard_all_idle: true`.
 
+### If I update a pool's config while browsers are acquired, do they get the new config when released?
+
+No. Config updates only apply to idle browsers — all of them by default, or just newly-created ones if you pass `discard_all_idle: false`. A browser that's acquired when you call `update()` keeps the config it was created with. Releasing it with `reuse: true` (the default) returns it to the pool still on the old config, so the pool can hold a mix of old- and new-config browsers until the acquired ones cycle out.
+
+To avoid stale browsers, release with `reuse: false` to destroy and rebuild on release, or wait for the acquired browsers to be destroyed via `timeout_seconds` (the pool refills with the new config automatically).
+
 ### Can pooled browsers save changes back to a profile?
 
 No. A profile attached to a pool is loaded read-only — pooled browsers never persist changes back to the profile, so `save_changes` does not apply to pools. Sending `save_changes` on a pool's profile is silently ignored (it is not rejected), so reusing a single-session profile object won't error. To capture profile state, use a single browser session instead: `kernel.browsers.create({ profile: { name, save_changes: true } })`.

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -236,6 +236,10 @@ The `size` parameter is always required when updating a pool, even if you only w
 
 By default, updating a pool discards all idle browsers and rebuilds them with the new configuration. Set `discard_all_idle: false` to keep existing idle browsers and only apply the new configuration to newly created browsers.
 
+<Note>
+Updating a pool only affects idle browsers. Browsers that are acquired when you call `update()` keep the configuration they were created with — releasing them with `reuse: true` returns them to the pool still on the old config. To avoid stale browsers, release with `reuse: false`, or wait for them to be destroyed via `timeout_seconds` and refilled with the new config.
+</Note>
+
 ## Flush idle browsers
 
 Destroy all idle browsers in the pool. Acquired browsers are not affected. The pool will automatically refill with the pool's specified configuration.


### PR DESCRIPTION
## Summary
- Add an FAQ entry clarifying that `browserPools.update()` only reconfigures **idle** browsers — a browser that's acquired at update time keeps its original config, and releasing it with `reuse: true` returns it to the pool still on the old config until it cycles out.
- Add a `<Note>` to the "Update a pool" section of the pools overview covering the same acquired-browser behavior, next to the existing `discard_all_idle` explanation.

## Why
The idle-browser update behavior (`discard_all_idle`, flush) is already documented, but the consequence for **acquired** browsers released with `reuse: true` wasn't called out anywhere. This is a real gotcha: a pool can hold a mix of old- and new-config browsers after an update until the acquired ones drain. The docs now spell out the two ways to force a clean cutover (`reuse: false` or letting them time out).

## Test plan
- [ ] Docs-only change; verify rendering in the Mintlify preview (`<Note>` component + FAQ formatting).