### PR TITLE
update header to use brand guidelines and make dark mode hover state slightly less maximalist

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,11 +33,11 @@ kbd {
    renders the group title as .sidebar-group-header (the old #sidebar-title id
    no longer exists), and the inner h3 inherits font/size/color from it. */
 #navigation-items .sidebar-group-header {
+  font-weight: 300 !important; /* Inter Light */
   font-size: 11px !important;
-  font-weight: 400 !important;
-  letter-spacing: 0.09em;
-  color: #60646c !important;
+  
 }
+
 html.dark #navigation-items .sidebar-group-header {
   color: rgba(237, 238, 240, 0.55) !important;
 }
@@ -49,6 +49,7 @@ html.dark #navigation-items .sidebar-group-header {
   padding-top: 1rem;
   border-top: 1px solid rgba(33, 34, 37, 0.1);
 }
+
 html.dark #navigation-items div[class*="mt-"] > .sidebar-group-header {
   border-top-color: rgba(237, 238, 240, 0.1);
 }
@@ -242,4 +243,8 @@ html.dark .callout[class*="yellow"] {
 }
 html.dark .callout[class*="yellow"] svg {
   color: #CAB168 !important;
+}
+
+.dark .card:hover {
+  border-color: rgb(223 223 223) !important;
 }


### PR DESCRIPTION
Updates styles to conform to brand guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual tweaks to Mintlify sidebar headers and card hover; no logic or data paths.
> 
> **Overview**
> **Sidebar section labels** in `#navigation-items .sidebar-group-header` now use **Inter Light** (`font-weight: 300`) per brand guidelines. Light-mode **letter-spacing**, **font-weight 400**, and the default **gray text color** on that selector were removed so styling leans on the shared rules and the existing **dark-mode** color override.
> 
> **Dark mode cards** get a subtler hover: `.dark .card:hover` sets a light gray border (`rgb(223 223 223)`) instead of a stronger default hover treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cd4c8e5162ed0752413e181c848f62f5ac026f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->