### PR TITLE
Document 1Password SSO/identity flow limitation

### DIFF
--- a/integrations/1password.mdx
+++ b/integrations/1password.mdx
@@ -141,10 +141,10 @@ If your 1Password item has a one-time password (TOTP) field configured, it will 
 
 ## Supported Login Types
 
-Managed Auth fills **direct logins** from 1Password: username/password credentials plus any TOTP field for 2FA.
+Managed Auth fills **direct logins** from 1Password items: username/password credentials plus any TOTP field for 2FA. This includes signing directly into an identity provider itself—for example logging into a Google or Gmail account with its stored username, password, and TOTP.
 
 <Warning>
-SSO and other identity-provider flows (e.g. "Sign in with Google" or "Sign in with Microsoft") are not supported. The 1Password API only exposes stored credential values, not identity sessions, so Managed Auth can only complete direct logins.
+1Password's linked-item "sign in with" references are not supported. When an item delegates authentication to a separate item—for example a PostHog item set to **sign in with Google**—that link is not exposed through the 1Password API, so Managed Auth can't follow it to the underlying credential. Store a direct login (username/password, plus a TOTP field if needed) for the target site instead.
 </Warning>
 
 ## Credential Options

--- a/integrations/1password.mdx
+++ b/integrations/1password.mdx
@@ -139,6 +139,14 @@ If multiple items match a domain, the first match is used. Organize your vaults 
 
 If your 1Password item has a one-time password (TOTP) field configured, it will be used automatically for 2FA—no additional setup needed.
 
+## Supported Login Types
+
+Managed Auth fills **direct logins** from 1Password: username/password credentials plus any TOTP field for 2FA.
+
+<Warning>
+SSO and other identity-provider flows (e.g. "Sign in with Google" or "Sign in with Microsoft") are not supported. The 1Password API only exposes stored credential values, not identity sessions, so Managed Auth can only complete direct logins.
+</Warning>
+
 ## Credential Options
 
 The `credential` object supports multiple sources:


### PR DESCRIPTION
## Summary
- Add a **Supported Login Types** section to the 1Password integration docs clarifying that Managed Auth fills direct logins (username/password + TOTP) from 1Password.
- Add a warning callout that SSO and other identity-provider flows ("Sign in with Google", etc.) are not supported, because the 1Password API only exposes stored credential values, not identity sessions.

## Why
The docs described TOTP and direct credential support but never stated that SSO/identity flows are unsupported, which came up as a gap when explaining the integration's scope.

## Preview
`https://tbd-6fc993ce-hypeship-1password-no-sso-note.mintlify.app/integrations/1password`

## Test plan
- [ ] Verify the new section renders correctly in Mintlify preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds a **Supported Login Types** section after TOTP in `integrations/1password.mdx` so Managed Auth scope is explicit: **direct** 1Password logins (username/password and optional TOTP), including signing into an IdP like Google with stored credentials.
> 
> A **Warning** callout states that 1Password **linked-item “sign in with”** references (e.g. PostHog → sign in with Google) are not available via the 1Password API, so users should store a direct login for the target site instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222a52c85c3a6d8670336e343c899322230cc6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->