### PR TITLE
Reframe FAQ 'Unsupported Websites' as bot-detection education

### DIFF
--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -19,13 +19,16 @@ If you're experiencing slower-than-expected browser creation times, review your 
 - Browsers persist independently of CDP. Depending on your timeout configuration, it will continue running even if the CDP connection closes. You can reconnect to the same `cdp_ws_url` if you're unexpectedly disconnected.
 - We recommend implementing reconnect logic, as network interruptions or lifecycle events can cause CDP sessions to close. Detect disconnects and automatically re-establish a CDP connection when this occurs.
 
-## Unsupported Websites
+## Sites with heavier bot detection
 
-There are some websites that are not supported by Kernel browsers due to their restrictions around automation and associated bot detection. These include:
+Kernel browsers can navigate to most websites, including popular ones with a reputation for aggressive automation defenses (LinkedIn, Facebook, Instagram, X, Amazon, Reddit, and similar). Loading a page and interacting with it is not the same problem as staying undetected through a login flow or at scale — which is where friction actually shows up.
 
-- LinkedIn
-- Facebook
-- Instagram
-- X (Twitter)
-- Amazon
-- Reddit
+Where you're most likely to hit resistance:
+
+- **Login and account-creation flows** — repeated logins, especially from new IPs, are a common trigger for challenges and account locks. Use [Managed Auth](/auth/overview) to keep sessions persistently logged in rather than re-authenticating each run.
+- **High-volume or high-concurrency scraping** — many requests from the same exit IP raise the block rate. Spread load across [proxies](/proxies/overview) and reuse [Profiles](/auth/profiles).
+- **Sites running aggressive vendors** (Cloudflare, DataDome, PerimeterX, Imperva, Akamai) — these can challenge even anonymous page loads. Enable [stealth mode](/browsers/bot-detection/stealth) and consider [computer controls](/browsers/computer-controls) for more human-like interaction.
+
+<Info>
+  Before automating a target site, test it manually first — see the [bot detection guide](/browsers/bot-detection/overview) for the recommended approach and mitigations.
+</Info>

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -21,13 +21,14 @@ If you're experiencing slower-than-expected browser creation times, review your 
 
 ## Sites with heavier bot detection
 
-Kernel browsers can navigate to most websites, including popular ones with a reputation for aggressive automation defenses (LinkedIn, Facebook, Instagram, X, Amazon, Reddit, and similar). Loading a page and interacting with it is not the same problem as staying undetected through a login flow or at scale — which is where friction actually shows up.
+Kernel browsers can navigate to most websites, including popular ones with a reputation for aggressive automation defenses (LinkedIn, Facebook, Instagram, X, Amazon, Reddit, and similar). Loading and interacting with a page is a different problem from staying undetected at scale — which is where friction tends to show up.
 
 Where you're most likely to hit resistance:
 
-- **Login and account-creation flows** — repeated logins, especially from new IPs, are a common trigger for challenges and account locks. Use [Managed Auth](/auth/overview) to keep sessions persistently logged in rather than re-authenticating each run.
 - **High-volume or high-concurrency scraping** — many requests from the same exit IP raise the block rate. Spread load across [proxies](/proxies/overview) and reuse [Profiles](/auth/profiles).
 - **Sites running aggressive vendors** (Cloudflare, DataDome, PerimeterX, Imperva, Akamai) — these can challenge even anonymous page loads. Enable [stealth mode](/browsers/bot-detection/stealth) and consider [computer controls](/browsers/computer-controls) for more human-like interaction.
+
+For workflows behind a login, [Managed Auth](/auth/overview) handles the login flow and keeps sessions persistently authenticated across runs.
 
 <Info>
   Before automating a target site, test it manually first — see the [bot detection guide](/browsers/bot-detection/overview) for the recommended approach and mitigations.

--- a/browsers/faq.mdx
+++ b/browsers/faq.mdx
@@ -19,17 +19,17 @@ If you're experiencing slower-than-expected browser creation times, review your 
 - Browsers persist independently of CDP. Depending on your timeout configuration, it will continue running even if the CDP connection closes. You can reconnect to the same `cdp_ws_url` if you're unexpectedly disconnected.
 - We recommend implementing reconnect logic, as network interruptions or lifecycle events can cause CDP sessions to close. Detect disconnects and automatically re-establish a CDP connection when this occurs.
 
