### PR TITLE
Add July 3 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,24 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="July 3" tags={["Product", "Docs"]}>
+## Product updates
+
+- Added `kernel extensions get <id-or-name>` to the [CLI](https://github.com/kernel/cli) for extension metadata lookups, with table or JSON output.
+- Added `kernel browsers telemetry events <id>` to the [CLI](https://github.com/kernel/cli) for paginated historical telemetry reads, and a `--replay=all` flag on `browsers telemetry stream` to replay from the oldest retained event.
+- Browser pools dropped the `--save-changes` flag on `browser-pools create`/`update` in favor of simplified id/name-only pool profiles; single-session `browsers create --save-changes` is unaffected.
+- Added support for the `claude-sonnet-5` model to [`@onkernel/cua-ai`](https://github.com/kernel/cua).
+- Threaded `previous_response_id` through the Tzafon and OpenAI computer-use providers in [`@onkernel/cua-ai`](https://github.com/kernel/cua), so multi-turn runs send only the latest screenshot delta instead of replaying the full history each turn.
+- Rebuilt the dashboard managed-auth connection detail page around an overview/history/config tab layout, with a pinned stats row and a full event timeline (logins, re-auths, health checks) filterable by type.
+- Added mobile proxy creation to the dashboard, with country, state, and city targeting.
+- Added tablet (`768x1024`) and mobile (`390x844`) viewport presets to the dashboard pool create/edit dialogs.
+
+## Documentation updates
+
+- Added a [Computer Use overview page](/integrations/computer-use/overview) covering the shared screenshot-predict-execute loop and a guide for building custom agents with `@onkernel/cua-agent`.
+- Clarified that browsers released back into a pool with the default `reuse: true` keep their original configuration, and that `browserPools.update()` only rebuilds idle browsers when `discard_all_idle: true` is passed.
+</Update>
+
 <Update label="June 26" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,18 +12,18 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 <Update label="July 3" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added `kernel extensions get <id-or-name>` to the [CLI](https://github.com/kernel/cli) for extension metadata lookups, with table or JSON output.
-- Added `kernel browsers telemetry events <id>` to the [CLI](https://github.com/kernel/cli) for paginated historical telemetry reads, and a `--replay=all` flag on `browsers telemetry stream` to replay from the oldest retained event.
-- Browser pools dropped the `--save-changes` flag on `browser-pools create`/`update` in favor of simplified id/name-only pool profiles; single-session `browsers create --save-changes` is unaffected.
-- Added support for the `claude-sonnet-5` model to [`@onkernel/cua-ai`](https://github.com/kernel/cua).
+- Shipped `kernel extensions get <id-or-name>` in the [CLI](https://github.com/kernel/cli) for extension metadata lookups, with table or JSON output.
+- Extended CLI browser telemetry with `kernel browsers telemetry events <id>` for paginated historical reads and a `--replay=all` flag on `browsers telemetry stream` to replay from the oldest retained event.
+- Simplified browser pool profiles to id/name-only, dropping the `--save-changes` flag on `browser-pools create`/`update`; single-session `browsers create --save-changes` is unaffected.
+- Extended [`@onkernel/cua-ai`](https://github.com/kernel/cua) with computer-use support for the `claude-sonnet-5` model.
 - Threaded `previous_response_id` through the Tzafon and OpenAI computer-use providers in [`@onkernel/cua-ai`](https://github.com/kernel/cua), so multi-turn runs send only the latest screenshot delta instead of replaying the full history each turn.
 - Rebuilt the dashboard managed-auth connection detail page around an overview/history/config tab layout, with a pinned stats row and a full event timeline (logins, re-auths, health checks) filterable by type.
-- Added mobile proxy creation to the dashboard, with country, state, and city targeting.
-- Added tablet (`768x1024`) and mobile (`390x844`) viewport presets to the dashboard pool create/edit dialogs.
+- Brought mobile proxy creation into the dashboard, with country, state, and city targeting.
+- Expanded the dashboard pool create/edit dialogs with tablet (`768x1024`) and mobile (`390x844`) viewport presets.
 
 ## Documentation updates
 
-- Added a [Computer Use overview page](/integrations/computer-use/overview) covering the shared screenshot-predict-execute loop and a guide for building custom agents with `@onkernel/cua-agent`.
+- Published a [Computer Use overview page](/integrations/computer-use/overview) covering the shared screenshot-predict-execute loop and a guide for building custom agents with `@onkernel/cua-agent`.
 - Clarified that browsers released back into a pool with the default `reuse: true` keep their original configuration, and that `browserPools.update()` only rebuilds idle browsers when `discard_all_idle: true` is passed.
 </Update>
 


### PR DESCRIPTION
## Summary

Adds the July 3 changelog entry covering items publicly shipped and deployed since the June 26 update.

**Verified against merged PRs / released versions:**

Product
- CLI `extensions get`, `browsers telemetry events`, `--replay=all`, and drop of `browser-pools` `--save-changes` — CLI PR #192 (merged June 27 UTC).
- `claude-sonnet-5` in `@onkernel/cua-ai` — CUA PR #48, cua-ai v0.3.3 (June 30).
- `previous_response_id` threading for Tzafon and OpenAI CUA providers — CUA PR #46 (June 29).
- Dashboard managed-auth connection detail redesign — kernel PR #2536 (July 1).
- Dashboard mobile proxy creation — kernel PR #2545 (June 29).
- Dashboard tablet/mobile viewport presets — kernel PR #2051 (July 2).

Docs
- Computer Use overview page — docs PR #425 (June 30).
- Reused pool browsers / `discard_all_idle` clarification — docs PRs #431 (July 1) and #433 (July 2).

## Deltas from the initial draft

- Added the `previous_response_id` bullet (fixes Tzafon overflow after ~4 turns, cuts OpenAI per-turn payload growth).
- Added dashboard bullets: managed-auth tabbed layout + timeline, mobile proxy creation, tablet/mobile viewport presets.
- Merged the two pool-behavior docs bullets so the copy also matches the corrected `discard_all_idle` default (`false`).

## Test plan

- [ ] Mintlify preview renders the new `<Update>` block correctly.
- [ ] Links resolve (`/integrations/computer-use/overview`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog copy with no runtime or API behavior changes in this PR.
> 
> **Overview**
> Adds a new **July 3** `<Update>` block at the top of `changelog.mdx`, ahead of the June 26 entry.
> 
> **Product** bullets cover CLI (`extensions get`, browser telemetry history/replay, simplified pool profiles without `--save-changes`), `@onkernel/cua-ai` (`claude-sonnet-5`, `previous_response_id` for lighter multi-turn CUA), and dashboard work (managed-auth connection detail tabs/timeline, mobile proxy creation, tablet/mobile pool viewport presets).
> 
> **Documentation** bullets link the new [Computer Use overview](/integrations/computer-use/overview) and clarify pool reuse vs `browserPools.update()` / `discard_all_idle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6283ef4e28180c62f58a4672870a06299646dddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->