### PR TITLE
Docs: packaging plan gating + limits, non-pricing pages (packaging PR 8)

### DIFF
--- a/auth/configuration.mdx
+++ b/auth/configuration.mdx
@@ -368,7 +368,7 @@ After creating a connection, you can update its configuration with `auth.connect
 | `login_url` | Override the login page URL |
 | `credential` | Update the linked credential |
 | `allowed_domains` | Update allowed redirect domains |
-| `health_check_interval` | Seconds between health checks (minimum varies by plan) |
+| `health_check_interval` | Seconds between health checks (the [minimum varies by plan](/auth/connection-lifecycle#cadence)) |
 | `health_checks` | Whether periodic health checks run for this connection |
 | `auto_reauth` | Whether a failed scheduled health check is allowed to attempt automatic re-authentication |
 | `save_credentials` | Whether to save credentials on successful login |

--- a/auth/connection-lifecycle.mdx
+++ b/auth/connection-lifecycle.mdx
@@ -28,6 +28,7 @@ Health checks run on a configurable interval. Your plan sets the minimum:
 
 | Plan | Minimum interval |
 |------|------------------|
+| Developer (free) | 6 hours |
 | Hobbyist | 1 hour |
 | Start-Up | 20 minutes |
 | Enterprise | Fully configurable (as low as 5 minutes) |

--- a/auth/faq.mdx
+++ b/auth/faq.mdx
@@ -55,6 +55,6 @@ See [Profiles — Multiple auth connections per profile](/auth/profiles#multiple
 
 ## How is Managed Auth billed?
 
-Managed Auth is included on all paid plans with no per-connection fees. It uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage like any other browser session.
+Managed Auth is included on every plan with no per-connection fees—the free Developer plan supports up to 3 connections, and paid plans are unlimited. It uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage like any other browser session.
 
 Auth sessions are fast (typically 5-30 seconds each). Kernel monitors session health and re-authenticates automatically when sessions expire—most stay valid for days. For example, keeping 100 auth connections logged in typically costs less than $5/month in browser usage. See [Pricing & Limits](/info/pricing#managed-auth) for details.

--- a/browsers/extensions.mdx
+++ b/browsers/extensions.mdx
@@ -47,6 +47,10 @@ This name must be unique within your [project](/info/projects).
 To retrieve an extension's metadata without downloading the archive, call `GET /extensions/{id_or_name}/metadata`.
 The response includes the extension's ID, name, size, and timestamps.
 
+<Info>
+    The Developer (free) and Hobbyist plans can keep 1 uploaded extension per organization at a time; uploading a second returns an error. Deleting a stored extension frees the slot. Start-Up and Enterprise plans have no limit on stored extensions. See [Pricing & Limits](/info/pricing#concurrency-limits).
+</Info>
+
 ## Using extensions in a browser
 
 Passing the extension name or ID to the `create` method will load it into the browser.
@@ -54,7 +58,7 @@ Passing the extension name or ID to the `create` method will load it into the br
 <Info>
     Loading an extension into a browser triggers a Chromium restart, which can take several seconds. Use [browser pools](/browsers/pools) to access browsers with extensions faster.
 
-    The number of extensions you can load into a single browser depends on your plan — see [Pricing & Limits](/info/pricing#concurrency-limits).
+    Loading extensions into a browser isn't plan-limited — every plan can load up to 20 extensions per browser session. See [Pricing & Limits](/info/pricing#concurrency-limits).
 </Info>
 
 

--- a/browsers/extensions.mdx
+++ b/browsers/extensions.mdx
@@ -53,6 +53,8 @@ Passing the extension name or ID to the `create` method will load it into the br
 
 <Info>
     Loading an extension into a browser triggers a Chromium restart, which can take several seconds. Use [browser pools](/browsers/pools) to access browsers with extensions faster.
+
+    The number of extensions you can load into a single browser depends on your plan — see [Pricing & Limits](/info/pricing#concurrency-limits).
 </Info>
 
 

--- a/browsers/pools.mdx
+++ b/browsers/pools.mdx
@@ -31,7 +31,7 @@ A few constraints to weigh before moving a workload onto a browser pool:
 - **One fixed configuration per browser pool**, with `start_url` the only setting you can override per acquisition — see [Create a browser pool](#create-a-browser-pool).
 - **Profiles load read-only**, and a browser pool holds one at a time — see [Profiles with browser pools](#profiles-with-browser-pools) for how to persist state per user.
 - **Browser pool capacity counts against your [concurrency limit](/info/pricing#concurrency-limits)** whether or not its browsers are acquired, though idle pooled browsers aren't billed.
-- **Plan-gated.** Browser pools are available on the Start-Up and Enterprise plans.
+- **Bounded by your plan's concurrency.** Browser pools are available on every plan, but pool size counts against your [concurrency limit](/info/pricing#concurrency-limits), so your plan caps how large a pool you can create.
 
 ## Create a browser pool
 

--- a/browsers/replays.mdx
+++ b/browsers/replays.mdx
@@ -5,6 +5,8 @@ description: "Record and view browser sessions as mp4 videos"
 
 Replays capture browser sessions as video recordings that you can view or download later. You have full control over when replays start and stop, allowing you to capture specific interactions or workflows.
 
+Replays are available on every plan. How long a replay is kept depends on your plan — see [Pricing & Limits](/info/pricing#managed-infrastructure).
+
 ## Starting and stopping recordings
 
 To start recording a browser session, use the replays API on an active browser:

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -31,19 +31,21 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 | Configurable browser viewports | ✅ | ✅ | ✅ | ✅ |
 | Managed stealth mode | ✅ | ✅ | ✅ | ✅ |
 | Computer controls API | ✅ | ✅ | ✅ | ✅ |
-| Browser replays | ❌ | 7 days | 30 days | Custom |
-| Browser profiles | ❌ | ✅ | ✅ | ✅ |
-| Managed auth profiles | ❌ | ✅ | ✅ | ✅ |
-| File uploads & downloads | ❌ | ✅ | ✅ | ✅ |
-| Configurable browser extensions | ❌ | ❌ | ✅ | ✅ |
+| Browser replays | 1 day | 7 days | 30 days | Custom |
+| Browser profiles | ✅ | ✅ | ✅ | ✅ |
+| Managed auth profiles | ✅ | ✅ | ✅ | ✅ |
+| File uploads & downloads | ✅ | ✅ | ✅ | ✅ |
+| Configurable browser extensions | ✅ | ✅ | ✅ | ✅ |
 | Configurable & BYO proxies | ❌ | ❌ | ✅ | ✅ |
-| Browser pools | ❌ | ❌ | ✅ | ✅ |
+| Browser pools | ✅ | ✅ | ✅ | ✅ |
 | Support | Discord | Discord | Email | Shared Slack |
 | SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
 | GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | HIPAA compliance (BAA) | ❌ | ❌ | ❌ | ✅ |
 
 > Note: Included monthly credits apply to usage costs only.
+
+> Note: Files written inside a browser (uploads and downloads) only live as long as that browser session on every plan — see [File I/O](/browsers/file-io).
 
 ## Browser pools
 
@@ -53,7 +55,7 @@ With [browser pools](/browsers/pools), you pay the standard usage-based price pe
 
 ## Managed Auth
 
-Managed Auth is included on all paid plans with no per-connection fees. Under the hood, it uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage and concurrency like any other browser session.
+Managed Auth is included on every plan with no per-connection fees—the free Developer plan supports up to 3 connections, and paid plans are unlimited. Under the hood, it uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage and concurrency like any other browser session.
 
 Auth sessions are fast (typically 5-30 seconds each). Kernel monitors session health and re-authenticates automatically when sessions expire—most stay valid for days. For example, keeping 100 auth connections logged in typically costs less than $5/month in browser usage.
 
@@ -64,11 +66,13 @@ Kernel enforces a single concurrency limit covering all browsers you run at once
 | Feature | Developer (free + usage) | Hobbyist ($30 / mo + usage) | Start-Up ($200 / mo + usage) | Enterprise |
 | --- | --- | --- | --- | --- |
 | Concurrent browsers | 5 | 10 | 150 | Custom |
-| App invocations | 5 | 10 | 50 | Custom |
+| App invocations | 5 | 10 | 150 | Custom |
 | App invocations (per-app) | 5 | 10 | 20 | Custom |
-| Managed auth health check interval | N/A | 1 hour minimum | 20 minutes minimum | Custom |
+| Managed auth health check interval | 6 hours minimum | 1 hour minimum | 20 minutes minimum | Custom |
+| Managed auth connections | 3 | Unlimited | Unlimited | Unlimited |
+| Browser extensions per browser | 1 | 1 | 20 | Custom |
 
-> Note: A [browser pool](/browsers/pools) counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on Start-Up and Enterprise plans.
+> Note: A [browser pool](/browsers/pools) counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on every plan, and your concurrency limit caps how large a pool you can create.
 
 > Note: Browsers in [Standby Mode](/browsers/standby) count against your concurrency limit.
 

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -70,7 +70,10 @@ Kernel enforces a single concurrency limit covering all browsers you run at once
 | App invocations (per-app) | 5 | 10 | 20 | Custom |
 | Managed auth health check interval | 6 hours minimum | 1 hour minimum | 20 minutes minimum | Custom |
 | Managed auth connections | 3 | Unlimited | Unlimited | Unlimited |
-| Browser extensions per browser | 1 | 1 | 20 | Custom |
+| Stored custom extensions | 1 | 1 | Unlimited | Unlimited |
+| Extensions per browser session | 20 | 20 | 20 | 20 |
+
+> Note: `Stored custom extensions` is how many [extensions](/browsers/extensions) your org can keep uploaded at once; deleting a stored extension frees the slot. Loading extensions into a browser isn't plan-limited — every plan can load up to 20 per browser session.
 
 > Note: A [browser pool](/browsers/pools) counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on every plan, and your concurrency limit caps how large a pool you can create.
 

--- a/integrations/vercel/eve-extension.mdx
+++ b/integrations/vercel/eve-extension.mdx
@@ -70,7 +70,7 @@ Once mounted, the agent has the following tools, namespaced under your mount (e.
 - **`manage_auth_connections`**: Kernel's [managed auth](/auth/overview), so the agent logs into sites through a stored connection or a hosted login flow instead of typing credentials into the page.
 - **`manage_profiles`**: create and reuse browser [profiles](/auth/profiles) (persistent cookies, logins, storage).
 - **`manage_proxies`**: create and attach [proxies](/proxies/overview) (datacenter, ISP, residential, mobile) with geo-targeting.
-- **`manage_replays`**: start, stop, and list video replay recordings for a session, so you can capture what the agent did as an MP4. Requires a paid Kernel plan.
+- **`manage_replays`**: start, stop, and list video replay recordings for a session, so you can capture what the agent did as an MP4. Replay [retention varies by plan](/info/pricing#managed-infrastructure).
 - the **`browse` skill**: the loop the model follows to drive the browser end to end.
 
 The `browse` skill runs autonomously but is human-in-the-loop friendly:

--- a/reference/cli/managed-auth.mdx
+++ b/reference/cli/managed-auth.mdx
@@ -16,7 +16,7 @@ Create a managed auth connection for a profile and domain.
 | `--domain <domain>` | Target domain for authentication (required). |
 | `--allowed-domain <domain>` | Additional allowed domains (repeatable). |
 | `--login-url <url>` | Login page URL to skip discovery. |
-| `--health-check-interval <seconds>` | Seconds between health checks (300–86400). |
+| `--health-check-interval <seconds>` | Seconds between health checks (300–86400); your [plan sets the effective minimum](/auth/connection-lifecycle#cadence). |
 | `--proxy-id <id>` | Proxy ID to use. |
 | `--proxy-name <name>` | Proxy name to use. |
 | `--credential-provider <name>` | External credential provider name. |
@@ -105,7 +105,7 @@ Update connection settings such as login URL, health checks, credential source, 
 |------|-------------|
 | `--login-url <url>` | Login page URL (set to an empty string to clear). |
 | `--allowed-domain <domain>` | Additional allowed domains (replaces the existing list). |
-| `--health-check-interval <seconds>` | Seconds between health checks. |
+| `--health-check-interval <seconds>` | Seconds between health checks (300–86400); your [plan sets the effective minimum](/auth/connection-lifecycle#cadence). |
 | `--proxy-id <id>` | Proxy ID to use. |
 | `--proxy-name <name>` | Proxy name to use. |
 | `--credential-provider <name>` | External credential provider name. |


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge yet.** This documents functionality that is **not yet deployed**. It merges only when the August '26 self-serve packaging changes ship, timed with the announcement.

Linear: [KERNEL-1903](https://linear.app/onkernel/issue/KERNEL-1903) (parent: [KERNEL-1507](https://linear.app/onkernel/issue/KERNEL-1507))

## New plan state documented

- **Free (Developer)**: profiles unlimited, managed auth with 3 connections and a 6-hour minimum health-check interval, file I/O (files persist only for the browser session), replays with 1-day retention, browser pools (size bounded by browser concurrency), 1 stored custom extension per org.
- **Hobbyist**: unchanged except extensions (1 stored per org) and pools now available; health-check minimum stays 1 hour.
- **Start-Up**: app invocation concurrency 50 → 150; unlimited stored extensions.
- **Proxies and GPU remain Start-Up and Enterprise. Enterprise unchanged.**

### Extension limit semantics

Extension limits are on **storage**, not runtime:

- **Stored custom extensions** (enforced on `POST /extensions`): 1 per org on Developer (free) and Hobbyist, unlimited on Start-Up and Enterprise. Deleting a stored extension frees the slot.
- **Loading extensions into a browser session is not plan-limited.** A flat technical ceiling of 20 extensions per browser session applies to every plan.

## Pages changed

- `info/pricing.mdx` — managed-infrastructure table (replays, profiles, managed auth profiles, file I/O, extensions, pools), concurrency table (app invocations 50 → 150, health-check interval Free 6h, new managed auth connections row, `Stored custom extensions` row at 1/1/Unlimited/Unlimited, and `Extensions per browser session` at 20 for all plans), managed auth billing copy, and the stale "browser pools are Start-Up and Enterprise" note.
- `auth/connection-lifecycle.mdx` — added a Developer (free) row at 6 hours to the cadence table.
- `auth/configuration.mdx` — `health_check_interval` description now links to the cadence table.
- `auth/faq.mdx` — managed auth is on every plan, 3 connections on free.
- `reference/cli/managed-auth.mdx` — both `--health-check-interval` flags note the plan-set effective minimum (range stays 300–86400).
- `browsers/pools.mdx` — replaced the plan-gated limitation with a concurrency-bounded one.
- `browsers/replays.mdx` — replays available on every plan, retention varies.
- `browsers/extensions.mdx` — callout in the upload section for the 1-stored-extension cap on Developer/Hobbyist; the "using extensions in a browser" note now states loading is not plan-limited (20 per session for everyone).
- `integrations/vercel/eve-extension.mdx` — `manage_replays` no longer says "requires a paid plan".

No changelog entry — that's added at announcement time.

## Proxies copy finding

`proxies/overview.mdx` never states that proxies are Start-Up and Enterprise only. The only gating statement on that page is the bypass-hosts note (line ~315), which correctly says Start-Up and Enterprise. The only place proxy gating appears at all is the `Configurable & BYO proxies` row in `info/pricing.mdx`. So the copy isn't wrong, it's incomplete — a Developer or Hobbyist reader on `/proxies/overview` gets no signal that proxies are unavailable to them. Left unchanged per instructions; worth a follow-up ticket to add a plan callout to the proxies overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
