### PR TITLE
Make 1Password linked-item docs example generic

### DIFF
--- a/integrations/1password.mdx
+++ b/integrations/1password.mdx
@@ -141,10 +141,10 @@ If your 1Password item has a one-time password (TOTP) field configured, it will 
 
 ## Supported Login Types
 
-Managed Auth fills **direct logins** from 1Password items: username/password credentials plus any TOTP field for 2FA. This includes signing directly into an identity provider itself—for example logging into a Google or Gmail account with its stored username, password, and TOTP.
+Managed Auth fills **direct logins** from 1Password items: username/password credentials plus any TOTP field for 2FA. This includes signing directly into an identity provider itself—for example logging into a Google account with its stored username, password, and TOTP.
 
 <Warning>
-1Password's linked-item "sign in with" references are not supported. When an item delegates authentication to a separate item—for example a PostHog item set to **sign in with Google**—that link is not exposed through the 1Password API, so Managed Auth can't follow it to the underlying credential. Store a direct login (username/password, plus a TOTP field if needed) for the target site instead.
+1Password's linked-item "sign in with" references are not supported. When an item delegates authentication to a separate item—for example a site item set to **sign in with** another login—that link is not exposed through the 1Password API, so Managed Auth can't follow it to the underlying credential. Store a direct login (username/password, plus a TOTP field if needed) for the target site instead.
 </Warning>
 
 ## Credential Options


### PR DESCRIPTION
## Summary
- Generalize the "sign in with" linked-item example in the 1Password integration docs so it doesn't name a specific third-party service.

## Why
Follow-up to the earlier linked-item clarification — the example should describe the linked-item pattern generically rather than referencing a particular product.

## Preview
`https://tbd-6fc993ce-hypeship-1password-generic-linked-item.mintlify.app/integrations/1password`

## Test plan
- [ ] Verify the section renders correctly in Mintlify preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation copy only; no runtime, API, or credential-handling behavior changes.
> 
> **Overview**
> Updates **Supported Login Types** in the 1Password integration docs so examples stay generic: the direct-login illustration now refers to a **Google account** only (drops the redundant “Gmail” wording).
> 
> The linked-item **Warning** no longer names PostHog or Google SSO; it describes a **site item** that **sign in with** another login, matching the limitation that the 1Password API does not expose those references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8b74fd353d57a5897cb07984da8b59370e1092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->