### PR TITLE
Disable Vercel git deployments for Mintlify docs repo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
This repo is deployed by Mintlify, not Vercel. The connected Vercel project is misconfigured as a Next.js app and this repo has no package.json, so every deployment fails with "No Next.js version detected" — on main and on every PR.

Adding `vercel.json` with `deploymentEnabled: false` stops Vercel from attempting deployments at the repo level. Docs continue to deploy through Mintlify as before.

Same fix as the earlier PR #475.