### PR TITLE
white link underlines instead of gold

### DIFF
--- a/style.css
+++ b/style.css
@@ -248,3 +248,7 @@ html.dark .callout[class*="yellow"] svg {
 .dark .card:hover {
   border-color: rgb(223 223 223) !important;
 }
+
+.dark .link {
+  border-bottom-color: #EDEEF0
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic CSS-only change to documentation theme; no runtime or security impact.
> 
> **Overview**
> **Dark mode link styling** now sets `.link` underline color to `#EDEEF0` (light gray/white) instead of the previous gold accent.
> 
> This is a single rule in `style.css` under the existing `.dark` overrides, aligned with other dark-theme neutrals like `--btn-border` and card hover borders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c9afb34d2e3921edc7e89b4304082d3e95c436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->