-## Sites with heavier bot detection
+## Bot detection varies by site
 
-Kernel browsers can navigate to most websites, including popular ones with a reputation for aggressive automation defenses (LinkedIn, Facebook, Instagram, X, Amazon, Reddit, and similar). Loading and interacting with a page is a different problem from staying undetected at scale — which is where friction tends to show up.
+Websites differ widely in how aggressively they detect and challenge automation, and the same site can behave differently depending on how you approach it. Rather than a fixed list of "supported" and "unsupported" sites, it's more useful to understand what drives that friction and how to reduce it.
 
-Where you're most likely to hit resistance:
+What tends to increase bot-detection friction:
 
 - **High-volume or high-concurrency scraping** — many requests from the same exit IP raise the block rate. Spread load across [proxies](/proxies/overview) and reuse [Profiles](/auth/profiles).
-- **Sites running aggressive vendors** (Cloudflare, DataDome, PerimeterX, Imperva, Akamai) — these can challenge even anonymous page loads. Enable [stealth mode](/browsers/bot-detection/stealth) and consider [computer controls](/browsers/computer-controls) for more human-like interaction.
+- **Aggressive detection vendors** (Cloudflare, DataDome, PerimeterX, Imperva, Akamai) — these can challenge even anonymous page loads. Enable [stealth mode](/browsers/bot-detection/stealth) and consider [computer controls](/browsers/computer-controls) for more human-like interaction.
 
 For workflows behind a login, [Managed Auth](/auth/overview) handles the login flow and keeps sessions persistently authenticated across runs.
 
 <Info>
-  Before automating a target site, test it manually first — see the [bot detection guide](/browsers/bot-detection/overview) for the recommended approach and mitigations.
+  Because behavior is site- and configuration-specific, test your target site manually before automating — see the [bot detection guide](/browsers/bot-detection/overview) for the recommended approach and mitigations.
 </Info>


### PR DESCRIPTION
## Summary

The FAQ's **Unsupported Websites** section listed specific sites (LinkedIn, Facebook, Instagram, X, Amazon, Reddit) as unsupported. That was inaccurate and had caused customer-facing confusion.

This rewrites the section as **education** rather than a supported/unsupported verdict. It makes no claim about whether any specific site can or cannot be automated — instead it explains that bot-detection behavior is site- and configuration-specific, what drives friction, and how to reduce it.

## What changed

Replaces the flat list with a **"Bot detection varies by site"** section that:

- Frames detection as site- and config-dependent, not a fixed allow/deny list
- Names the factors that increase friction — high-volume/high-concurrency scraping and aggressive detection vendors (Cloudflare, DataDome, PerimeterX, etc.)
- Points to the right mitigation for each (proxies, Profiles, stealth, computer controls)
- Points to Managed Auth for logged-in workflows (positively, not as a limitation)
- Recommends manual testing of the target site before automating

## Notes

- No per-site names, no can/cannot claims, no block-rate numbers or methodology table.
- Supersedes the stale, never-merged #357 and #358.
- Docs-only change. All internal links verified against the current repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and link updates with no runtime or API behavior changes.
> 
> **Overview**
> The browsers FAQ no longer names LinkedIn, Facebook, Instagram, X, Amazon, and Reddit as unsupported. The **Unsupported Websites** section becomes **Bot detection varies by site**, explaining that friction depends on approach and scale rather than a binary supported/unsupported list.
> 
> It adds practical drivers of detection—high-volume scraping from shared exit IPs and aggressive vendors (Cloudflare, DataDome, PerimeterX, Imperva, Akamai)—with pointers to [proxies](/proxies/overview), [Profiles](/auth/profiles), [stealth mode](/browsers/bot-detection/stealth), [computer controls](/browsers/computer-controls), and [Managed Auth](/auth/overview) for logged-in flows. An `<Info>` callout directs readers to test targets manually and use the [bot detection guide](/browsers/bot-detection/overview).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba58603dc174c923a91762a4e31de854680f3861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->