### PR TITLE
docs: clarify viewport sets window size, not page viewport

### DIFF
--- a/browsers/viewport.mdx
+++ b/browsers/viewport.mdx
@@ -135,6 +135,32 @@ func main() {
 The `refresh_rate` parameter only applies to live view sessions and is ignored for [headless](/browsers/headless) browsers.
 </Info>
 
+## Window size vs. page viewport
+
+The `viewport` parameter sets the dimensions of the browser **window**, not the visible page area. On headful browsers, Chromium's UI (tab strip and toolbar) occupies part of the window height, so the page renders in a slightly shorter area than the configured height. For example, with a 1280x800 viewport, `window.innerHeight` will be less than 800 and content near the bottom of the page may not be visible in screenshots or live view.
+
+If your automation expects an exact page viewport, either:
+
+- **Set the page viewport through your automation framework**, which controls the rendered page size directly regardless of the window dimensions:
+
+<CodeGroup>
+
+```typescript Typescript/Javascript
+// Playwright
+await page.setViewportSize({ width: 1280, height: 800 });
+```
+
+```python Python
+# Playwright
+await page.set_viewport_size({"width": 1280, "height": 800})
+```
+
+</CodeGroup>
+
+- **Account for the browser UI when choosing dimensions** by adding its height to the `height` you pass to Kernel, so the remaining page area matches your target size.
+
+On [headless](/browsers/headless) browsers there is no browser UI, so the page viewport matches the configured dimensions exactly.
+
 ## Supported viewport configurations
 
 Kernel supports specific viewport configurations tuned for optimal performance and Computer Use compatibility. When you provide width and height without specifying refresh_rate, it will be automatically determined if the dimensions match one of the supported resolutions exactly. The following resolutions are supported:
@@ -414,4 +440,4 @@ if err != nil {
 - The viewport configuration is set when the browser is created and applies to the initial browser window
 - Higher resolutions (like 2560x1440) may impact the performance and responsiveness of live view sessions
 - The viewport size affects how websites render, especially those with responsive designs
-- Screenshots taken from the browser will match the configured viewport dimensions
+- Screenshots taken through your automation framework capture the page viewport, which on headful browsers is shorter than the configured dimensions due to the browser UI (see [Window size vs. page viewport](#window-size-vs-page-viewport))


### PR DESCRIPTION
## Why

Customer feedback (Slack): they set a 1280x800 viewport and the bottom of the screen was cut off in their tests. Root cause: the `viewport` parameter sets the browser **window** dimensions, and on headful browsers Chromium's UI (tab strip, toolbar) consumes part of that height — so the visible page area is shorter than the configured height. The docs never mentioned this, so it read as a regression on the customer's side.

## What

- New **Window size vs. page viewport** section on `browsers/viewport.mdx` explaining the behavior, with two workarounds:
  - set the page viewport directly via the automation framework (Playwright `setViewportSize` example)
  - pad the configured height to account for the browser UI
- Notes that headless browsers have no browser UI, so the page viewport matches exactly
- Corrects the Considerations bullet that claimed screenshots always match the configured dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to viewport guidance; no runtime or API behavior changes.
> 
> **Overview**
> Documents that Kernel’s `viewport` parameter controls **browser window** size, not the rendered page area on headful sessions—Chromium chrome reduces usable height (e.g. 1280×800 can clip the bottom in live view and screenshots).
> 
> Adds a **Window size vs. page viewport** section with Playwright `setViewportSize` examples and guidance to pad configured height for browser UI, and notes headless sessions match dimensions exactly. Updates **Considerations** so automation-framework screenshots are described as page viewport–sized, with a link to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d795d482b5883798b41d49ffc0390ae756d99f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->