### PR TITLE
Document reading ISP proxy static IP via ip_address

### DIFF
--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -147,3 +147,39 @@ func main() {
 </CodeGroup>
 
 See the [overview](/proxies/overview#bypass-hosts) for full bypass host rules and examples.
+
+## Getting the static IP address
+
+Because an ISP proxy has a static exit IP, you can read that IP once and reuse it — for example, to add it to an IP allowlist. The IP is returned as `ip_address` in the response when you [create a proxy](/api-reference/proxies/create-a-proxy) and when you [get a proxy by ID](/api-reference/proxies/get-proxy-by-id).
+
+<CodeGroup>
+```typescript Typescript/Javascript
+const proxy = await kernel.proxies.create({
+  type: 'isp',
+  name: 'my-isp-proxy',
+});
+
+console.log(proxy.ip_address);
+```
+
+```python Python
+proxy = kernel.proxies.create(
+    type="isp",
+    name="my-isp-proxy",
+)
+
+print(proxy.ip_address)
+```
+
+```go Go
+proxy, err := client.Proxies.New(ctx, kernel.ProxyNewParams{
+	Type: kernel.ProxyNewParamsTypeIsp,
+	Name: kernel.String("my-isp-proxy"),
+})
+if err != nil {
+	panic(err)
+}
+
+fmt.Println(proxy.IPAddress)
+```
+</CodeGroup>

--- a/proxies/isp.mdx
+++ b/proxies/isp.mdx
@@ -150,7 +150,7 @@ See the [overview](/proxies/overview#bypass-hosts) for full bypass host rules an
 
 ## Getting the static IP address
 
-Because an ISP proxy has a static exit IP, you can read that IP once and reuse it — for example, to add it to an IP allowlist. The IP is returned as `ip_address` in the response when you [create a proxy](/api-reference/proxies/create-a-proxy) and when you [get a proxy by ID](/api-reference/proxies/get-proxy-by-id).
+Because an ISP proxy has a static exit IP, you can read that IP once and reuse it — for example, to add it to an IP allowlist. The IP is returned as `ip_address` in the response when you [create a proxy](https://kernel.sh/docs/api-reference/proxies/create-a-proxy) and when you [get a proxy by ID](https://kernel.sh/docs/api-reference/proxies/get-proxy-by-id).
 
 <CodeGroup>
 ```typescript Typescript/Javascript


### PR DESCRIPTION
## Summary

Adds a "Getting the static IP address" section at the bottom of the ISP proxies guide explaining how to read the static exit IP from the proxy API.

- The IP is returned as `ip_address` in the response to creating a proxy and getting a proxy by ID.
- Links out to the respective API reference pages ([create a proxy](/api-reference/proxies/create-a-proxy), [get proxy by ID](/api-reference/proxies/get-proxy-by-id)).
- Includes TypeScript, Python, and Go examples reading the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `proxies/isp.mdx` with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Getting the static IP address** section to the ISP proxies guide, placed after the bypass-hosts content.
> 
> It explains that ISP proxies expose a stable exit IP via the **`ip_address`** field on create-proxy and get-proxy-by-id responses, with links to those API reference pages and a short allowlist use case. **TypeScript**, **Python**, and **Go** snippets show how to read that field after creating a proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a9502ae666a63b2377b73a1f44d4fd6db47573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->