### PR TITLE
docs: add URLAllowlist navigation-restriction example to chrome policies

### DIFF
--- a/browsers/chrome-policies.mdx
+++ b/browsers/chrome-policies.mdx
@@ -272,6 +272,38 @@ const browser = await kernel.browsers.create({
 ```
 </CodeGroup>
 
+### Restrict navigation to specific URLs
+
+To lock a browser to an approved set of URLs, block everything with `URLBlocklist` and then allow back only the URLs you want with `URLAllowlist`. Entries match a whole domain (`chatgpt.com`) or a specific path (`en.wikipedia.org/wiki/Cat`), and more specific entries take precedence. This gates top-level navigation, so any other URL returns `ERR_BLOCKED_BY_ADMINISTRATOR`; it does not block resources or API calls a permitted page loads from other origins.
+
+<CodeGroup>
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+browser = kernel.browsers.create(
+    chrome_policy={
+        "URLBlocklist": ["*"],
+        "URLAllowlist": ["chatgpt.com", "en.wikipedia.org/wiki/Cat"],
+    }
+)
+```
+
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const browser = await kernel.browsers.create({
+  chrome_policy: {
+    URLBlocklist: ["*"],
+    URLAllowlist: ["chatgpt.com", "en.wikipedia.org/wiki/Cat"],
+  },
+});
+```
+</CodeGroup>
+
 ## Available policies
 
 Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object. Refer to the official docs for the full list of supported policy names, types, and values.


### PR DESCRIPTION
## Summary

Adds a "Restrict navigation to specific URLs" section to `browsers/chrome-policies.mdx`, directly below "Block DevTools and page source", showing the allowlist-only pattern:

```json
{ "URLBlocklist": ["*"], "URLAllowlist": ["chatgpt.com", "en.wikipedia.org/wiki/Cat"] }
```

Same level of detail and structure as the DevTools section (intro paragraph + Python/TS `CodeGroup`).

## Notes

- Entries match a whole domain or a specific path; more specific entries take precedence.
- The section notes the behavior I verified against a live Kernel browser: the policy gates top-level navigation (non-allowlisted URLs return `ERR_BLOCKED_BY_ADMINISTRATOR`) but does not block sub-resources or API calls a permitted page loads from other origins.
- Docs-only change; preview will render at the branch Mintlify URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime, API, or security logic modifications.
> 
> **Overview**
> Adds a **Restrict navigation to specific URLs** common-use-case section to `browsers/chrome-policies.mdx`, placed after the DevTools blocklist example.
> 
> The section documents the **block-all-then-allow** pattern (`URLBlocklist: ["*"]` plus `URLAllowlist` for approved domains/paths), including how matching and precedence work and that only **top-level navigation** is gated (`ERR_BLOCKED_BY_ADMINISTRATOR`), not sub-resources or cross-origin APIs on allowed pages. Python and TypeScript `browsers.create()` snippets mirror the existing DevTools section format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb1161d68e56d2cece1b427d8e3493981ce4d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->