### PR TITLE
Document unified concurrency limit (CUS-275)

### DIFF
--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -58,15 +58,18 @@ Auth sessions are fast (typically 5-30 seconds each). Kernel monitors session he
 
 ## Concurrency limits
 
+Kernel enforces a single concurrency limit covering all browsers you run at once — whether created on demand with `browsers.create()` or reserved in a [browser pool](/browsers/pools/overview). Your full limit is available to either API in any mix.
+
 | Feature | Developer (free + usage) | Hobbyist ($30 / mo + usage) | Start-Up ($200 / mo + usage) | Enterprise |
 | --- | --- | --- | --- | --- |
-| Reserved browsers ([browser pools](/browsers/pools/overview)) | 0 | 0 | 100 | Custom |
-| On-demand browsers | 5 | 10 | 50 | Custom |
+| Concurrent browsers | 5 | 10 | 150 | Custom |
 | App invocations | 5 | 10 | 50 | Custom |
 | App invocations (per-app) | 5 | 10 | 20 | Custom |
 | Managed auth health check interval | N/A | 1 hour minimum | 20 minutes minimum | Custom |
 
-> Note: Browsers in [Standby Mode](/browsers/standby) count against on-demand concurrency limits.
+> Note: Reserved capacity in a [browser pool](/browsers/pools/overview) counts toward your concurrency limit whether or not the browsers are currently acquired — a pool sized to 40 browsers uses 40 of your limit. Browser pools are available on Start-Up and Enterprise plans.
+
+> Note: Browsers in [Standby Mode](/browsers/standby) count against your concurrency limit.
 
 > Note: Limits are org-wide by default unless stated otherwise. `Managed auth profiles` refer to profiles with active auth connections that Kernel maintains using your stored [Credentials](/auth/credentials) or [1Password connection](/integrations/1password). A single profile can have multiple auth connections (one per domain) — see [Profiles](/auth/profiles#multiple-auth-connections-per-profile) for details.
 

--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -320,9 +320,9 @@ if err := client.Projects.Delete(ctx, "proj_abc123"); err != nil {
 
 ## Concurrency Limits
 
-Kernel caps how many browser sessions can run at once, at two levels:
+Kernel caps how many browsers can run at once, at two levels. A single limit covers both on-demand browsers (`browsers.create()`) and [browser pools](/browsers/pools/overview) — standalone sessions and reserved pool capacity count against the same cap.
 
-- **Organization limit** — the total concurrent sessions allowed across your whole organization, determined by your plan. Every session counts against it.
+- **Organization limit** — the total concurrent browsers allowed across your whole organization, determined by your plan. Every browser session and every reserved pool slot counts against it.
 - **Per-project limits** — optional caps on individual projects, so one team or environment can't consume the entire org limit.
 
 Per-project caps come from two places:
@@ -336,18 +336,22 @@ A project's effective cap resolves in this order:
 2. Otherwise, the organization's default project cap, if set.
 3. Otherwise, no per-project cap — only the organization limit applies.
 
-A per-project cap never lets a project exceed your organization's concurrent-session limit.
+A per-project cap never lets a project exceed your organization's concurrency limit.
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `GET` | `/org/limits` | Get the org concurrent-session limit and the default per-project cap |
+| `GET` | `/org/limits` | Get the org concurrency limit and the default per-project cap |
 | `PATCH` | `/org/limits` | Set the default per-project cap (send `0` to clear it) |
 | `GET` | `/org/projects/{id}/limits` | Get a single project's limit overrides |
 | `PATCH` | `/org/projects/{id}/limits` | Set a single project's limit overrides (send `0` to clear a cap) |
 
+<Info>
+  `max_pooled_sessions` is deprecated. Pooled browsers now count toward `max_concurrent_sessions`, and requests that set `max_pooled_sessions` return a `400`.
+</Info>
+
 ### Set an org-wide default
 
-Apply a default of 10 concurrent sessions to every project that doesn't have its own override:
+Apply a default of 10 concurrent browsers to every project that doesn't have its own override:
 
 <CodeGroup>
 ```bash cURL

--- a/reference/cli/projects.mdx
+++ b/reference/cli/projects.mdx
@@ -68,9 +68,9 @@ Update per-project limit overrides. Pass `0` to a limit to remove the cap for th
 
 | Flag | Description |
 |------|-------------|
-| `--max-concurrent-sessions <n>` | Maximum concurrent browser sessions (0 to remove cap). |
+| `--max-concurrent-sessions <n>` | Maximum concurrent browsers, covering both on-demand sessions and browser pool reservations (0 to remove cap). |
 | `--max-concurrent-invocations <n>` | Maximum concurrent app invocations (0 to remove cap). |
-| `--max-pooled-sessions <n>` | Maximum pooled sessions capacity (0 to remove cap). |
+| `--max-pooled-sessions <n>` | Deprecated — pooled browsers now count toward `--max-concurrent-sessions`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ```bash


### PR DESCRIPTION
## Summary

Updates docs for the consolidation of the separate on-demand and browser-pool concurrency limits into a single unified concurrency limit ([CUS-275](https://linear.app/onkernel/issue/CUS-275/hark-billing-consolidate-on-demand-concurrency-limit-and-bpool), enforcement shipped in kernel/kernel#2540).

- **`info/pricing.mdx`** — replaces the separate "Reserved browsers" / "On-demand browsers" rows with a single "Concurrent browsers" row (5 / 10 / 150 / Custom), adds an intro explaining the unified limit, notes that reserved pool capacity counts toward the limit, and updates the Standby note.
- **`info/projects.mdx`** — rewrites the Concurrency Limits intro to describe the unified semantics (create + pool reservations share one cap), updates "concurrent-session limit" wording, and adds a deprecation note for `max_pooled_sessions`.
- **`reference/cli/projects.mdx`** — marks `--max-pooled-sessions` deprecated and clarifies `--max-concurrent-sessions` covers both.

API reference / SDK description updates are in a companion PR on kernel/kernel (openapi.yaml → Stainless).

## ⚠️ Do not merge yet

Draft until the `kernel_api_unified_concurrency_limit` flag is switched to **on** and affected customers with custom overrides have been notified. Merging early would document behavior most orgs don't have yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; merge timing should follow the feature flag rollout noted in the PR.
> 
> **Overview**
> Documents **one org-wide concurrency cap** for on-demand `browsers.create()` and **browser pool** reservations, replacing the old split between reserved vs on-demand limits.
> 
> **`info/pricing.mdx`** adds an intro on the unified limit, collapses the plan table to a single **Concurrent browsers** row (Start-Up **150** vs the old 100 reserved + 50 on-demand), and clarifies that **reserved pool size** and **Standby** browsers both consume that cap.
> 
> **`info/projects.mdx`** rewrites concurrency semantics (sessions + pool slots share one org limit), updates API wording to “concurrency limit,” and notes **`max_pooled_sessions` is deprecated** (counts toward `max_concurrent_sessions`; setting it returns **400**).
> 
> **`reference/cli/projects.mdx`** aligns `--max-concurrent-sessions` with the unified model and marks **`--max-pooled-sessions` deprecated**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8bcd95e70bd3d832cbbc4d23a5fdff69d5a906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->