### PR TITLE
Document Managed Auth tab ownership

### DIFF
--- a/auth/profiles.mdx
+++ b/auth/profiles.mdx
@@ -180,6 +180,12 @@ fmt.Println("Live view:", kernelBrowser2.BrowserLiveViewURL)
 
 By default, Profiles restore existing tabs saved in the profile. Pass `start_url` with the profile to clear those restored tabs and open a specific page when the new browser starts.
 
+<Note>
+Managed Auth controls the tab state of profiles attached to auth connections. Each login or automatic re-authentication starts in a single tab at the configured login URL, or at the domain homepage when no login URL is configured. After a successful authentication, Kernel saves the resulting tab state with the updated authentication data. Failed and canceled sessions leave the saved profile unchanged.
+
+Don't depend on previous tabs or windows remaining in a Managed Auth profile. Set `start_url` when you create a browser if your automation requires a specific first page.
+</Note>
+
 <CodeGroup>
 ```typescript Typescript/Javascript
 const browser = await kernel.browsers.create({


### PR DESCRIPTION
## Summary

- explain that Managed Auth starts login and re-authentication in a deterministic single tab
- clarify that successful authentication persists the resulting tab state while failed and canceled sessions do not
- recommend setting `start_url` when an automation requires a specific first page

## Testing

- rendered `/auth/profiles` with the Mintlify local preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to profiles/Managed Auth behavior; no runtime or API code modified.
> 
> **Overview**
> Adds a **Note** under **Override opening existing tabs in a new session** in `auth/profiles.mdx` that spells out how **Managed Auth** treats tabs on profiles tied to auth connections.
> 
> The note states that each login or automatic re-auth opens a **single tab** at the configured login URL (or the domain homepage if none is set). **Successful** auth persists that tab state with updated credentials; **failed or canceled** sessions do not alter the saved profile. It warns automations not to rely on prior tabs/windows on Managed Auth profiles and to pass **`start_url`** when the first page must be explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5675861771fb054a25bb9aa8cbf6896023775ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->