### PR TITLE
docs: sync CLI reference with latest commands

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -298,6 +298,7 @@
               "reference/cli/managed-auth",
               "reference/cli/projects",
               "reference/cli/api-keys",
+              "reference/cli/org",
               "reference/cli/audit-logs",
               "reference/cli/mcp"
             ]

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -8,7 +8,7 @@ The Kernel CLI helps you access and manage your Kernel resources.
 
 ```bash
 # Using brew
-brew install onkernel/tap/kernel
+brew install kernel/tap/kernel
 
 # Using pnpm
 pnpm install -g @onkernel/cli

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -8,7 +8,7 @@ The Kernel CLI helps you access and manage your Kernel resources.
 
 ```bash
 # Using brew
-brew install kernel/tap/kernel
+brew install onkernel/tap/kernel
 
 # Using pnpm
 pnpm install -g @onkernel/cli
@@ -59,7 +59,10 @@ kernel --version
     Manage projects and scope commands with `--project`.
   </Card>
   <Card icon="key" title="API Keys" href="/reference/cli/api-keys">
-    Create, list, rename, and delete API keys.
+    Create, inspect, rotate, rename, and delete API keys.
+  </Card>
+  <Card icon="building" title="Organization Limits" href="/reference/cli/org">
+    View and configure organization concurrency limits.
   </Card>
   <Card icon="clock-rotate-left" title="Audit Logs" href="/reference/cli/audit-logs">
     Search and download organization audit logs.

--- a/reference/cli/api-keys.mdx
+++ b/reference/cli/api-keys.mdx
@@ -51,6 +51,7 @@ kernel api-keys get key_01jwv4tn5m8k3q2v7x9p0a1bc2
 
 | Flag | Description |
 |------|-------------|
+| `--include-deleted` | Include soft-deleted API keys in the lookup. |
 | `--output json`, `-o json` | Output the raw JSON object. |
 
 ## `kernel api-keys update <id>`
@@ -65,6 +66,29 @@ kernel api-keys update key_01jwv4tn5m8k3q2v7x9p0a1bc2 --name staging-ci-rotated
 |------|-------------|
 | `--name <name>` | New API key name. Required. |
 | `--output json`, `-o json` | Output the raw JSON object. |
+
+## `kernel api-keys rotate <id>`
+
+Issue a replacement API key. The rotated key keeps working for a grace period so you can migrate callers without downtime.
+
+```bash
+kernel api-keys rotate key_01jwv4tn5m8k3q2v7x9p0a1bc2 \
+  --days-to-expire 90 \
+  --expire-in-days 7 \
+  --yes \
+  --output json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--days-to-expire <days>` | Lifetime of the new key, from `1` to `3650` days. Omit to reuse the rotated key's lifetime. |
+| `--expire-in-days <days>` | Grace period before the rotated key expires. Pass `0` to expire it immediately; omit for the default of 7 days. |
+| `--yes`, `-y` | Skip the confirmation prompt. |
+| `--output json`, `-o json` | Output the raw JSON object, including the new one-time plaintext key. |
+
+<Warning>
+  Save the new plaintext key when you rotate it. Kernel won't return it again.
+</Warning>
 
 ## `kernel api-keys delete <id>`
 

--- a/reference/cli/browsers.mdx
+++ b/reference/cli/browsers.mdx
@@ -59,6 +59,7 @@ Update a running browser session — change or remove its proxy, load a profile,
 | `--viewport <WxH@fps>` | Set viewport size (e.g. `1920x1080@25`). |
 | `--force` | Force a viewport resize even during an active live view or recording. |
 | `--telemetry <spec>` | Update [telemetry](/browsers/telemetry/overview): `all` resets to the default set, `off` disables, or a comma-separated list like `console,network` to merge those categories into the current selection. |
+| `--disable-default-proxy` | Disable the default stealth proxy so the browser connects directly. Pass `--disable-default-proxy=false` to re-enable it. |
 | `--output json`, `-o json` | Output raw API response as JSON. |
 
 ### `kernel browsers curl <session-id> <url>`
@@ -156,6 +157,7 @@ Execute a command synchronously inside the browser VM.
 | `--timeout <seconds>` | Execution timeout. |
 | `--as-user <user>` | Run as a specific user. |
 | `--as-root` | Run as root. |
+| `--env <KEY=VALUE>` | Set an environment variable for the process (repeatable). |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel browsers process spawn <session-id> [--] [command...]`
@@ -169,6 +171,10 @@ Execute a command asynchronously in the browser VM.
 | `--timeout <seconds>` | Execution timeout. |
 | `--as-user <user>` | Run as a specific user. |
 | `--as-root` | Run as root. |
+| `--env <KEY=VALUE>` | Set an environment variable for the process (repeatable). |
+| `--allocate-tty` | Allocate a pseudo-terminal (PTY) for interactive shells. |
+| `--cols <n>` | Set the initial terminal columns. Requires `--allocate-tty`. |
+| `--rows <n>` | Set the initial terminal rows. Requires `--allocate-tty`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel browsers process kill <session-id> <process-id>`

