### PR TITLE
Document sensitive identity provider auth safety

### DIFF
--- a/auth/connection-lifecycle.mdx
+++ b/auth/connection-lifecycle.mdx
@@ -18,7 +18,7 @@ After the initial login, every connection moves through this loop:
     If the check finds the session expired and the connection's `can_reauth` is `true`, Kernel runs the saved login flow with the stored credentials in the background. A successful login resets the loop.
   </Step>
   <Step title="NEEDS_AUTH (if not eligible, or auto-reauth fails)">
-    If auto-reauth isn't possible — credentials aren't linked, the saved flow requires human input, or the login keeps failing — the connection's `status` flips to `NEEDS_AUTH` and a new login session is required.
+    If auto-reauth isn't possible — credentials aren't linked, the saved flow requires human input, or the login keeps failing — the connection's `status` flips to `NEEDS_AUTH`. Scheduled health checks pause until a new login succeeds.
   </Step>
 </Steps>
 

--- a/auth/connection-lifecycle.mdx
+++ b/auth/connection-lifecycle.mdx
@@ -18,7 +18,7 @@ After the initial login, every connection moves through this loop:
     If the check finds the session expired and the connection's `can_reauth` is `true`, Kernel runs the saved login flow with the stored credentials in the background. A successful login resets the loop.
   </Step>
   <Step title="NEEDS_AUTH (if not eligible, or auto-reauth fails)">
-    If auto-reauth isn't possible — credentials aren't linked, the saved flow requires human input, or the login keeps failing — the connection's `status` flips to `NEEDS_AUTH`. Scheduled health checks pause until a new login succeeds.
+    If auto-reauth isn't possible — credentials aren't linked, the saved flow requires human input, or the login keeps failing — the connection's `status` flips to `NEEDS_AUTH` and a new login session is required.
   </Step>
 </Steps>
 

--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -4,7 +4,7 @@ title: FAQ
 
 ## How does automatic re-authentication work?
 
-When you link credentials to a connection, Kernel runs periodic health checks, detects logged-out sessions, and re-authenticates in the background so the profile stays logged in. See [Connection Lifecycle](/auth/connection-lifecycle) for the full lifecycle, cadence options, and `can_reauth` rules.
+When you link credentials to a connection, Kernel runs periodic health checks, detects logged-out sessions, and re-authenticates in the background so the profile stays logged in. Scheduled checks pause when the connection enters `NEEDS_AUTH` and resume after a successful login. See [Connection Lifecycle](/auth/connection-lifecycle) for the full lifecycle, cadence options, and `can_reauth` rules.
 
 ## What are sign-in options?
 
@@ -16,6 +16,10 @@ Managed Auth supports username/password authentication and most SSO providers.
 
 <Warning>
 Passkey-based authentication (e.g., Google accounts with passkeys enabled) is not currently supported. If a user's SSO provider requires a passkey, the login will fail with the `unsupported_auth_method` error code.
+</Warning>
+
+<Warning>
+For Google and other sensitive identity providers, use an established account and attach a stable ISP or custom proxy before login. Keep the default 1-hour health-check interval unless you need faster detection; repeated checks from a new account or changing IP addresses can trigger the provider's security controls. Google connections require stable egress when using 5-minute checks.
 </Warning>
 
 ## What happens if login fails?

--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -19,7 +19,7 @@ Passkey-based authentication (e.g., Google accounts with passkeys enabled) is no
 </Warning>
 
 <Warning>
-For Google and other sensitive identity providers, use an established account and attach a stable ISP or custom proxy before login. Keep the default 1-hour health-check interval unless you need faster detection; repeated checks from a new account or changing IP addresses can trigger the provider's security controls. Google connections require stable egress when using 5-minute checks.
+For sensitive identity providers, use an established account and attach a stable ISP or custom proxy before login. Keep the default 1-hour health-check interval unless you need faster detection; repeated checks from a new account or changing IP addresses can trigger the provider's security controls.
 </Warning>
 
 ## What happens if login fails?

--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -4,7 +4,7 @@ title: FAQ
 
 ## How does automatic re-authentication work?
 
-When you link credentials to a connection, Kernel runs periodic health checks, detects logged-out sessions, and re-authenticates in the background so the profile stays logged in. Scheduled checks pause when the connection enters `NEEDS_AUTH` and resume after a successful login. See [Connection Lifecycle](/auth/connection-lifecycle) for the full lifecycle, cadence options, and `can_reauth` rules.
+When you link credentials to a connection, Kernel runs periodic health checks, detects logged-out sessions, and re-authenticates in the background so the profile stays logged in. See [Connection Lifecycle](/auth/connection-lifecycle) for the full lifecycle, cadence options, and `can_reauth` rules.
 
 ## What are sign-in options?
 


### PR DESCRIPTION
## summary
- warn users to use established accounts and stable egress for sensitive identity providers
- recommend the default hourly health-check cadence to reduce provider security triggers

## validation
- `git diff --check`
- docs preview not run because the Mintlify CLI is unavailable in this environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or auth logic impact.
> 
> **Overview**
> Adds a **Warning** under the Managed Auth FAQ’s “Which authentication methods are supported?” section, next to the existing passkey limitation callout.
> 
> It tells customers using **sensitive identity providers** to log in with an **established account**, use a **stable ISP or custom proxy** before login, and **keep the default 1-hour health-check interval** unless faster detection is required—because **new accounts**, **changing IPs**, or **frequent checks** can trip provider security controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b3a4e977212fabc5af0089e25de184cd604777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->