### PR TITLE
Add managed proxy without CAPTCHA solver to stealth BYO patterns

### DIFF
--- a/browsers/bot-detection/stealth.mdx
+++ b/browsers/bot-detection/stealth.mdx
@@ -68,6 +68,7 @@ Anti-detection is the platform default, so you can freely mix in your own networ
 
 - **BYO proxy, keep CAPTCHA solver** — launch a stealth browser with your own [proxy](/proxies/overview) via `proxy_id`. Replaces the ISP default; CAPTCHA solver stays loaded.
 - **BYO proxy, no CAPTCHA solver** — launch a non-stealth browser with your own `proxy_id`. Full anti-detection config, no managed proxy or CAPTCHA extension.
+- **Managed proxy, no CAPTCHA solver** — launch a non-stealth browser with a defined managed proxy via `proxy_id`. Full anti-detection config with a Kernel managed proxy and no CAPTCHA extension enabled.
 - **Disable the default proxy at runtime** — on a running stealth browser, set [`disable_default_proxy`](/proxies/overview#disable-default-proxy-on-stealth-browsers) to route directly while keeping the CAPTCHA solver.
 
 ### Stealth with your own proxy


### PR DESCRIPTION
## Summary

Adds a new bullet to the "Bring your own proxy or CAPTCHA solver" list on the stealth docs page covering the managed-proxy-without-CAPTCHA-solver pattern:

> **Managed proxy, no CAPTCHA solver** — launch a non-stealth browser with a defined managed proxy via `proxy_id`. Full anti-detection config with a Kernel managed proxy and no CAPTCHA extension enabled.

Fills the gap between the existing BYO-proxy patterns and rounds out the combinations of managed vs. bring-your-own proxy with/without the CAPTCHA solver.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a third bullet to **Bring your own proxy or CAPTCHA solver** on the stealth docs page, describing **managed proxy, no CAPTCHA solver**: create a non-stealth browser with a Kernel managed `proxy_id` to keep full anti-detection while skipping the CAPTCHA extension.
> 
> This documents the combination that was missing next to the existing BYO-proxy bullets and the runtime `disable_default_proxy` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9a9ef73a73841723d4678cfd1daebeca7f991b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->