### PR TITLE
docs(mcp): execute_playwright_code passthrough + manage_replays tool

### DIFF
--- a/browsers/playwright-execution.mdx
+++ b/browsers/playwright-execution.mdx
@@ -353,4 +353,8 @@ This makes it ideal for one-off operations where you need maximum speed.
 
 ## MCP server integration
 
-This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents create a session with the `manage_browsers` tool, run Playwright code against it with the `execute_playwright_code` tool, and can capture a video with the `manage_replays` tool.
+This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents drive it across three tools:
+
+- `manage_browsers` — create a session (and delete it when done).
+- `execute_playwright_code` — run Playwright code against that session.
+- `manage_replays` — optionally record a video while the automation runs.

--- a/browsers/playwright-execution.mdx
+++ b/browsers/playwright-execution.mdx
@@ -353,4 +353,4 @@ This makes it ideal for one-off operations where you need maximum speed.
 
 ## MCP server integration
 
-This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents can use the `execute_playwright_code` tool to run Playwright code against browsers with automatic video replay and cleanup.
+This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents create a session with the `manage_browsers` tool, run Playwright code against it with the `execute_playwright_code` tool, and can capture a video with the `manage_replays` tool.

--- a/browsers/playwright-execution.mdx
+++ b/browsers/playwright-execution.mdx
@@ -353,8 +353,4 @@ This makes it ideal for one-off operations where you need maximum speed.
 
 ## MCP server integration
 
-This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents drive it across three tools:
-
-- `manage_browsers` — create a session (and delete it when done).
-- `execute_playwright_code` — run Playwright code against that session.
-- `manage_replays` — optionally record a video while the automation runs.
+This feature is available as a tool in our [MCP server](/reference/mcp-server). AI agents can use the `execute_playwright_code` tool to run Playwright code against browsers directly in the VM with lower latency.

--- a/docs.json
+++ b/docs.json
@@ -337,6 +337,7 @@
               "reference/mcp-server/tools/manage-apps",
               "reference/mcp-server/tools/computer-action",
               "reference/mcp-server/tools/execute-playwright-code",
+              "reference/mcp-server/tools/manage-replays",
               "reference/mcp-server/tools/exec-command",
               "reference/mcp-server/tools/search-docs"
             ]

--- a/reference/mcp-server/examples.mdx
+++ b/reference/mcp-server/examples.mdx
@@ -15,9 +15,21 @@ Assistant: I'll execute your web-scraper action with reddit.com as the target.
 
 ```
 Human: Go to example.com and get me the page title
-Assistant: I'll execute Playwright code to navigate to the site and retrieve the title.
-[Uses execute_playwright_code tool with code: "await page.goto('https://example.com'); return await page.title();"]
-Returns: { success: true, result: "Example Domain", replay_url: "https://..." }
+Assistant: I'll create a browser session, then execute Playwright code to navigate to the site and retrieve the title.
+[Uses manage_browsers tool with action: "create" to launch a session]
+[Uses execute_playwright_code tool with session_id and code: "await page.goto('https://example.com'); return await page.title();"]
+Returns: { success: true, result: "Example Domain" }
+[Uses manage_browsers tool with action: "delete" to clean up the session]
+```
+
+## Record a video replay of an automation
+
+```
+Human: Record a video while you scrape this page
+Assistant: I'll start a replay recording, run the automation, then stop it.
+[Uses manage_replays tool with action: "start" and the session_id]
+[Uses execute_playwright_code tool to run the automation]
+[Uses manage_replays tool with action: "stop" to end the recording]
 ```
 
 ## Set up browser profiles for authentication

--- a/reference/mcp-server/tools/execute-playwright-code.mdx
+++ b/reference/mcp-server/tools/execute-playwright-code.mdx
@@ -3,7 +3,9 @@ title: "execute_playwright_code"
 description: "Run Playwright/TypeScript code against a browser session"
 ---
 
-Execute Playwright/TypeScript automation code against a Kernel browser session. If `session_id` is provided, uses that existing browser; otherwise creates a new one. Returns the result with a video replay URL, and auto-cleans up browsers it creates.
+Execute Playwright/TypeScript automation code against an existing Kernel browser session. This tool is a thin passthrough: it runs your code in the browser's VM and returns the result. It does not manage browser lifecycle — create and delete sessions with [`manage_browsers`](/reference/mcp-server/tools/manage-browsers).
+
+<Note>`session_id` is required. Unlike earlier versions, this tool no longer creates a browser when `session_id` is omitted, and no longer deletes the browser after execution. Create a session with `manage_browsers` (action `create`), pass its `session_id` here, then delete it with `manage_browsers` when done.</Note>
 
 <Tip>Use `computer_action` with the `screenshot` action instead of `page.screenshot()` in your code. For a comprehensive page state snapshot, use `await page._snapshotForAI()`.</Tip>
 
@@ -12,12 +14,13 @@ Execute Playwright/TypeScript automation code against a Kernel browser session. 
 | Parameter | Description |
 |-----------|-------------|
 | `code` | Playwright/TypeScript code with a `page` object in scope. Required. |
-| `session_id` | Existing browser session ID. If omitted, a new browser is created and cleaned up after execution. |
+| `session_id` | Existing browser session ID to run against. Required. |
 
 ## Example
 
 ```json
 {
+  "session_id": "session_abc123",
   "code": "await page.goto('https://example.com'); return await page.title();"
 }
 ```
