### PR TITLE
Add July 31 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -28,19 +28,11 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 
 ## Documentation updates
 
-- Added a new [Claude Code + Desktop integration guide](/integrations/claude/claude-code-and-desktop).
-- Added a new [Claude Agent SDK integration guide](/integrations/claude/claude-agent-sdk).
-- Added a new [Vercel Eve extension integration guide](/integrations/vercel/eve-extension).
-- Added a new [Bots and agents overview page](/bots).
-- Documented [custom proxy CA bundles](/proxies/custom) for BYO MITM setups.
-- Documented [audit log search and export](/info/audit-logs).
-- Documented [per-user profile persistence through browser pools](/browsers/pools/overview).
-- Documented [MCP server passthrough for `execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code) and the new [`manage_replays`](/reference/mcp-server/tools/manage-replays) tool.
-- Documented [managed auth tab ownership](/auth/profiles).
-- Added a Chrome policy use case for blocking DevTools and reorganized [Chrome Policies](/browsers/chrome-policies) into an Advanced section.
-- Reframed the "Unsupported Websites" FAQ entry as bot-detection education.
-- Added [browser telemetry to the pricing feature matrix](/info/pricing).
-- Synced the [CLI reference](/reference/cli) with the current command set.
+- Published new integration guides for [Claude Code + Desktop](/integrations/claude/claude-code-and-desktop), the [Claude Agent SDK](/integrations/claude/claude-agent-sdk), and the [Vercel Eve extension](/integrations/vercel/eve-extension).
+- Documented [custom proxy CA bundles](/proxies/custom) for BYO MITM setups, [audit log search and export](/info/audit-logs), [per-user profile persistence through browser pools](/browsers/pools/overview), and [managed auth tab ownership](/auth/profiles).
+- Added a [bots and agents overview](/bots) and reframed the "Unsupported Websites" FAQ entry as bot-detection education.
+- Refreshed the reference docs with [`execute_playwright_code` passthrough](/reference/mcp-server/tools/execute-playwright-code) and the new [`manage_replays`](/reference/mcp-server/tools/manage-replays) MCP tool, plus a [CLI reference](/reference/cli) sync with the current command set.
+- Added a Chrome policy use case for blocking DevTools, reorganized [Chrome Policies](/browsers/chrome-policies) into an Advanced section, and added [browser telemetry to the pricing feature matrix](/info/pricing).
 </Update>
 
 <Update label="July 17" tags={["Product", "Docs"]}>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,43 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="July 30" tags={["Product", "Docs"]}>
+## Product updates
+
+- Added customer-supplied CA bundles to [custom proxies](/proxies/custom) for BYO TLS-terminating (MITM) proxies. The bundle is stored encrypted per proxy and installed into the browser's trust store at session time, so a proxy that re-signs upstream certificates with its own root CA no longer fails every HTTPS page with `ERR_CERT_AUTHORITY_INVALID`. Configurable via the API, the dashboard, and a `--ca-bundle` flag on `kernel proxies create` in the [CLI](https://github.com/kernel/cli).
+- Added support for solving PerimeterX / HUMAN "Press & Hold" challenges in [stealth-mode browsers](/browsers/bot-detection/stealth).
+- Improved stealth egress fingerprint parity with Chrome, including Chrome-identical TLS (JA4) and HTTP/2 fingerprints. Rolling out gradually.
+- Proxy swaps via `PATCH /browsers/{id}` now take effect on live sessions regardless of which egress path the browser was provisioned on. Established tunnels through the old upstream are severed, so the browser re-dials through the new proxy instead of continuing to egress through the old one.
+- Expanded [managed auth](/auth/overview): [browser telemetry](/browsers/telemetry/overview) is now configurable per connection and captured on timeline events, the health-check interval is adjustable from the dashboard, and health checks and their replays now appear on the connection timeline alongside logins and re-auths.
+- Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with Claude Opus 5 and Moonshot Kimi K3 computer-use providers, semantic browser waits (`waitFor` conditions instead of fixed sleeps), verified browser action plans, and gated Anthropic's native `computer_20260701` / `browser_20260701` tools by model.
+- Added named markers to browser [replay recordings](/browsers/replays), exposed as MP4 chapters so playback jumps directly to key moments.
+- Added a `get_telemetry` action to the [MCP server](/reference/mcp-server)'s `manage_browsers` tool for reading archived [browser telemetry](/browsers/telemetry/overview) — including for deleted sessions and events captured before telemetry was turned off — with category filters, time windows, and pagination.
+- Added a complete audit log download helper to the Go, Node, and Python SDKs.
+- Extended the [CLI](https://github.com/kernel/cli) `browser-pools` commands with telemetry configuration, matching the flags already on `browsers create`/`update`.
+- Improved `kernel upgrade` in the [CLI](https://github.com/kernel/cli) to refresh the Homebrew tap before upgrading, so it always picks up the latest published version, and made CLI commands fail fast on interactive prompts in non-interactive shells to avoid hanging scripts.
+- Improved `kernel audit-logs search` output to show user IDs as a separate column.
+- Released [`@onkernel/eve-extension`](https://github.com/kernel/eve-extension) v0.1.3, a Kernel-powered browser extension for Vercel's Eve agent, with `manage_replays` now in the default browser toolset.
+- Shipped inline text editing and document bookmarks (with a public bookmarks agent API) in [just-html](https://github.com/kernel/just-html).
+- Published a [Codex plugin](https://github.com/kernel/skills) packaging for the Kernel [skills](https://github.com/kernel/skills) repo, so Codex users can install the full Kernel skill set the same way Claude Code and Cursor users can.
+- Published [`eve-connect-kernel`](https://github.com/kernel/eve-connect-kernel), a cookbook that wires Eve, Vercel Connect, and Kernel together so an agent can do work on authenticated websites.
+
+## Documentation updates
+
+- Added a new [Claude Code + Desktop integration guide](/integrations/claude/claude-code-and-desktop).
+- Added a new [Claude Agent SDK integration guide](/integrations/claude/claude-agent-sdk).
+- Added a new [Vercel Eve extension integration guide](/integrations/vercel/eve-extension).
+- Added a new [Bots and agents overview page](/bots).
+- Documented [custom proxy CA bundles](/proxies/custom) for BYO MITM setups.
+- Documented [audit log search and export](/info/audit-logs).
+- Documented [per-user profile persistence through browser pools](/browsers/pools/overview).
+- Documented [MCP server passthrough for `execute_playwright_code`](/reference/mcp-server/tools/execute-playwright-code) and the new [`manage_replays`](/reference/mcp-server/tools/manage-replays) tool.
+- Documented [managed auth tab ownership](/auth/profiles).
+- Added a Chrome policy use case for blocking DevTools and reorganized [Chrome Policies](/browsers/chrome-policies) into an Advanced section.
+- Reframed the "Unsupported Websites" FAQ entry as bot-detection education.
+- Added [browser telemetry to the pricing feature matrix](/info/pricing).
+- Synced the [CLI reference](/reference/cli) with the current command set.
+</Update>
+
 <Update label="July 17" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -18,7 +18,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Expanded [managed auth](/auth/overview): [browser telemetry](/browsers/telemetry/overview) is now configurable per connection and captured on timeline events, the health-check interval is adjustable from the dashboard, and health checks and their replays now appear on the connection timeline alongside logins and re-auths.
 - Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with Claude Opus 5 and Moonshot Kimi K3 computer-use providers, semantic browser waits (`waitFor` conditions instead of fixed sleeps), verified browser action plans, and gated Anthropic's native `computer_20260701` / `browser_20260701` tools by model.
 - Added named markers to browser [replay recordings](/browsers/replays), exposed as MP4 chapters so playback jumps directly to key moments.
-- Extended the [CLI](https://github.com/kernel/cli) `browser-pools` commands with telemetry configuration, matching the flags already on `browsers create`/`update`.
+- Extended the [CLI](https://github.com/kernel/cli) `browser-pools` commands with telemetry configuration, matching `browsers create`/`update`.
 - Improved `kernel upgrade` in the [CLI](https://github.com/kernel/cli) to refresh the Homebrew tap before upgrading to pick up latest version, and made CLI commands fail fast on interactive prompts in non-interactive shells to avoid hanging scripts.
 - Added a complete audit log download helper to the Go, Node, and Python SDKs.
 - Added support for solving PerimeterX / HUMAN "Press & Hold" challenges in [stealth-mode browsers](/browsers/bot-detection/stealth).

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,25 +9,22 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
-<Update label="July 30" tags={["Product", "Docs"]}>
+<Update label="July 31" tags={["Product", "Docs"]}>
 ## Product updates
 
-- Added customer-supplied CA bundles to [custom proxies](/proxies/custom) for BYO TLS-terminating (MITM) proxies. The bundle is stored encrypted per proxy and installed into the browser's trust store at session time, so a proxy that re-signs upstream certificates with its own root CA no longer fails every HTTPS page with `ERR_CERT_AUTHORITY_INVALID`. Configurable via the API, the dashboard, and a `--ca-bundle` flag on `kernel proxies create` in the [CLI](https://github.com/kernel/cli).
-- Added support for solving PerimeterX / HUMAN "Press & Hold" challenges in [stealth-mode browsers](/browsers/bot-detection/stealth).
-- Improved stealth egress fingerprint parity with Chrome, including Chrome-identical TLS (JA4) and HTTP/2 fingerprints. Rolling out gradually.
-- Proxy swaps via `PATCH /browsers/{id}` now take effect on live sessions regardless of which egress path the browser was provisioned on. Established tunnels through the old upstream are severed, so the browser re-dials through the new proxy instead of continuing to egress through the old one.
+- Released [`@onkernel/eve-extension`](https://github.com/kernel/eve-extension) v0.1.3, a Kernel-powered browser extension for Vercel's Eve agent.
+- Published a [Codex plugin](https://github.com/kernel/skills) packaging for the Kernel [skills](https://github.com/kernel/skills) repo, so Codex users can install the full Kernel skill set the same way Claude Code and Cursor users can.
+- Added a `get_telemetry` action to the [MCP server](/reference/mcp-server)'s `manage_browsers` tool for reading archived [browser telemetry](/browsers/telemetry/overview) — including for deleted sessions and events captured before telemetry was turned off — with category filters, time windows, and pagination.
 - Expanded [managed auth](/auth/overview): [browser telemetry](/browsers/telemetry/overview) is now configurable per connection and captured on timeline events, the health-check interval is adjustable from the dashboard, and health checks and their replays now appear on the connection timeline alongside logins and re-auths.
 - Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with Claude Opus 5 and Moonshot Kimi K3 computer-use providers, semantic browser waits (`waitFor` conditions instead of fixed sleeps), verified browser action plans, and gated Anthropic's native `computer_20260701` / `browser_20260701` tools by model.
 - Added named markers to browser [replay recordings](/browsers/replays), exposed as MP4 chapters so playback jumps directly to key moments.
-- Added a `get_telemetry` action to the [MCP server](/reference/mcp-server)'s `manage_browsers` tool for reading archived [browser telemetry](/browsers/telemetry/overview) — including for deleted sessions and events captured before telemetry was turned off — with category filters, time windows, and pagination.
-- Added a complete audit log download helper to the Go, Node, and Python SDKs.
 - Extended the [CLI](https://github.com/kernel/cli) `browser-pools` commands with telemetry configuration, matching the flags already on `browsers create`/`update`.
 - Improved `kernel upgrade` in the [CLI](https://github.com/kernel/cli) to refresh the Homebrew tap before upgrading, so it always picks up the latest published version, and made CLI commands fail fast on interactive prompts in non-interactive shells to avoid hanging scripts.
+- Added a complete audit log download helper to the Go, Node, and Python SDKs.
+- Added support for solving PerimeterX / HUMAN "Press & Hold" challenges in [stealth-mode browsers](/browsers/bot-detection/stealth).
+- Added customer-supplied CA bundles to [custom proxies](/proxies/custom) for BYO TLS-terminating (MITM) proxies.
 - Improved `kernel audit-logs search` output to show user IDs as a separate column.
-- Released [`@onkernel/eve-extension`](https://github.com/kernel/eve-extension) v0.1.3, a Kernel-powered browser extension for Vercel's Eve agent, with `manage_replays` now in the default browser toolset.
 - Shipped inline text editing and document bookmarks (with a public bookmarks agent API) in [just-html](https://github.com/kernel/just-html).
-- Published a [Codex plugin](https://github.com/kernel/skills) packaging for the Kernel [skills](https://github.com/kernel/skills) repo, so Codex users can install the full Kernel skill set the same way Claude Code and Cursor users can.
-- Published [`eve-connect-kernel`](https://github.com/kernel/eve-connect-kernel), a cookbook that wires Eve, Vercel Connect, and Kernel together so an agent can do work on authenticated websites.
 
 ## Documentation updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -19,7 +19,7 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 - Extended [`@onkernel/cua-agent`](https://github.com/kernel/cua) with Claude Opus 5 and Moonshot Kimi K3 computer-use providers, semantic browser waits (`waitFor` conditions instead of fixed sleeps), verified browser action plans, and gated Anthropic's native `computer_20260701` / `browser_20260701` tools by model.
 - Added named markers to browser [replay recordings](/browsers/replays), exposed as MP4 chapters so playback jumps directly to key moments.
 - Extended the [CLI](https://github.com/kernel/cli) `browser-pools` commands with telemetry configuration, matching the flags already on `browsers create`/`update`.
-- Improved `kernel upgrade` in the [CLI](https://github.com/kernel/cli) to refresh the Homebrew tap before upgrading, so it always picks up the latest published version, and made CLI commands fail fast on interactive prompts in non-interactive shells to avoid hanging scripts.
+- Improved `kernel upgrade` in the [CLI](https://github.com/kernel/cli) to refresh the Homebrew tap before upgrading to pick up latest version, and made CLI commands fail fast on interactive prompts in non-interactive shells to avoid hanging scripts.
 - Added a complete audit log download helper to the Go, Node, and Python SDKs.
 - Added support for solving PerimeterX / HUMAN "Press & Hold" challenges in [stealth-mode browsers](/browsers/bot-detection/stealth).
 - Added customer-supplied CA bundles to [custom proxies](/proxies/custom) for BYO TLS-terminating (MITM) proxies.


### PR DESCRIPTION
## Summary

Adds the July 30 changelog entry covering product and documentation updates since the July 17 entry.

Product highlights: customer-supplied CA bundles for BYO TLS-terminating proxies, PerimeterX / HUMAN "Press & Hold" challenge solving, stealth egress fingerprint parity with Chrome, live proxy swaps across egress paths, per-connection managed auth telemetry with health checks on the connection timeline, new computer-use providers and semantic waits in `@onkernel/cua-agent`, named replay markers as MP4 chapters, a `get_telemetry` MCP action, and CLI/SDK improvements.

The documentation section lists the pages added or reworked in the same window.

## Notes

- Bug fixes are intentionally excluded from this entry.
- Every relative link in the new entry was checked against `docs.json` navigation and the corresponding `.mdx` file on disk — all 18 resolve.
- The two telemetry links point at `/browsers/telemetry/overview`. `/browsers/telemetry` is not a page and has no redirect; earlier entries link to it and are left unchanged here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no runtime or API behavior changes in this diff.
> 
> **Overview**
> **Adds a new July 31 changelog entry** at the top of `changelog.mdx`, in the same `<Update>` format as prior releases.
> 
> The **Product updates** section calls out integrations and tooling (Eve extension, Codex skills plugin), MCP `get_telemetry`, expanded managed auth and telemetry on connection timelines, `@onkernel/cua-agent` provider and wait improvements, replay MP4 chapter markers, CLI pool telemetry and non-interactive behavior, SDK audit-log download helpers, PerimeterX press-and-hold solving, custom proxy CA bundles, and related CLI/SDK tweaks.
> 
> The **Documentation updates** section lists new integration guides, proxy/audit/pools/auth docs, bots overview and FAQ reframing, MCP/CLI reference refreshes, Chrome policies reorg, and pricing matrix updates for browser telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc1c7b4206bcf6ed0c5227e323d1e293480b76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->