### PR TITLE
docs: clarify reused pool browsers keep stale config until flushed

### DIFF
--- a/browsers/pools/faq.mdx
+++ b/browsers/pools/faq.mdx
@@ -24,6 +24,10 @@ When a browser from a pool is set to be destroyed (by reaching its specified `ti
 
 Yes, use `kernel.browserPools.update()`. By default, idle browsers are discarded and rebuilt with new configuration. Set `discard_all_idle: false` to only apply changes to newly created browsers.
 
+### If I update a pool, do browsers that are currently in use pick up the new configuration?
+
+No. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during the update keeps its original configuration. If you release it with `reuse: true` (the default), it returns to the pool still running the old configuration and keeps getting handed out that way. It won't pick up the new configuration until it's flushed, either by a later `kernel.browserPools.update()` with `discard_all_idle: true` or by `kernel.browserPools.flush()`. To get every browser onto the new configuration, flush the pool once the in-use browsers have been released.
+
 ### If I update a profile's contents, will my pool's idle browsers pick up the change?
 
 No. Idle browsers in a pool are pre-loaded with the profile's contents at the time they were filled. Updating the profile (for example, re-saving auth state to the same `profile_id`) does not propagate to already-warmed browsers — only newly-filled browsers will use the updated profile.

--- a/browsers/pools/faq.mdx
+++ b/browsers/pools/faq.mdx
@@ -26,7 +26,9 @@ Yes, use `kernel.browserPools.update()`. By default, idle browsers are discarded
 
 ### If I update a pool, do browsers that are currently in use pick up the new configuration?
 
-No. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during the update keeps its original configuration. If you release it with `reuse: true` (the default), it returns to the pool still running the old configuration and keeps getting handed out that way. It won't pick up the new configuration until it's flushed, either by a later `kernel.browserPools.update()` with `discard_all_idle: true` or by `kernel.browserPools.flush()`. To get every browser onto the new configuration, flush the pool once the in-use browsers have been released.
+No. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during the update keeps its original configuration, and if you release it with `reuse: true` (the default) it returns to the pool still running the old configuration and keeps getting handed out that way.
+
+You have three ways to get it onto the new configuration: release it with `reuse: false` so it's destroyed and rebuilt on release instead of the old one returning to the pool; let the acquired browser reach its `timeout_seconds` while idle so it's destroyed and the pool refills automatically; or flush it after the fact with `kernel.browserPools.flush()` (or a later `kernel.browserPools.update()` with `discard_all_idle: true`) once the in-use browsers have been released.
 
 ### If I update a profile's contents, will my pool's idle browsers pick up the change?
 

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -236,6 +236,10 @@ The `size` parameter is always required when updating a pool, even if you only w
 
 By default, updating a pool discards all idle browsers and rebuilds them with the new configuration. Set `discard_all_idle: false` to keep existing idle browsers and only apply the new configuration to newly created browsers.
 
+<Warning>
+Reused browsers keep the configuration they were created with. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during an update keeps its original configuration, and if you then release it with `reuse: true` (the default) it re-enters the pool still carrying that stale configuration and keeps getting handed out that way. It won't pick up the new configuration until it's flushed, either by a later `update()` with `discard_all_idle: true` or by [`flush()`](#flush-idle-browsers). To guarantee every browser runs the new configuration, flush the pool once the in-use browsers have been released.
+</Warning>
+
 ## Flush idle browsers
 
 Destroy all idle browsers in the pool. Acquired browsers are not affected. The pool will automatically refill with the pool's specified configuration.

--- a/browsers/pools/overview.mdx
+++ b/browsers/pools/overview.mdx
@@ -237,7 +237,13 @@ The `size` parameter is always required when updating a pool, even if you only w
 By default, updating a pool discards all idle browsers and rebuilds them with the new configuration. Set `discard_all_idle: false` to keep existing idle browsers and only apply the new configuration to newly created browsers.
 
 <Warning>
-Reused browsers keep the configuration they were created with. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during an update keeps its original configuration, and if you then release it with `reuse: true` (the default) it re-enters the pool still carrying that stale configuration and keeps getting handed out that way. It won't pick up the new configuration until it's flushed, either by a later `update()` with `discard_all_idle: true` or by [`flush()`](#flush-idle-browsers). To guarantee every browser runs the new configuration, flush the pool once the in-use browsers have been released.
+Reused browsers keep the configuration they were created with. A pool update only rebuilds the browsers that are idle at the time of the update (the default `discard_all_idle: true` behavior). A browser that's acquired during an update keeps its original configuration, and if you then release it with `reuse: true` (the default) it re-enters the pool still carrying that stale configuration and keeps getting handed out that way.
+
+You have three ways to get an in-use browser onto the new configuration:
+
+- **Prevent it on release:** release with `reuse: false`. The browser is destroyed and rebuilt with the current pool configuration instead of the old one returning to the pool.
+- **Let it expire:** don't release the acquired browser for reuse. Let it reach its `timeout_seconds` while idle, at which point it's destroyed and the pool refills automatically with the new configuration.
+- **Clean it up after the fact:** [`flush()`](#flush-idle-browsers) the pool, or run a later `update()` with `discard_all_idle: true`, once the in-use browsers have been released.
 </Warning>
 
 ## Flush idle browsers


### PR DESCRIPTION
## Summary

Clarifies a subtle but important browser-pool behavior that wasn't documented: a browser released with `reuse: true` (the default) re-enters the pool carrying the configuration it was created with. A pool update only rebuilds the browsers that are **idle at the time of the update** (the default `discard_all_idle: true` behavior), so a browser that's acquired during an update keeps its old config and, once released with `reuse: true`, keeps getting handed out that way. It won't pick up the new configuration until it's flushed (a later `update()` with `discard_all_idle: true`, or `flush()`).

## Changes

- **`browsers/pools/overview.mdx`** — added a `<Warning>` in the "Update a pool" section explaining reused browsers retain their original config and how to force them onto the new config.
- **`browsers/pools/faq.mdx`** — added a matching FAQ entry ("If I update a pool, do browsers that are currently in use pick up the new configuration?"), mirroring the existing profile-staleness entry.

## Test plan

- [ ] Run `mintlify dev` and confirm both pages render, the `<Warning>` callout displays, and the in-page `flush()` anchor link resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to pool FAQ and overview; no runtime or API behavior changes.
> 
> **Overview**
> Documents that **`kernel.browserPools.update()`** only rebuilds **idle** browsers (default `discard_all_idle: true`). Browsers **acquired during** an update keep their original config, and releasing with default **`reuse: true`** puts them back in the pool still on the old config.
> 
> Adds a **`<Warning>`** in the pools overview **Update a pool** section and a matching **FAQ** entry (aligned with the existing profile-staleness FAQ). Both explain three remediation paths: **`reuse: false`** on release, idle **`timeout_seconds`**, or **`flush()`** / a later **`update()`** with **`discard_all_idle: true`** after releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14120cec4d8c8c558abfb843dbf41aec5109f5e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->