### PR TITLE
Document proxy health check in proxies overview

### DIFF
--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -198,59 +198,26 @@ func main() {
 
 ## Check proxy health
 
-Before attaching a proxy to a browser session, run a health check to verify credentials and connectivity. This is especially useful right after creation, after rotating credentials, or when a session against the proxy starts failing. Pass an optional `url` to test reachability against a specific target instead of Kernel's default test URLs.
+Before attaching a proxy to a browser session, run a health check to verify credentials and connectivity. Pass an optional `url` to test reachability against a specific target instead of Kernel's default test URLs.
 
 <CodeGroup>
 ```typescript Typescript/Javascript
-import Kernel from '@onkernel/sdk';
-
-const kernel = new Kernel();
-
-const result = await kernel.proxies.check(proxy.id, {
-  url: 'https://example.com',
-});
-console.log(result.last_checked_at, result.ip_address);
+await kernel.proxies.check(proxy.id, { url: 'https://example.com' });
 ```
 
 ```python Python
-from kernel import Kernel
-
-kernel = Kernel()
-
-result = kernel.proxies.check(
-    id=proxy.id,
-    url="https://example.com",
-)
-print(result.last_checked_at, result.ip_address)
+kernel.proxies.check(id=proxy.id, url="https://example.com")
 ```
 
 ```go Go
-package main
-
-import (
-	"context"
-	"fmt"
-
-	"github.com/kernel/kernel-go-sdk"
-)
-
-func main() {
-	ctx := context.Background()
-	client := kernel.NewClient()
-
-	result, err := client.Proxies.Check(ctx, proxy.ID, kernel.ProxyCheckParams{
-		URL: kernel.String("https://example.com"),
-	})
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(result.LastCheckedAt, result.IPAddress)
-}
+client.Proxies.Check(ctx, proxy.ID, kernel.ProxyCheckParams{
+    URL: kernel.String("https://example.com"),
+})
 ```
 </CodeGroup>
 
 <Info>
-For ISP and datacenter proxies, the exit IP is stable, so a successful check against a `url` reliably indicates that subsequent browser sessions will reach the same target from the same IP. For residential and mobile proxies, the exit node changes between requests, so the check validates credentials and connectivity but does not guarantee that a later session will use the same exit IP. When `url` is provided, the result does not update the proxy's stored health status, since a failure may indicate a problem with the target site rather than the proxy itself.
+For ISP and datacenter proxies the exit IP is stable, so a successful check against a `url` reliably indicates that subsequent sessions will reach the same target from the same IP. For residential and mobile proxies the exit node changes between requests, so the check validates credentials and connectivity but not site-specific reachability. When `url` is provided, the result does not update the proxy's stored health status.
 </Info>
 
 ## Bypass hosts

--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -196,6 +196,63 @@ func main() {
 ```
 </CodeGroup>
 
+## Check proxy health
+
+Before attaching a proxy to a browser session, run a health check to verify credentials and connectivity. This is especially useful right after creation, after rotating credentials, or when a session against the proxy starts failing. Pass an optional `url` to test reachability against a specific target instead of Kernel's default test URLs.
+
+<CodeGroup>
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const result = await kernel.proxies.check(proxy.id, {
+  url: 'https://example.com',
+});
+console.log(result.last_checked_at, result.ip_address);
+```
+
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+result = kernel.proxies.check(
+    id=proxy.id,
+    url="https://example.com",
+)
+print(result.last_checked_at, result.ip_address)
+```
+
+```go Go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kernel/kernel-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+	client := kernel.NewClient()
+
+	result, err := client.Proxies.Check(ctx, proxy.ID, kernel.ProxyCheckParams{
+		URL: kernel.String("https://example.com"),
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(result.LastCheckedAt, result.IPAddress)
+}
+```
+</CodeGroup>
+
+<Info>
+For ISP and datacenter proxies, the exit IP is stable, so a successful check against a `url` reliably indicates that subsequent browser sessions will reach the same target from the same IP. For residential and mobile proxies, the exit node changes between requests, so the check validates credentials and connectivity but does not guarantee that a later session will use the same exit IP. When `url` is provided, the result does not update the proxy's stored health status, since a failure may indicate a problem with the target site rather than the proxy itself.
+</Info>
+
 ## Bypass hosts
 
 Configure specific hostnames to bypass the proxy and connect directly. This is useful for accessing internal services, metadata endpoints, or reducing latency for trusted domains.


### PR DESCRIPTION
## Summary

Adds a "Check proxy health" section to the proxies overview page with guidance on when to run a health check (after creation, after rotating credentials, when a session starts failing) and code samples in TS/Python/Go.

The examples include the optional `url` parameter to test reachability against a specific target, and an Info callout explains the ISP/datacenter vs residential/mobile nuance and the fact that passing `url` does not update the proxy's stored health status.

## Test plan

- [ ] Preview renders the new section under "Use with browsers" and above "Bypass hosts"
- [ ] Code samples compile against the current SDKs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX change with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Check proxy health** section to `proxies/overview.mdx`, placed after **Use with browsers** and before **Bypass hosts**.
> 
> The section documents running `proxies.check` before attaching a proxy to a session, with optional `url` to test a specific target instead of Kernel defaults. It includes TypeScript, Python, and Go samples and an Info callout on ISP/datacenter (stable exit IP vs URL reachability) vs residential/mobile (rotating exits), plus that supplying `url` does not update the proxy's stored health status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea269b096de1184906c4e58d2b9e38106bb5d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->