### PR TITLE
Update ToS onkernel.com references to kernel.sh

### DIFF
--- a/tos.mdx
+++ b/tos.mdx
@@ -10,9 +10,9 @@ PLEASE READ THIS MASTER SERVICES AGREEMENT (“AGREEMENT”) CAREFULLY BEFORE US
 
 **Customer Data** — means all data, information, and other materials submitted by Customer to the Services.
 
-**Documentation** — means any user guide, help information and other documentation and information regarding the Services that is delivered by Company to Customer in electronic or other form, available at [https://www.onkernel.com/docs/introduction](https://www.onkernel.com/docs/introduction), including any updates provided by Company from time to time.
+**Documentation** — means any user guide, help information and other documentation and information regarding the Services that is delivered by Company to Customer in electronic or other form, available at [https://www.kernel.sh/docs/introduction](https://www.kernel.sh/docs/introduction), including any updates provided by Company from time to time.
 
-**Kernel Website** — means the website located at [https://www.onkernel.com/](https://www.onkernel.com/).
+**Kernel Website** — means the website located at [https://www.kernel.sh/](https://www.kernel.sh/).
 
 **Services** — means the products and services made available by Company to Customer as may be mutually agreed to by the parties in an Order Form.
 
@@ -54,7 +54,7 @@ Except for the limited rights and licenses expressly granted to Customer hereund
 Except as expressly permitted in this Agreement, Customer shall not directly or indirectly (a) use any of Company's Confidential Information to create any service, software, documentation or data that is similar to or competes with any aspect of the Services, (b) disassemble, decompile, reverse engineer or use any other means to attempt to discover any source code of the Services, or the underlying ideas, algorithms or trade secrets therein, (c) use the Documentation for any reason other than in connection with the Services, (d) encumber, sublicense, transfer, rent, lease, time-share or use the Services in any service bureau arrangement or otherwise for the benefit of any third party, (e) copy, distribute, manufacture, adapt, create derivative works of, translate, localize, port or otherwise modify any aspect of the Services, (f) use or allow the transmission, transfer, export, re-export or other transfer of any product, technology or information it obtains or learns pursuant to this Agreement (or any direct product thereof) in violation of any export control or other laws and regulations of the United States or any other relevant jurisdiction or (g) permit any third party to engage in any of the foregoing proscribed acts.
 
 ### 3.5 Data Processing Addendum
-To the extent that, in connection with the Platform or Services, Customer provides any Customer Data that contains “Personal Data” from a European “Data Subject” that is subject to the European Union's General Data Protection Regulation, Provider's data processing addendum (“DPA”) available at [https://www.onkernel.com/docs/dpa](https://www.onkernel.com/docs/dpa) will apply. Any terms not defined in this Section 3.5 will have the meanings given to them in the DPA.
+To the extent that, in connection with the Platform or Services, Customer provides any Customer Data that contains “Personal Data” from a European “Data Subject” that is subject to the European Union's General Data Protection Regulation, Provider's data processing addendum (“DPA”) available at [https://www.kernel.sh/docs/dpa](https://www.kernel.sh/docs/dpa) will apply. Any terms not defined in this Section 3.5 will have the meanings given to them in the DPA.
 
 ## 4. Confidentiality
 

--- a/tos.mdx
+++ b/tos.mdx
@@ -10,7 +10,7 @@ PLEASE READ THIS MASTER SERVICES AGREEMENT (“AGREEMENT”) CAREFULLY BEFORE US
 
 **Customer Data** — means all data, information, and other materials submitted by Customer to the Services.
 
-**Documentation** — means any user guide, help information and other documentation and information regarding the Services that is delivered by Company to Customer in electronic or other form, available at [https://www.kernel.sh/docs/introduction](https://www.kernel.sh/docs/introduction), including any updates provided by Company from time to time.
+**Documentation** — means any user guide, help information and other documentation and information regarding the Services that is delivered by Company to Customer in electronic or other form, available at [https://www.kernel.sh/docs](https://www.kernel.sh/docs), including any updates provided by Company from time to time.
 
 **Kernel Website** — means the website located at [https://www.kernel.sh/](https://www.kernel.sh/).
 


### PR DESCRIPTION
## Summary
Updates the three `www.onkernel.com` URL references in the Terms of Service page to `www.kernel.sh`, keeping the existing paths intact.

- Documentation link → `https://www.kernel.sh/docs/introduction`
- Kernel Website definition → `https://www.kernel.sh/`
- DPA link → `https://www.kernel.sh/docs/dpa`

## Test plan
- [ ] Verify links resolve on the docs preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL changes in legal copy; no application logic or security behavior is modified.
> 
> **Overview**
> Updates the **Terms of Service** (`tos.mdx`) so contractual references use the **kernel.sh** domain instead of **onkernel.com**.
> 
> The **Documentation** definition now points to `https://www.kernel.sh/docs` (previously `onkernel.com/docs/introduction`). **Kernel Website** is defined as `https://www.kernel.sh/`. Section **3.5** links the GDPR **DPA** to `https://www.kernel.sh/docs/dpa`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041a23b53f65d35ce8c7cd1eb1b8d5768bc20683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->