### PR TITLE
Style inline code as monospace chips

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,23 +20,22 @@ kbd {
    variables like `payload` render in a proportional font with no chip and read
    as malformed prose rather than code. force a monospace stack and a subtle
    background so inline code looks like code. code blocks live inside <pre> and
-   keep their own styling. tinted with kernel green (#81b300) as a fill so it
-   reads as brand, not sterile grey — green is used as the chip fill with the
-   existing charcoal text, per the brand rule (never green body text). */
+   keep their own styling. tinted with a light gold (#cab168, the docs accent)
+   fill so it reads as brand, not sterile grey, with the existing charcoal text. */
 :not(pre) > code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace !important;
   font-size: 0.875em !important;
   padding: 0.1em 0.35em !important;
-  background-color: rgba(129, 179, 0, 0.12) !important;
-  border: 1px solid rgba(129, 179, 0, 0.35) !important;
+  background-color: rgba(202, 177, 104, 0.14) !important;
+  border: 1px solid rgba(202, 177, 104, 0.4) !important;
   letter-spacing: normal !important;
   font-weight: 400 !important;
 }
 
 html.dark :not(pre) > code {
-  background-color: rgba(129, 179, 0, 0.16) !important;
-  border-color: rgba(129, 179, 0, 0.4) !important;
+  background-color: rgba(202, 177, 104, 0.18) !important;
+  border-color: rgba(202, 177, 104, 0.45) !important;
 }
 
 /* remove all rounded corners site-wide */

--- a/style.css
+++ b/style.css
@@ -16,6 +16,27 @@ kbd {
   text-transform: none !important;
 }
 
+/* inline code — the global Inter font family bleeds onto bare <code> spans, so
+   variables like `payload` render in a proportional font with no chip and read
+   as malformed prose rather than code. force a monospace stack and a subtle
+   background so inline code looks like code. code blocks live inside <pre> and
+   keep their own styling. */
+:not(pre) > code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace !important;
+  font-size: 0.875em !important;
+  padding: 0.1em 0.35em !important;
+  background-color: rgba(33, 34, 37, 0.06) !important;
+  border: 1px solid rgba(33, 34, 37, 0.1) !important;
+  letter-spacing: normal !important;
+  font-weight: 400 !important;
+}
+
+html.dark :not(pre) > code {
+  background-color: rgba(237, 238, 240, 0.06) !important;
+  border-color: rgba(237, 238, 240, 0.12) !important;
+}
+
 /* remove all rounded corners site-wide */
 *,
 *::before,

--- a/style.css
+++ b/style.css
@@ -20,21 +20,23 @@ kbd {
    variables like `payload` render in a proportional font with no chip and read
    as malformed prose rather than code. force a monospace stack and a subtle
    background so inline code looks like code. code blocks live inside <pre> and
-   keep their own styling. */
+   keep their own styling. tinted with kernel green (#81b300) as a fill so it
+   reads as brand, not sterile grey — green is used as the chip fill with the
+   existing charcoal text, per the brand rule (never green body text). */
 :not(pre) > code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace !important;
   font-size: 0.875em !important;
   padding: 0.1em 0.35em !important;
-  background-color: rgba(33, 34, 37, 0.06) !important;
-  border: 1px solid rgba(33, 34, 37, 0.1) !important;
+  background-color: rgba(129, 179, 0, 0.12) !important;
+  border: 1px solid rgba(129, 179, 0, 0.35) !important;
   letter-spacing: normal !important;
   font-weight: 400 !important;
 }
 
 html.dark :not(pre) > code {
-  background-color: rgba(237, 238, 240, 0.06) !important;
-  border-color: rgba(237, 238, 240, 0.12) !important;
+  background-color: rgba(129, 179, 0, 0.16) !important;
+  border-color: rgba(129, 179, 0, 0.4) !important;
 }
 
 /* remove all rounded corners site-wide */


### PR DESCRIPTION
## Summary

Inline `code` variables in the docs were rendering in the global Inter (proportional) font with no visual treatment — weird spacing, wrong size, and no code-like appearance, so they read as malformed prose instead of code.

Root cause: the site's `fonts.family: Inter` config applies broadly, and bare inline `<code>` spans (e.g. `payload`, `runtimeContext`, `App`) had no dedicated styling to override it. Code blocks were unaffected since they live inside `<pre>`/`.code-group` with their own mono styling.

This adds a scoped `:not(pre) > code` rule in `style.css`:
- monospace font stack
- subtle background chip + border (respects the site-wide `border-radius: 0`)
- normal letter-spacing and `0.875em` sizing

Includes a dark-mode variant using the same neutral tokens already used elsewhere in the file.

## Test page

Set up as a test on the [Developing](https://www.kernel.sh/docs/apps/develop#registering-actions) page, which is dense with inline variables. If it looks good, the same treatment covers inline code across all docs pages (the rule is global). Preview once the Mintlify branch build is up.

## Notes

- No page content changed — CSS only.
- Table inline code keeps its existing dedicated sizing/padding (higher specificity) and picks up the new mono font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS with scoped selectors; no content, auth, or data paths touched.
> 
> **Overview**
> Adds global **`style.css`** rules for **inline** `<code>` (via `:not(pre) > code`) so bare variables pick up a monospace stack, subtle gold-tinted chip background/border, and normalized sizing/letter-spacing instead of inheriting Inter from the site font config. **`<pre>`** blocks are unchanged.
> 
> A **`html.dark`** override bumps background and border opacity for the same inline treatment in dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e25d3ff1df27f309f103d0ccff8db1b5ff0842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->