### PR TITLE
Add GA4 integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -375,5 +375,10 @@
       "github": "https://github.com/orgs/kernel",
       "linkedin": "https://www.linkedin.com/company/trykernel"
     }
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-GVEXRLYSN4"
+    }
   }
 }


### PR DESCRIPTION
Enables the Mintlify GA4 integration with measurement ID `G-GVEXRLYSN4` so kernel.sh/docs pageviews land in the shared GA4 property.

## Test plan
- [ ] Preview build shows `gtag` fires on a few doc pages.
- [ ] Confirm GA4 Realtime shows docs pageviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site analytics config only; no runtime product, auth, or data-path changes.
> 
> **Overview**
> Adds Mintlify’s **GA4** integration to `docs.json` with measurement ID **`G-GVEXRLYSN4`**, so **kernel.sh/docs** pageviews are sent to the shared GA4 property.
> 
> This is configuration-only: Mintlify will load **`gtag`** on doc pages; no app or API code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ee9bf511c0e41387d9e40996113e57a95d72c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->