### PR TITLE
Add audit logs to managed infrastructure pricing

### DIFF
--- a/info/audit-logs.mdx
+++ b/info/audit-logs.mdx
@@ -17,6 +17,10 @@ Search and download are available on **Start-Up** and **Enterprise** plans. Cont
 
 Audit logs are also available from the [CLI](/reference/cli/audit-logs).
 
+<Note>
+  Kernel retains audit log events for 1 year. Search and download can access any event within this window.
+</Note>
+
 ## Filter audit logs
 
 The API and SDKs use the same filters for search and downloads:

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -40,14 +40,14 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 | Browser pools | ❌ | ❌ | ✅ | ✅ |
 | Support | Discord | Discord | Email | Shared Slack |
 | SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
-| Audit log search & export | ✅ | ✅ | ✅ | ✅ |
+| Audit log search & export | ❌ | ❌ | ✅ | ✅ |
 | Continuous audit log export to S3 | ❌ | ❌ | ❌ | ✅ |
 | GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | HIPAA compliance (BAA) | ❌ | ❌ | ❌ | ✅ |
 
 > Note: Included monthly credits apply to usage costs only.
 
-> Note: [Audit logs](/info/audit-logs) are retained for 1 year on all plans. Search and export are available on every plan. Continuous export delivers audit events to your own S3 bucket as gzipped JSON Lines (`.jsonl.gz`), with managed IAM/KMS setup, reliable delivery, and monitoring.
+> Note: [Audit logs](/info/audit-logs) are available on Start-Up and Enterprise plans, with 1-year retention. Continuous export delivers audit events to your own S3 bucket as gzipped JSON Lines (`.jsonl.gz`), with managed IAM/KMS setup, reliable delivery, and monitoring.
 
 ## Browser pools
 

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -38,12 +38,12 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 | Custom browser extensions | 1 | 1 | unlimited | unlimited |
 | Configurable & BYO proxies | ❌ | ❌ | ✅ | ✅ |
 | Browser pools | ✅ | ✅ | ✅ | ✅ |
+| GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | Projects | 1 | 1 | unlimited | unlimited |
 | Support | Discord | Discord | Email | Shared Slack |
 | SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
 | Audit log search & export | ❌ | ❌ | ✅ | ✅ |
 | Continuous audit log export to S3 | ❌ | ❌ | ❌ | ✅ |
-| GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | HIPAA compliance (BAA) | ❌ | ❌ | ❌ | ✅ |
 
 > Note: Included monthly credits apply to usage costs only.

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -40,10 +40,14 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 | Browser pools | ❌ | ❌ | ✅ | ✅ |
 | Support | Discord | Discord | Email | Shared Slack |
 | SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
+| Audit log search & export | ✅ | ✅ | ✅ | ✅ |
+| Continuous audit log export to S3 | ❌ | ❌ | ❌ | ✅ |
 | GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | HIPAA compliance (BAA) | ❌ | ❌ | ❌ | ✅ |
 
 > Note: Included monthly credits apply to usage costs only.
+
+> Note: [Audit logs](/info/audit-logs) are retained for 1 year on all plans. Search and export are available on every plan. Continuous export delivers audit events to your own S3 bucket as gzipped JSON Lines (`.jsonl.gz`), with managed IAM/KMS setup, reliable delivery, and monitoring.
 
 ## Browser pools
 

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -47,7 +47,7 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 
 > Note: Included monthly credits apply to usage costs only.
 
-> Note: [Audit logs](/info/audit-logs) are available on Start-Up and Enterprise plans, with 1-year retention. Continuous export delivers audit events to your own S3 bucket as gzipped JSON Lines (`.jsonl.gz`), with managed IAM/KMS setup, reliable delivery, and monitoring.
+> Note: [Audit logs](/info/audit-logs) are retained for 1 year. See the audit logs page for search, download, and continuous S3 export details.
 
 ## Browser pools
 


### PR DESCRIPTION
## Summary

Documents audit logs across the pricing and audit logs pages.

**`info/pricing.mdx`** — adds two rows to the **Managed infrastructure** table:

- **Audit log search & export** — Start-Up and Enterprise
- **Continuous audit log export to S3** — Enterprise only

Plus a short note pointing to the [Audit Logs](/info/audit-logs) page and stating the 1-year retention window.

**`info/audit-logs.mdx`** — adds a note in the intro documenting the 1-year retention window, which the pricing page references but wasn't stated on the canonical page.

## Testing

Docs-only change (Mintlify, no build step). Verified the table column count, that the `/info/audit-logs` link matches the navigation entry in `docs.json`, and that the retention note uses the same `<Note>` component convention as the rest of the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Documents **audit log** availability on the **Pricing & Limits** managed infrastructure table and states **1-year retention** on the canonical audit logs page.
> 
> **`info/pricing.mdx`** adds two rows: **Audit log search & export** (Start-Up and Enterprise) and **Continuous audit log export to S3** (Enterprise only), aligned with the plan callouts already on the audit logs intro.
> 
> **`info/audit-logs.mdx`** adds a `<Note>` that Kernel retains events for one year and that search/download cover that window, so retention is explicit where pricing may reference it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337c97adf3e95b55e5fa0c89f38e2713e2280cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->