@@ -27,7 +30,8 @@ Returns:
 ```json
 {
   "success": true,
-  "result": "Example Domain",
-  "replay_url": "https://..."
+  "result": "Example Domain"
 }
 ```
+
+<Tip>To capture a video recording around your automation, start a recording with [`manage_replays`](/reference/mcp-server/tools/manage-replays) before your calls and stop it when done.</Tip>

--- a/reference/mcp-server/tools/manage-browsers.mdx
+++ b/reference/mcp-server/tools/manage-browsers.mdx
@@ -5,6 +5,8 @@ description: "Create, list, get, and delete browser sessions"
 
 Manage browser sessions on the Kernel platform. Created browsers run in isolated VMs and support headless/stealth modes, profiles, proxies, viewports, extensions, and SSH tunneling.
 
+Browser lifecycle lives here: `create` a session before running [`execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code) against it, and `delete` it when you're done.
+
 ## Actions
 
 | Action | Description |

--- a/reference/mcp-server/tools/manage-replays.mdx
+++ b/reference/mcp-server/tools/manage-replays.mdx
@@ -3,7 +3,7 @@ title: "manage_replays"
 description: "Start, stop, and list video replay recordings for a browser session"
 ---
 
-Record video replays of a browser session. Recording is opt-in and session-scoped: start a recording once, run your automation (for example with [`execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code)), then stop it — rather than recording each call separately.
+Record video replays of a browser session. Recording is opt-in and session-scoped: start a recording once, run your automation (for example with [`execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code)), then stop it.
 
 <Note>Replays require a headful session. They are not available for [headless](/browsers/headless) browsers.</Note>
 

--- a/reference/mcp-server/tools/manage-replays.mdx
+++ b/reference/mcp-server/tools/manage-replays.mdx
@@ -1,0 +1,38 @@
+---
+title: "manage_replays"
+description: "Start, stop, and list video replay recordings for a browser session"
+---
+
+Record video replays of a browser session. Recording is opt-in and session-scoped: start a recording once, run your automation (for example with [`execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code)), then stop it — rather than recording each call separately.
+
+<Note>Replays require a headful session. They are not available for [headless](/browsers/headless) browsers.</Note>
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| `start` | Begin recording a session. Returns a `replay_id`. |
+| `stop` | Stop a recording. |
+| `list` | List recordings for a session, including their view/download URLs. |
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `action` | Operation to perform: `start`, `stop`, or `list`. Required. |
+| `session_id` | Browser session ID. Required. |
+| `replay_id` | Recording ID to stop. Required for `stop`. |
+| `framerate` | (start) Frames per second for the recording. |
+| `max_duration_in_seconds` | (start) Maximum recording length in seconds. |
+| `record_audio` | (start) Capture audio in addition to video. |
+
+## Example
+
+```json
+{
+  "action": "start",
+  "session_id": "session_abc123",
+  "framerate": 30,
+  "max_duration_in_seconds": 300
+}
+```

--- a/reference/mcp-server/tools/manage-replays.mdx
+++ b/reference/mcp-server/tools/manage-replays.mdx
@@ -32,7 +32,6 @@ Record video replays of a browser session. Recording is opt-in and session-scope
 {
   "action": "start",
   "session_id": "session_abc123",
-  "framerate": 30,
   "max_duration_in_seconds": 300
 }
 ```


### PR DESCRIPTION
Updates the MCP server docs to match the new tool behavior in kernel-mcp-server (server-side change already merged).

## What changed

- **`execute_playwright_code`** — rewritten as a thin passthrough. `session_id` is now **required**; the tool no longer creates a browser when it's omitted, no longer deletes the browser afterward, and no longer returns a `replay_url`. Added a note steering callers to `manage_browsers` for lifecycle and updated the example (input includes `session_id`, output drops `replay_url`).
- **`manage_replays`** — new tool page documenting the `start` / `stop` / `list` actions and the `framerate`, `max_duration_in_seconds`, `record_audio` start params. Added to the Tools nav in `docs.json`.
- **`manage_browsers`** — added a line noting browser lifecycle lives here (create before execute, delete when done).
- **Examples** — the Playwright example now shows create → execute → delete; added a "record a video replay" example using `manage_replays`.
- **`browsers/playwright-execution.mdx`** — reworded the MCP integration blurb (no longer "automatic video replay and cleanup").

## Notes

- Param descriptions for `manage_replays` are inferred from the PR summary; worth a skim against the tool's live schema before publishing.
- Docs-only change; `docs.json` validates as JSON. No preview build run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security impact; main risk is minor inaccuracy in inferred `manage_replays` param descriptions until verified against the live schema.
> 
> **Overview**
> Aligns MCP docs with **kernel-mcp-server** behavior: **`execute_playwright_code`** is documented as a thin VM passthrough with **required** `session_id`, no implicit create/delete, and no **`replay_url`** in responses; lifecycle is explicitly **`manage_browsers`** (create → execute → delete).
> 
> Adds a **`manage_replays`** reference page (`start` / `stop` / `list`, headful-only note) and wires it into **`docs.json`** nav. **`manage_browsers`** and MCP **examples** now show the create/execute/delete flow plus an opt-in replay recording example; **`playwright-execution.mdx`** drops “automatic video replay and cleanup” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d36173fe0a7970fba4db074fb436239d719465f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->