### PR TITLE
Fix Stripe Projects browser API access pricing

### DIFF
--- a/integrations/stripe-projects-browser.mdx
+++ b/integrations/stripe-projects-browser.mdx
@@ -43,7 +43,7 @@ kernel browsers create
 
 | Situation | Price |
 |-----------|--------|
-| No active Kernel plan on the org | Usage-based: **$0.01/min** (standard), **$0.02/min** (stealth) |
+| No active Kernel plan on the org | Usage-based by browser type: **$0.001/min** headless, **$0.008/min** headful, **$0.048/min** headful + GPU (stealth included) |
 | Active `plan:developer`, `plan:hobbyist`, or `plan:startup` | **Included** with plan (component pricing `free` under parent plan) |
 
 Provision a plan first when the developer needs predictable monthly credits and concurrency limits.

--- a/integrations/stripe-projects.mdx
+++ b/integrations/stripe-projects.mdx
@@ -19,7 +19,7 @@ Stripe service slugs are prefixed with `kernel/` (from the app manifest name).
 | `kernel/browser:api-access` | deployable | project | API key for launching browsers in a Stripe Project |
 
 - Only **one plan** can be active per Kernel org at a time (`allowed_updates` defines upgrade/downgrade paths).
-- `browser:api-access` is **free** when any active plan is provisioned; otherwise it is usage-based (\$0.01/min standard, \$0.02/min stealth).
+- `browser:api-access` is **free** when any active plan is provisioned; otherwise it is usage-based by browser type (\$0.001/min headless, \$0.008/min headful, \$0.048/min headful + GPU; stealth included).
 
 ## Common CLI flows
 


### PR DESCRIPTION
## Summary

The two Stripe Projects docs pages listed usage-based pricing for `browser:api-access` as **$0.01/min (standard), $0.02/min (stealth)**. This does not match actual billing.

The real usage-based rates are **by browser type**, and stealth is included (there is no separate/doubled stealth rate):

- **$0.001/min** headless
- **$0.008/min** headful
- **$0.048/min** headful + GPU

This matches both the public pricing page (`info/pricing` per-second rates × 60) and the Stripe Projects service catalog served to Stripe (the `project` deployable's pricing string), which derives its amounts from `PLAN_CONFIG` so they stay aligned with billing reality.

## Changes

- `integrations/stripe-projects-browser.mdx` — Pricing table row
- `integrations/stripe-projects.mdx` — service catalog note

No code or generated files touched. Docs-only change, verified against the public pricing page and the service catalog source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to pricing text; no runtime, billing, or API behavior changes.
> 
> **Overview**
> Corrects **usage-based pricing** for `kernel/browser:api-access` in the Stripe Projects integration docs so they match real billing (and the public pricing / service catalog).
> 
> Both **`integrations/stripe-projects-browser.mdx`** (pricing table) and **`integrations/stripe-projects.mdx`** (catalog note) replace the old **$0.01/min standard / $0.02/min stealth** wording with **by browser type**: **$0.001/min** headless, **$0.008/min** headful, **$0.048/min** headful + GPU, with **stealth included** (no separate stealth multiplier). Plan-included behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0cbec553f6d1d5d6080489652b00eb94b77122a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->