### PR TITLE
docs: use official Claude directory connector

### DIFF
--- a/integrations/claude/claude-code-and-desktop.mdx
+++ b/integrations/claude/claude-code-and-desktop.mdx
@@ -3,12 +3,18 @@ title: "Claude Code and Desktop"
 description: "Give Claude Code and Claude Desktop a Kernel cloud browser"
 ---
 
-Connect the Claude apps you already use to Kernel. There are two ways to bring Kernel into [Claude Code](https://www.claude.com/product/claude-code):
+Connect the Claude apps you already use to Kernel.
+
+## Claude Desktop
+
+Claude Desktop reaches Kernel through Kernel's [official connector](https://claude.ai/directory/kernel), added as a custom connector under **Settings → Connectors**. The [Claude client guide](/reference/mcp-server/clients/claude) has the steps, and covers Claude.ai as well.
+
+## Marketplace plugin (Claude Code)
+
+There are two ways to bring Kernel into [Claude Code](https://www.claude.com/product/claude-code):
 
 - **Marketplace plugin** — load Kernel's skills directly into Claude Code so it knows how to manage cloud browsers and write automations.
 - **Remote MCP server** — connect Claude Code to Kernel's [MCP server](/reference/mcp-server) to create and manage cloud browsers from chat.
-
-## Marketplace plugin (Claude Code)
 
 Kernel publishes an [official skills marketplace](https://github.com/kernel/skills) for Claude Code. Installing a plugin from it loads Kernel's best-practice skills into your coding agent.
 
@@ -46,7 +52,3 @@ claude mcp add --transport http kernel https://mcp.onkernel.com/mcp
 # Then in the REPL run once to authenticate:
 /mcp
 ```
-
-## Claude Desktop
-
-Claude Desktop reaches Kernel through the same remote MCP server, added as a custom connector under **Settings → Connectors**. The [Claude client guide](/reference/mcp-server/clients/claude) has the steps, and covers Claude.ai as well.

--- a/integrations/claude/claude-code-and-desktop.mdx
+++ b/integrations/claude/claude-code-and-desktop.mdx
@@ -11,11 +11,6 @@ Claude Desktop reaches Kernel through Kernel's [official connector](https://clau
 
 ## Marketplace plugin (Claude Code)
 
-There are two ways to bring Kernel into [Claude Code](https://www.claude.com/product/claude-code):
-
-- **Marketplace plugin** — load Kernel's skills directly into Claude Code so it knows how to manage cloud browsers and write automations.
-- **Remote MCP server** — connect Claude Code to Kernel's [MCP server](/reference/mcp-server) to create and manage cloud browsers from chat.
-
 Kernel publishes an [official skills marketplace](https://github.com/kernel/skills) for Claude Code. Installing a plugin from it loads Kernel's best-practice skills into your coding agent.
 
 Run these in the Claude Code REPL, one line at a time:
@@ -35,7 +30,7 @@ See the [skills repo](https://github.com/kernel/skills#available-skills) for the
 
 ## Remote MCP server (Claude Code)
 
-Add Kernel's remote MCP server to manage cloud browsers from Claude Code.
+Add Kernel's [remote MCP server](/reference/mcp-server) to manage cloud browsers from Claude Code.
 
 **Using the Kernel CLI (recommended):**
 

--- a/integrations/claude/overview.mdx
+++ b/integrations/claude/overview.mdx
@@ -9,7 +9,7 @@ Kernel gives Claude a real, cloud-hosted browser to work in, so your agents can 
 
 ### Claude Code and Claude Desktop
 
-Connect the Claude apps you already use to Kernel. Add Kernel's [remote MCP server](/reference/mcp-server) to manage cloud browsers from Claude Code or Claude Desktop, or install the [marketplace plugin](https://github.com/kernel/skills#claude-code) to load Kernel's CLI and SDK skills into Claude Code.
+Connect the Claude apps you already use to Kernel. Add Kernel's [official connector](https://claude.ai/directory/kernel) to manage cloud browsers from Claude Desktop and Claude.ai, or install the [marketplace plugin](https://github.com/kernel/skills#claude-code) to load Kernel's CLI and SDK skills into Claude Code.
 
 [Set up Claude Code and Desktop →](/integrations/claude/claude-code-and-desktop)
 

--- a/reference/mcp-server/clients/claude.mdx
+++ b/reference/mcp-server/clients/claude.mdx
@@ -7,10 +7,11 @@ description: "Connect Claude.ai, Claude Desktop, and Claude Code to the Kernel M
 
 ## Pro, Max, Team & Enterprise (Claude.ai and Claude Desktop)
 
-1. Go to **Settings → Connectors → Add custom connector**.
-2. Enter: **Integration name:** `Kernel`, **Integration URL:** `https://mcp.onkernel.com/mcp`, then click **Add**.
-3. In **Settings → Connectors**, click **Connect** next to `Kernel` to launch OAuth and approve.
-4. In chat, click **Search and tools** and enable the Kernel tools if needed.
+Kernel is available as an [official connector](https://claude.ai/directory/kernel) in the Claude directory.
+
+1. Open Kernel's [official connector](https://claude.ai/directory/kernel) and click **Connect** (or find `Kernel` under **Settings → Connectors**).
+2. Launch OAuth and approve.
+3. In chat, click **Search and tools** and enable the Kernel tools if needed.
 
 <Info>On Claude for Work (Team/Enterprise), only Primary Owners or Owners can enable custom connectors for the org. After it's configured, each user still needs to go to **Settings → Connectors** and click **Connect** to authorize it for their account.</Info>
 


### PR DESCRIPTION
## Summary

Updates the Claude docs to point at Kernel's newly published [official connector](https://claude.ai/directory/kernel) in the Claude directory.

- **MCP client page** (`reference/mcp-server/clients/claude.mdx`) — the Pro/Max/Team/Enterprise "connect your client" section now links users to the official connector in the Claude directory instead of walking through manual custom-connector setup (entering the integration URL by hand).
- **Claude guide** (`integrations/claude/claude-code-and-desktop.mdx`) — the Claude Desktop section now links out to the official connector, and has been moved to the first section on the page.

## Testing

Docs-only change (Mintlify MDX). Section headings are unchanged where anchors matter, so existing `#claude-desktop` links still resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mintlify MDX-only edits with no runtime, auth, or API changes.
> 
> **Overview**
> Documentation now steers **Claude Desktop and Claude.ai** users to Kernel’s **[official connector](https://claude.ai/directory/kernel)** instead of manual “custom connector” setup with the MCP URL.
> 
> On **`reference/mcp-server/clients/claude.mdx`**, the Pro/Max/Team/Enterprise flow is shortened to open the directory entry, OAuth, and enable tools in chat. **`integrations/claude/overview.mdx`** matches that split: official connector for Desktop/Claude.ai, marketplace plugin for Claude Code.
> 
> **`integrations/claude/claude-code-and-desktop.mdx`** puts **Claude Desktop** first, links the official connector, and leaves Claude Code on marketplace plugin + remote MCP (with an explicit link to the MCP reference). No product or API behavior changes—docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a22696972be6d85423419ddd92ccb47df5d357a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->