### PR TITLE
Add kiosk mode as first viewport recommendation

### DIFF
--- a/browsers/viewport.mdx
+++ b/browsers/viewport.mdx
@@ -141,6 +141,26 @@ The `viewport` parameter sets the dimensions of the browser **window**, not the 
 
 If your automation expects an exact page viewport, either:
 
+- **Use kiosk mode** to remove the browser UI, so the window dimensions match the page viewport exactly. Pass `--kiosk` in `launch_args`:
+
+<CodeGroup>
+
+```typescript Typescript/Javascript
+const kernelBrowser = await kernel.browsers.create({
+  launch_args: ["--kiosk"],
+  viewport: { width: 1920, height: 1080 }
+});
+```
+
+```python Python
+kernel_browser = kernel.browsers.create(
+    launch_args=["--kiosk"],
+    viewport={"width": 1920, "height": 1080}
+)
+```
+
+</CodeGroup>
+
 - **Set the page viewport through your automation framework**, which controls the rendered page size directly regardless of the window dimensions:
 
 <CodeGroup>

--- a/browsers/viewport.mdx
+++ b/browsers/viewport.mdx
@@ -141,7 +141,7 @@ The `viewport` parameter sets the dimensions of the browser **window**, not the 
 
 If your automation expects an exact page viewport, either:
 
-- **Use kiosk mode** to remove the browser UI, so the window dimensions match the page viewport exactly. Set `kiosk_mode` to `true`:
+- **Use kiosk mode** to remove the browser UI, so the window dimensions match the page viewport exactly:
 
 <CodeGroup>
 

--- a/browsers/viewport.mdx
+++ b/browsers/viewport.mdx
@@ -161,7 +161,7 @@ kernel_browser = kernel.browsers.create(
 
 </CodeGroup>
 
-- **Set the page viewport through your automation framework**, which controls the rendered page size directly regardless of the window dimensions:
+- **Set the page viewport through your automation framework.** This will update the rendered page size, but will not be reflected in the live view or computer controls:
 
 <CodeGroup>
 

--- a/browsers/viewport.mdx
+++ b/browsers/viewport.mdx
@@ -141,20 +141,20 @@ The `viewport` parameter sets the dimensions of the browser **window**, not the 
 
 If your automation expects an exact page viewport, either:
 
-- **Use kiosk mode** to remove the browser UI, so the window dimensions match the page viewport exactly. Pass `--kiosk` in `launch_args`:
+- **Use kiosk mode** to remove the browser UI, so the window dimensions match the page viewport exactly. Set `kiosk_mode` to `true`:
 
 <CodeGroup>
 
 ```typescript Typescript/Javascript
 const kernelBrowser = await kernel.browsers.create({
-  launch_args: ["--kiosk"],
+  kiosk_mode: true,
   viewport: { width: 1920, height: 1080 }
 });
 ```
 
 ```python Python
 kernel_browser = kernel.browsers.create(
-    launch_args=["--kiosk"],
+    kiosk_mode=True,
     viewport={"width": 1920, "height": 1080}
 )
 ```


### PR DESCRIPTION
Adds kiosk mode (`--kiosk` flag) as the first recommendation in the "Window size vs. page viewport" section. Kiosk mode removes Chromium's browser UI so the window dimensions match the page viewport exactly, which is the simplest way to solve the mismatch problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to viewport guidance; no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates **`browsers/viewport.mdx`** so **kiosk mode** is the **first** fix when window size and page viewport must match on headful browsers.
> 
> The new bullet explains that **`kiosk_mode: true`** hides Chromium UI so configured **`viewport`** dimensions align with the rendered page, with **TypeScript** and **Python** `browsers.create` examples combining `kiosk_mode` and `viewport`.
> 
> The automation-framework option is reworded to call out that **`setViewportSize` / `set_viewport_size`** change the rendered page but **do not** update **live view** or **computer controls**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b27c2f7b052630e2414658066253c0f3be3ccca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->