### PR TITLE
Add July 10 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -14,23 +14,17 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 
 - Consolidated on-demand and browser-pool concurrency into a single unified [concurrency limit](/info/projects) that counts `browsers.create()` sessions and pool reservations against one org cap. `max_pooled_sessions` is deprecated; `max_concurrent_sessions` now covers both. Rolling out gradually.
 - Shipped `kernel audit-logs search` in the [CLI](https://github.com/kernel/cli) for querying the org audit log by time window, HTTP method, service, auth strategy, and user, with table or JSON output. `GET` requests are excluded by default to keep the signal on mutations.
-- Extended `kernel browsers telemetry events` in the [CLI](https://github.com/kernel/cli) with per-category, per-type, and session-token filter flags plus paged reads across the full retained archive.
-- Added a `refresh_on_profile_update` flag to [browser pools](/browsers/pools) (SDK, [CLI](https://github.com/kernel/cli) `--refresh-on-profile-update`, and dashboard). Opted-in pools automatically flush their idle browsers when the pool's managed-auth profile re-authenticates, so pooled sessions stay logged in instead of serving stale cookies after a re-auth.
+- Added a `refresh_on_profile_update` flag to [browser pools](/browsers/pools) (SDK, [CLI](https://github.com/kernel/cli) `--refresh-on-profile-update`, and dashboard). Opted-in pools automatically flush their idle browsers when the pool's managed-auth profile re-authenticates, so pooled sessions stay logged in after a re-auth.
 - Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with action-plane modes — `computer`, `browser`, and `hybrid` — plus `setMode()` and a `/mode` runtime switcher, and wired in support for Anthropic's shipped native `computer_20260701` and `browser_20260701` tools.
-- Telemetry requests on `browsers.create` now merge onto the operational default set (`control`, `connection`, `system`, `captcha`) instead of replacing it, so opting into a rich category like `page` no longer silently drops the defaults. Create and update resolve identical payloads identically.
-- Browser telemetry `page_error` events now include the exception message text (not just the type), so debugging session errors no longer requires opening the replay.
-- Fixed browser telemetry `interaction_click` / `interaction_key` / `interaction_scroll_settled` events not firing when the `interaction` category was enabled mid-session or against an already-loaded page, and stopped dropping keystrokes during fast or automated typing.
 - Exposed `profile_id` and `extension_ids` on browser pool reads, and returned an SHA-256 checksum for uploaded extensions.
 - Added the ability to inspect credential value keys and remove specific values on managed-auth credential updates.
 - `DELETE /org/api_keys/{id}` now returns `400 cannot_delete_current_key` when the target key is the one authenticating the request, so scripts and Terraform-style provisioners can't brick their own credentials mid-run.
 
 ## Documentation updates
 
-- Documented the unified [concurrency limit](/info/projects) semantics and marked `max_pooled_sessions` deprecated across pricing, projects, and the CLI reference.
+- Documented the unified [concurrency limit](/info/projects) and marked `max_pooled_sessions` deprecated across pricing, projects, and the CLI reference.
 - Documented the new [`refresh_on_profile_update`](/browsers/pools) browser pool flag.
 - Added a proxy [health check](/proxies/overview) reference to the proxies overview.
-- Added a [Google Analytics 4](/integrations/ga4) integration guide.
-- Made the [1Password](/integrations/1password) linked-item example generic across item types and documented the current SSO/identity flow limitation.
 </Update>
 
 <Update label="July 3" tags={["Product", "Docs"]}>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,30 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="July 10" tags={["Product", "Docs"]}>
+## Product updates
+
+- Consolidated on-demand and browser-pool concurrency into a single unified [concurrency limit](/info/projects) that counts `browsers.create()` sessions and pool reservations against one org cap. `max_pooled_sessions` is deprecated; `max_concurrent_sessions` now covers both. Rolling out gradually.
+- Shipped `kernel audit-logs search` in the [CLI](https://github.com/kernel/cli) for querying the org audit log by time window, HTTP method, service, auth strategy, and user, with table or JSON output. `GET` requests are excluded by default to keep the signal on mutations.
+- Extended `kernel browsers telemetry events` in the [CLI](https://github.com/kernel/cli) with per-category, per-type, and session-token filter flags plus paged reads across the full retained archive.
+- Added a `refresh_on_profile_update` flag to [browser pools](/browsers/pools) (SDK, [CLI](https://github.com/kernel/cli) `--refresh-on-profile-update`, and dashboard). Opted-in pools automatically flush their idle browsers when the pool's managed-auth profile re-authenticates, so pooled sessions stay logged in instead of serving stale cookies after a re-auth.
+- Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with action-plane modes — `computer`, `browser`, and `hybrid` — plus `setMode()` and a `/mode` runtime switcher, and wired in support for Anthropic's shipped native `computer_20260701` and `browser_20260701` tools.
+- Telemetry requests on `browsers.create` now merge onto the operational default set (`control`, `connection`, `system`, `captcha`) instead of replacing it, so opting into a rich category like `page` no longer silently drops the defaults. Create and update resolve identical payloads identically.
+- Browser telemetry `page_error` events now include the exception message text (not just the type), so debugging session errors no longer requires opening the replay.
+- Fixed browser telemetry `interaction_click` / `interaction_key` / `interaction_scroll_settled` events not firing when the `interaction` category was enabled mid-session or against an already-loaded page, and stopped dropping keystrokes during fast or automated typing.
+- Exposed `profile_id` and `extension_ids` on browser pool reads, and returned an SHA-256 checksum for uploaded extensions.
+- Added the ability to inspect credential value keys and remove specific values on managed-auth credential updates.
+- `DELETE /org/api_keys/{id}` now returns `400 cannot_delete_current_key` when the target key is the one authenticating the request, so scripts and Terraform-style provisioners can't brick their own credentials mid-run.
+
+## Documentation updates
+
+- Documented the unified [concurrency limit](/info/projects) semantics and marked `max_pooled_sessions` deprecated across pricing, projects, and the CLI reference.
+- Documented the new [`refresh_on_profile_update`](/browsers/pools) browser pool flag.
+- Added a proxy [health check](/proxies/overview) reference to the proxies overview.
+- Added a [Google Analytics 4](/integrations/ga4) integration guide.
+- Made the [1Password](/integrations/1password) linked-item example generic across item types and documented the current SSO/identity flow limitation.
+</Update>
+
 <Update label="July 3" tags={["Product", "Docs"]}>
 ## Product updates
 


### PR DESCRIPTION
## Summary

Adds the July 10 changelog entry covering product and docs changes that shipped July 3–9.

## Notes on the unified concurrency limit bullet

Both the product bullet and the docs bullet reference the unified concurrency limit, which is currently rolling out (10% of orgs + Kernel internal are on as of July 9 via infra#791). The customer-facing docs describing the new semantics live in a companion draft PR (kernel/docs#436) and the OpenAPI deprecation of `max_pooled_sessions` lives in kernel/kernel#2630. Those should land alongside this entry, otherwise the changelog references concepts that aren't yet documented.

## Test plan

- [ ] Preview the changelog page and confirm the July 10 entry renders above July 3 with the correct link targets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds a **July 10** changelog block above the existing July 3 entry, in the same `<Update>` format with separate **Product updates** and **Documentation updates** sections.
> 
> The product bullets announce shipped work from early July: unified org **concurrency** (`max_concurrent_sessions`, deprecated `max_pooled_sessions`), **`kernel audit-logs search`**, browser pool **`refresh_on_profile_update`**, **`@onkernel/cua-agent`** mode/tool updates, richer pool/extension/credential API surfaces, and a guard on **API key self-deletion**. The docs bullets point readers at the new concurrency semantics, the pool refresh flag, and proxy health-check docs.
> 
> **Note:** The PR description flags that linked docs/OpenAPI changes may still be in companion PRs, so some links may not match live docs until those land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508352747f1c2af185d8518c120217ad202752ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->