### PR TITLE
Document the Terraform provider

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -232,6 +232,7 @@
               "integrations/notte",
               "integrations/vibium",
               "integrations/stagehand",
+              "integrations/terraform",
               "integrations/valtown",
               {
                 "group": "Vercel",

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -34,6 +34,7 @@ Kernel provides detailed guides for popular agent frameworks:
 - **[Claude Agent SDK](/integrations/claude/claude-agent-sdk)** - Run Claude Agent SDK automations in cloud browsers
 - **[Claude Managed Agents](/integrations/claude/claude-managed-agents)** - Run Anthropic's hosted agent harness against cloud browsers
 - **[Stagehand](/integrations/stagehand)** - AI browser automation with natural language
+- **[Terraform](/integrations/terraform)** - Manage durable Kernel infrastructure as code
 - **[Computer Use (Anthropic)](/integrations/computer-use/anthropic)** - Claude's computer use capability
 - **[Computer Use (OpenAI)](/integrations/computer-use/openai)** - OpenAI's computer use capability
 - **[Computer Use (Gemini)](/integrations/computer-use/gemini)** - Gemini's computer use capability

--- a/integrations/terraform.mdx
+++ b/integrations/terraform.mdx
@@ -1,0 +1,39 @@
+---
+title: "Terraform"
+description: "Manage durable Kernel infrastructure with Terraform"
+---
+
+Use the official Kernel Terraform provider to manage durable infrastructure such as projects and browser pools.
+
+## Install the provider
+
+Add `kernel/kernel` to your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    kernel = {
+      source = "kernel/kernel"
+    }
+  }
+}
+
+provider "kernel" {}
+```
+
+Set `KERNEL_API_KEY` and, when needed, `KERNEL_PROJECT_ID` in the environment where Terraform runs. You can then manage Kernel projects and browser pools, read existing projects, profiles, proxies, and extensions, and import existing projects or browser pools by ID.
+
+<Note>
+The provider manages durable desired configuration. Use the Kernel SDKs or API for runtime browser operations such as creating sessions, acquiring browsers, releasing browsers, and viewing logs.
+</Note>
+
+## Provider documentation
+
+<CardGroup cols={2}>
+  <Card title="Terraform Registry" icon="cube" href="https://registry.terraform.io/providers/kernel/kernel/latest">
+    Browse installation instructions and the generated resource and data source reference.
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/kernel/terraform-provider-kernel">
+    View examples, release notes, source code, and contribution guidance.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- add a concise Terraform integration page to the public documentation
- link to the Terraform Registry for installation and generated reference docs
- link to GitHub for examples, releases, source, and contributions
- add the page to the sidebar and integrations overview

## Why

Kernel Terraform Provider v0.1 is publicly available. Customers need a discoverable path from Kernel documentation without duplicating the provider reference documentation maintained by the Registry and provider repository.

## Scope

The page documents durable infrastructure management only. It directs runtime browser operations to Kernel SDKs and APIs.

## Verification

- `python3 -m json.tool docs.json`
- `bunx --bun mint broken-links`
- verified `https://registry.terraform.io/providers/kernel/kernel/latest` returns HTTP 200
- reviewed the rendered MDX structure and navigation entry locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no application or infrastructure code changes.
> 
> **Overview**
> Adds a **Terraform** integration guide so customers can find the official `kernel/kernel` provider from Kernel docs after **v0.1** went public.
> 
> The new page covers minimal `required_providers` / `provider` setup, **`KERNEL_API_KEY`** and optional **`KERNEL_PROJECT_ID`**, and clarifies that Terraform is for durable config (projects, browser pools, imports) while runtime browser work stays on SDKs/API. It links out to the **Terraform Registry** and **GitHub** for full reference instead of duplicating provider docs.
> 
> Navigation is wired via **`docs.json`** (Integrations sidebar) and a bullet on **`integrations/overview.mdx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aedc9dc95363457a8c2f024f9fc75e5022036ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->