### PR TITLE
Fix execute_playwright_code tool docs

### DIFF
--- a/reference/mcp-server/tools/execute-playwright-code.mdx
+++ b/reference/mcp-server/tools/execute-playwright-code.mdx
@@ -7,13 +7,13 @@ Execute Playwright/TypeScript automation code against an existing Kernel browser
 
 <Note>`session_id` is required. Unlike earlier versions, this tool no longer creates a browser when `session_id` is omitted, and no longer deletes the browser after execution. Create a session with `manage_browsers` (action `create`), pass its `session_id` here, then delete it with `manage_browsers` when done.</Note>
 
-<Tip>Use `computer_action` with the `screenshot` action instead of `page.screenshot()` in your code. For a comprehensive page state snapshot, use `await page._snapshotForAI()`.</Tip>
+<Tip>Use `computer_action` with the `screenshot` action instead of `page.screenshot()` in your code. To read page state, return only what you need — prefer a targeted selector (e.g. `await page.locator('h1').innerText()`) or a region-scoped accessibility snapshot (e.g. `await page.locator('main').ariaSnapshot()`) rather than dumping the whole page.</Tip>
 
 ## Parameters
 
 | Parameter | Description |
 |-----------|-------------|
-| `code` | Playwright/TypeScript code with a `page` object in scope. Required. |
+| `code` | Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Required. |
 | `session_id` | Existing browser session ID to run against. Required. |
 
 ## Example


### PR DESCRIPTION
## Summary

The `execute_playwright_code` reference page had two issues, mirroring the tool-description fix in [kernel-mcp-server#125](https://github.com/kernel/kernel-mcp-server/pull/125):

1. **`page._snapshotForAI()` doesn't work.** The Tip recommended it for "a comprehensive page state snapshot," but it's a Playwright internal that isn't exposed in the stealth-patched execution runtime — it throws `TypeError: page._snapshotForAI is not a function`. It's also a whole-page dump (heavy on tokens). Replaced with region-scoped guidance: prefer a targeted selector or a region-scoped `ariaSnapshot()` rather than dumping the whole page.
2. **Incomplete scope.** The `code` param said "a `page` object in scope." Per [browsers/playwright-execution](https://docs.kernel.sh/browsers/playwright-execution), `page`, `context`, and `browser` are all in scope. Updated, and noted that the returned value is what's sent back.

Docs-only.

## Preview

`reference/mcp-server/tools/execute-playwright-code`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to an MCP tool reference page; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **`execute_playwright_code`** MCP reference so it matches the real execution runtime and Playwright guidance.
> 
> The **Tip** no longer suggests **`page._snapshotForAI()`** (not available in the stealth-patched VM and token-heavy). It now steers agents toward **targeted reads** — e.g. **`innerText()`** on a locator or **`ariaSnapshot()`** on a region — instead of whole-page dumps, while still recommending **`computer_action`** screenshots over **`page.screenshot()`**.
> 
> The **`code`** parameter description now documents **`page`**, **`context`**, and **`browser`** in scope and that the **`return`** value is what the tool sends back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add17606895aad79578a67c3cee84fcf1b46c705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->