### PR TITLE
Stop Vercel from deploying the docs repo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## Summary

The `Vercel` check has been red on every docs PR and on `main` for as long as the status history goes back. It is not a broken change — it is a misconfigured project.

From the build log:

```
Your application is being built using `next build`.
Installing dependencies... up to date in 415ms
Warning: Could not identify Next.js version, ensure it is defined as a project dependency.
Error: No Next.js version detected.
```

This repo has no `package.json` at all, and the Vercel project's framework preset is Next.js. There is nothing here for `next build` to build and never was. Docs are deployed by Mintlify, which is the check that actually tells you whether a change went live.

`vercel.json` with `git.deploymentEnabled: false` makes the Git integration skip this repo, so no deployment is attempted and no check is posted.

## Why bother

A check that is always red is a check nobody reads. #471, #469 and #468 all merged with it failing. Removing it means the next genuinely-red check on a docs PR means something.

## Alternative

Disconnecting the project in the Vercel dashboard does the same thing. This lives in the repo instead, where it is visible and revertible in review — pick whichever you prefer. If Kernel does intend to build this repo on Vercel eventually, the fix is a `package.json` plus the right framework preset, not this file.