### PR TITLE
Add August 13 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,29 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="August 13" tags={["Product", "Docs"]}>
+## Product updates
+
+- Expanded the [MCP server](/reference/mcp-server) with a branded OAuth consent flow, project-scoped access tokens, and required PKCE for new clients. Tools now accept a project name or ID, and org-wide connections can pick a project at connect time.
+- Improved the [MCP server](/reference/mcp-server): app invocations return an invocation ID immediately instead of blocking, with a new `list_invocation_browsers` action for the live views they create. Long-running browser operations no longer retry on transient errors, and `manage_browsers get_telemetry` supports bounded raw page reads.
+- Kernel is now a connector in the [Vercel Connect](https://vercel.com/connect) registry: `vercel connect create kernel --connection-method mcp` pre-fills the MCP URL, auth type, and branding, and brokers per-user OAuth so no Kernel API key touches your app.
+- Added a nested `proxy` object to the browser API, taking exactly one of `mode`, `id`, or `name`. Egress and stealth are now independent: an explicit [proxy](/proxies/overview) changes only where traffic exits and never toggles stealth or the CAPTCHA solver. `proxy_id` and `disable_default_proxy` are deprecated.
+- Added [private browser networking](/browsers/private-networking): `network.private_hosts` names the hosts and CIDRs a browser or browser pool should reach directly through the session's own network — for a VPN or tunnel inside the VM — while everything else keeps using Kernel-managed egress.
+- Expanded [managed auth](/auth/overview) with a nested `browser` configuration on connections covering `stealth`, `proxy`, and `telemetry`, applied as the default for every browser a connection launches. Set `browser.stealth` to `false` to skip stealth mode and the CAPTCHA solver. The older `proxy`, `proxy_id`, and `browser_telemetry` fields are deprecated.
+- Improved fingerprint coherence in [stealth-mode browsers](/browsers/bot-detection/stealth): the WebGL renderer persona now applies on GPU hosts as well as software-rendered ones, and storage quota, network information, and speech voices report plausible per-host values.
+- Browser responses now include `profile_save_changes`, so you can tell which sessions loaded a [profile](/auth/profiles) read-write and coordinate a single writer.
+- Fixed egress reliability issues: large downloads no longer truncate mid-body under backpressure, WebSocket and TURN traffic pass through unchanged, and origins that omit their intermediate certificate now verify the way Chrome does.
+- Extended the [CLI](https://github.com/kernel/cli) (v0.27.0–v0.29.0) with `--private-host` network flags, extension checksums in output, explicit clear controls for browser-pool settings, and persistent OAuth project scope.
+
+## Documentation updates
+
+- Documented [private browser networking](/browsers/private-networking), including `private_hosts` semantics for browsers and browser pools.
+- Added [safe profile writes](/auth/profiles) and clarified the `save_changes` requirement for [per-user pool profiles](/browsers/pools).
+- Added a guide for [reading the static IP of an ISP proxy](/proxies/isp) via `ip_address`.
+- Switched managed auth examples to SSE, updated the [Eve extension guide](/integrations/vercel/eve-extension) to use the Kernel connector registry entry, and swapped the Claude Code integration to the official [Claude directory connector](/integrations/claude/claude-code-and-desktop).
+- Added kiosk mode as the first [viewport](/browsers/viewport) recommendation and clarified that viewport sets window size, not page viewport.
+</Update>
+
 <Update label="August 7" tags={["Product", "Docs"]}>
 ## Product updates
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,7 +9,7 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
-<Update label="August 13" tags={["Product", "Docs"]}>
+<Update label="August 14" tags={["Product", "Docs"]}>
 ## Product updates
 
 - Expanded the [MCP server](/reference/mcp-server) with a branded OAuth consent flow, project-scoped access tokens, and required PKCE for new clients. Tools now accept a project name or ID, and org-wide connections can pick a project at connect time.


### PR DESCRIPTION
## Summary

Adds the August 13 changelog entry: 10 product bullets and 5 documentation bullets. Changelog only — no other files touched.

Every bullet was checked against a merged PR **and** its production deploy before being included:

- `kernel/kernel` API (ECS) and dashboard are live on the newest `main` commit.
- egress-proxy is live on the same commit; metro-api is live on a build that contains both egress fixes claimed here.
- `kernel-mcp-server` production is live on its `main` HEAD, so every MCP change listed is deployed.
- CLI claims are pinned to released tags (v0.27.0, v0.27.1, v0.28.0, v0.29.0).
- The stealth fingerprint change was verified against a live production browser session rather than from the patch alone.

## Deliberately excluded

Not shipped or not ready to announce:

- **Hypeman** (`pushes` API, QEMU microvm backend, ingress header auth) — merged to `main` but not in a release. The latest tag is v0.3.0, and `docs.hypeman.sh` pins a spec commit that predates the `pushes` endpoints, so a user on the released server cannot use any of it yet.
- **Audit log continuous S3 export** — shipped, released in the CLI, and documented, but the plan changes that shipped alongside it need a separate decision first.
- **Region selection** — plan-gated and behind an org allow-list, and the CLI flag is unreleased.
- **Configurable browser memory** — mid-rollout, later PRs in the stack are still pending.
- **Project spending caps** — no public API surface yet.

Shipped, but cut to keep the entry short:

- Free and Hobbyist plan changes, `GET /org/limits` plan-limit fields, and the Start-Up concurrent invocation limit increase.
- Dashboard improvements (live view controls, idle-session banner, faster session lists).
- Branded proxy error pages.
- Pricing page refresh, API reference now building from the deployed spec, and the MCP resource-lifecycle reference docs.

## Verification

- All 11 unique internal links resolve to real pages present in `docs.json` navigation. Three broken links in the original draft (`/browsers/profiles`, `/browsers/sessions`, `/integrations/vercel/connect`) are corrected to `/auth/profiles` and `/integrations/vercel/eve-extension`.
- Both external links checked live.
- Every API-shape claim (field names, deprecations, which schemas carry which field) validated by parsing the deployed OpenAPI spec. This caught one error during review: the nested `proxy` object exists on the browser API only, not on browser pools, and the bullet was corrected.
- `<Update>` tags balanced, no raw JSX characters in body text, no trailing whitespace.

No docs build step in this repo, so rendering should be confirmed on the Mintlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog addition with no runtime or API code changes.
> 
> **Overview**
> Adds a new **August 14** `<Update>` block at the top of `changelog.mdx`, ahead of the August 7 entry.
> 
> **Product updates** (10 bullets) announce shipped MCP OAuth/PKCE and invocation behavior, Vercel Connect as an MCP connector, browser API `proxy` nesting with deprecated `proxy_id` / `disable_default_proxy`, `network.private_hosts` private browser networking, managed-auth `browser` defaults, stealth fingerprint improvements, `profile_save_changes` on browser responses, egress reliability fixes, and CLI v0.27.0–v0.29.0 changes.
> 
> **Documentation updates** (5 bullets) call out new or revised guides for private networking, profile writes and pool `save_changes`, ISP proxy static IP, integration doc refreshes (SSE managed auth, Eve extension, Claude directory connector), and viewport/kiosk guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb9924a4b7abe5096a3d13c1eb7489466121efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->