### PR TITLE
Add manage_replays to eve-extension docs

### DIFF
--- a/integrations/vercel/eve-extension.mdx
+++ b/integrations/vercel/eve-extension.mdx
@@ -70,6 +70,7 @@ Once mounted, the agent has the following tools, namespaced under your mount (e.
 - **`manage_auth_connections`**: Kernel's [managed auth](/auth/overview), so the agent logs into sites through a stored connection or a hosted login flow instead of typing credentials into the page.
 - **`manage_profiles`**: create and reuse browser [profiles](/auth/profiles) (persistent cookies, logins, storage).
 - **`manage_proxies`**: create and attach [proxies](/proxies/overview) (datacenter, ISP, residential, mobile) with geo-targeting.
+- **`manage_replays`**: start, stop, and list video replay recordings for a session, so you can capture what the agent did as an MP4. Requires a paid Kernel plan.
 - the **`browse` skill**: the loop the model follows to drive the browser end to end.
 
 The `browse` skill runs autonomously but is human-in-the-loop friendly:
@@ -173,6 +174,7 @@ export default defineMcpClientConnection({
       "manage_credentials", // high blast radius: create/read/delete stored credentials
       "manage_profiles",
       "manage_proxies",
+      "manage_replays",
       "manage_browser_pools", // heavier tools, off by default
       "exec_command", // high blast radius: shell exec in the VM
     ],


### PR DESCRIPTION
Adds the `manage_replays` tool to the included tools list on the eve-extension integration page, matching the tool newly shipped in the latest `@onkernel/eve-extension` npm package. Also adds it to the connection-override allowlist example.

## Changes
- New bullet in **Included tools and skills**: start, stop, and list video replay recordings for a session (MP4 capture; requires a paid Kernel plan).
- Added `manage_replays` to the override allowlist example.

Docs-only change, no build step (Mintlify).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to `integrations/vercel/eve-extension.mdx` with no runtime or build impact.
> 
> **Overview**
> Updates the **Eve Extension** integration docs to reflect the **`manage_replays`** tool shipped in the latest `@onkernel/eve-extension` package.
> 
> The **Included tools and skills** list now describes session video replay controls (start, stop, list recordings as MP4) and notes that replays require a paid Kernel plan. The **connection override** `tools.allow` example also includes **`manage_replays`** so readers can opt into that tool alongside the other high-blast-radius entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb333a897cdd22caca09feab9dbbd962aa1a10ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->