### PR TITLE
docs(telemetry): document BAA category restrictions

### DIFF
--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -59,10 +59,10 @@ Some exposure is reduced for you automatically: input into sensitive fields such
 
 ### Restrictions for organizations with a BAA
 
-If your organization has signed a business associate agreement (BAA) with Kernel, the `network`, `console`, and `screenshot` categories are blocked and can't be captured. These are the categories most likely to record protected health information (PHI): full request and response data, arbitrary page logs, and rendered images of the screen.
+If your organization has signed a business associate agreement (BAA) with Kernel - the contract required to handle data under HIPAA - the `network`, `console`, and `screenshot` categories are blocked and can't be captured. These are the categories most likely to record protected health information (PHI): full request and response data, anything the page logs, and rendered images of the screen.
 
 The restriction is enforced when you create a session (`POST /browsers`) or update one (`PATCH /browsers/{id}`). Enabling any blocked category returns a `400` response with the code `telemetry_category_restricted`, and the session's telemetry config is left unchanged. The remaining browser-activity categories (`page` and `interaction`) and all operational categories stay available.
 
 <Warning>
-If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. `page` and `interaction` remain available under a BAA but can still carry identifiers or personal data - enable them only when you need them. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
+If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. `page` and `interaction` stay available under a BAA but can still carry personal data. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
 </Warning>

--- a/browsers/telemetry/categories.mdx
+++ b/browsers/telemetry/categories.mdx
@@ -57,6 +57,12 @@ Captured events are persisted and can be replayed by [resuming the stream](/brow
 
 Some exposure is reduced for you automatically: input into sensitive fields such as passwords is suppressed (`interaction_key` isn't emitted for them, and `interaction_click` omits the element text). Beyond that, because selection is opt-in, the most effective control is to capture only the categories you need - enable `network`, `console`, `page`, `interaction`, or `screenshot` deliberately, and prefer the operational categories when you only need session health.
 
+### Restrictions for organizations with a BAA
+
+If your organization has signed a business associate agreement (BAA) with Kernel, the `network`, `console`, and `screenshot` categories are blocked and can't be captured. These are the categories most likely to record protected health information (PHI): full request and response data, arbitrary page logs, and rendered images of the screen.
+
+The restriction is enforced when you create a session (`POST /browsers`) or update one (`PATCH /browsers/{id}`). Enabling any blocked category returns a `400` response with the code `telemetry_category_restricted`, and the session's telemetry config is left unchanged. The remaining browser-activity categories (`page` and `interaction`) and all operational categories stay available.
+
 <Warning>
-If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
+If you operate under HIPAA, GDPR, or similar obligations, be deliberate about the browser-activity categories: pointing them at a site that handles regulated data captures that data into storage. `page` and `interaction` remain available under a BAA but can still carry identifiers or personal data - enable them only when you need them. If you have compliance requirements around what Kernel may process, [contact us](mailto:security@kernel.sh) before enabling them.
 </Warning>


### PR DESCRIPTION
## Summary

- Documents that organizations with a signed BAA cannot capture the `network`, `console`, and `screenshot` telemetry categories.
- Clarifies that enforcement happens on session create (`POST /browsers`) and update (`PATCH /browsers/{id}`), returning `400 telemetry_category_restricted` with the config left unchanged.
- Notes that `page` and `interaction` remain available under a BAA but can still carry personal data, closing a gap where the sensitivity table flagged them as sensitive without explaining their availability.

## Context

The enforcement already exists in `packages/api` (`enforceTelemetryBAARestrictions` in `telemetry.go`, gated on the `kernel_org_baa` PostHog flag), but was previously undocumented — the categories page only had a soft advisory `<Warning>`. This makes the enforced behavior explicit.

## Test plan

- [ ] Verify the page renders in `mintlify dev` and the new H3 + updated Warning display correctly.

Made with [Cursor](https://cursor.com)