--- a/reference/cli/managed-auth.mdx
+++ b/reference/cli/managed-auth.mdx
@@ -24,6 +24,7 @@ Create a managed auth connection for a profile and domain.
 | `--credential-path <path>` | Provider-specific path (e.g. `VaultName/ItemName`). |
 | `--credential-auto` | Look up the credential by domain from the provider (defaults to true when `--credential-provider` is set without `--credential-path`). |
 | `--no-save-credentials` | Don't save credentials after a successful login. |
+| `--telemetry <spec>` | Set default browser telemetry for this connection: `all`, `off`, or a comma-separated category list like `console,network`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel auth connections list`
@@ -51,6 +52,7 @@ Start a login flow and return a hosted URL for authentication.
 |------|-------------|
 | `--proxy-id <id>` | Proxy ID to use for this login. |
 | `--proxy-name <name>` | Proxy name to use for this login. |
+| `--telemetry <spec>` | Override telemetry for this login only, merged with the connection's config. Pass `all`, `off`, or a comma-separated category list like `console,network`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel auth connections submit <id>`
@@ -58,7 +60,9 @@ Submit field values to an in-progress login flow. Poll the connection (or use `f
 
 | Flag | Description |
 |------|-------------|
-| `--field <name=value>` | Field name/value pair (repeatable). |
+| `--field-value <id=value>` | Canonical field ID/value pair from the connection's `fields` list (repeatable). Prefer this over `--field`. |
+| `--choice-id <id>` | Canonical choice ID from the connection's `choices` list. |
+| `--field <name=value>` | Legacy field name/value pair (repeatable). Prefer `--field-value`. |
 | `--mfa-option-id <id>` | MFA option ID when an MFA method was selected. |
 | `--sign-in-option-id <id>` | Sign-in option ID when the flow returned non-MFA choices. |
 | `--sso-button-selector <xpath>` | XPath selector when choosing an SSO button. |
@@ -80,6 +84,20 @@ Stream real-time login flow state updates over SSE.
 |------|-------------|
 | `--output json`, `-o json` | Output raw JSON events. |
 
+### `kernel auth connections timeline <id>`
+List the connection's login, reauthentication, and health-check events, most recent first.
+
+| Flag | Description |
+|------|-------------|
+| `--type <type>` | Filter to `login`, `reauth`, or `health_check`. |
+| `--page <n>` | Page number, 1-based (default: `1`). |
+| `--per-page <n>` | Items per page (default: `20`). |
+| `--output json`, `-o json` | Output a JSON object containing `events`, `page`, `per_page`, and `has_more`. |
+
+```bash
+kernel auth connections timeline auth_01k3m8v2c9w4n7q6 --type reauth --page 1 --per-page 20
+```
+
 ### `kernel auth connections update <id>`
 Update connection settings such as login URL, health checks, credential source, and proxy.
 
@@ -96,6 +114,7 @@ Update connection settings such as login URL, health checks, credential source, 
 | `--credential-auto` | Look up the credential by domain from the provider. |
 | `--save-credentials` | Save credentials after a successful login. |
 | `--no-save-credentials` | Don't save credentials after a successful login. |
+| `--telemetry <spec>` | Update telemetry for future browser sessions: `all`, `off`, or a comma-separated category list like `console,network`. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ### `kernel auth connections delete <id>`

--- a/reference/cli/org.mdx
+++ b/reference/cli/org.mdx
@@ -1,0 +1,38 @@
+---
+title: "Organization Limits"
+---
+
+Manage organization-wide concurrency limits and the default cap applied to projects without an explicit override.
+
+## `kernel org limits get`
+
+Show the organization's maximum concurrent browser sessions and the default per-project cap.
+
+| Flag | Description |
+|------|-------------|
+| `--output json`, `-o json` | Output raw JSON object. |
+
+```bash
+kernel org limits get --output json
+```
+
+## `kernel org limits set`
+
+Set the default per-project concurrency cap. This default applies only to projects that don't have an explicit [project limit override](/reference/cli/projects#project-limits).
+
+| Flag | Description |
+|------|-------------|
+| `--default-project-max-concurrent-sessions <n>` | Default maximum concurrent browsers for projects without an explicit override. Pass `0` to remove the default. Required. |
+| `--output json`, `-o json` | Output raw JSON object. |
+
+```bash
+# Give projects without an override a default cap of 20 sessions
+kernel org limits set --default-project-max-concurrent-sessions 20
+
+# Remove the default cap
+kernel org limits set --default-project-max-concurrent-sessions 0
+```
+
+<Info>
+  A project's explicit limit overrides this default. The organization's maximum concurrent sessions remains the upper bound.
+</Info>

--- a/reference/cli/profiles.mdx
+++ b/reference/cli/profiles.mdx
@@ -29,15 +29,28 @@ Create a new browser profile.
 | `--name <name>` | Optional unique profile name. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
+## `kernel profiles update <id-or-name>`
+Rename a profile.
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | New unique profile name. Required. |
+| `--output json`, `-o json` | Output raw JSON object. |
+
+```bash
+kernel profiles update checkout-session --name checkout-session-v2
+```
+
 ## `kernel profiles download <id-or-name>`
 Download a profile and extract its user-data archive into the directory given by `--to`. The directory is created if it doesn't exist.
 
 | Flag | Description |
 |------|-------------|
 | `--to <dir>` | Directory to extract the profile into. Required. |
+| `--format <format>` | Archive format: `tar.zst` (compressed, default) or `tar` (decompressed server-side). |
 
 ```bash
-kernel profiles download my-profile --to ./profile-data
+kernel profiles download checkout-session --to ./profile-data --format tar.zst
 ```
 
 ## `kernel profiles delete <id-or-name>`

--- a/reference/cli/projects.mdx
+++ b/reference/cli/projects.mdx
@@ -46,6 +46,20 @@ kernel projects create staging
 
 Show details for a project by ID or name.
 
+### `kernel projects update <id-or-name>`
+
+Update a project's name or status. You must provide at least one update flag.
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | New project name, from 1 to 255 characters. |
+| `--status <status>` | New project status: `active` or `archived`. |
+| `--output json`, `-o json` | Output raw JSON object. |
+
+```bash
+kernel projects update staging --name staging-us-east --status active
+```
+
 ### `kernel projects delete <id-or-name>`
 
 Delete a project. The project must be empty, and it can't be the last active project in the org.

--- a/reference/cli/proxies.mdx
+++ b/reference/cli/proxies.mdx
@@ -50,11 +50,24 @@ kernel proxies create --type custom --host proxy.example.com --port 8080 --usern
 kernel proxies create --type residential --country US --city sanfrancisco --state CA
 ```
 
+## `kernel proxies update <id>`
+Rename a proxy configuration. To change its type or connection settings, recreate the proxy.
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | New proxy name. Required. |
+| `--output json`, `-o json` | Output raw JSON object. |
+
+```bash
+kernel proxies update prx_01k3m8v2c9w4n7q6 --name us-checkout-proxy
+```
+
 ## `kernel proxies check <id>`
 Run a health check on a proxy to verify it's working and update its status.
 
 | Flag | Description |
 |------|-------------|
+| `--url <url>` | Public HTTP or HTTPS URL to test reachability against. |
 | `--output json`, `-o json` | Output raw JSON object. |
 
 ## `kernel proxies delete <id>`


### PR DESCRIPTION
## Description

Sync the docs site's CLI reference with the command and flag coverage added in [kernel/cli#140](https://github.com/kernel/cli/pull/140) and documented in the CLI README.

Updates:
- document browser default-proxy and process env/TTY flags
- document profile, project, and proxy update commands
- document managed-auth timeline, telemetry, and canonical submit flags
- document API key lookup/rotation additions
- add an Organization Limits CLI page, card, and navigation entry
- align the Homebrew install command with the CLI README

The timeline JSON docs describe the current pagination envelope (`events`, `page`, `per_page`, `has_more`) added by the follow-up bugbot fix in the merged CLI PR rather than the README's earlier "raw array" wording.

## Implementation Checklist

- [x] If updating our CLI, update the info in our CLI reference
- [x] Added the new Organization Limits page to `docs.json` navigation

## Testing

- [x] `git diff --check`
- [x] `docs.json` parses as valid JSON
- [x] `mintlify dev --port 3333` starts successfully
- [x] Updated pages return HTTP 200 locally:
  - `/reference/cli`
  - `/reference/cli/browsers`
  - `/reference/cli/profiles`
  - `/reference/cli/projects`
  - `/reference/cli/proxies`
  - `/reference/cli/managed-auth`
  - `/reference/cli/api-keys`
  - `/reference/cli/org`

## Related change

- https://github.com/kernel/cli/pull/140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or API behavior changes in this repo.
> 
> **Overview**
> **Syncs the docs site CLI reference** with command and flag coverage from the latest Kernel CLI release.
> 
> Adds a new **Organization Limits** page (`kernel org limits get/set`), navigation entry, and overview card. Expands existing pages with **update** commands for profiles, projects, and proxies; **API key** rotation, `--include-deleted` on get, and refreshed overview copy; **browser** session `--disable-default-proxy` and VM process `--env`, PTY/cols/rows on spawn; **managed auth** telemetry on create/login/update, canonical `--field-value` / `--choice-id` on submit, and **`connections timeline`** with paginated JSON; **profile download** `--format`; **proxy check** `--url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a4eb803e26d38dc9aaeadccab95d146fb1d11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->