### PR TITLE
Document automatic proxy cleanup

### DIFF
--- a/proxies/overview.mdx
+++ b/proxies/overview.mdx
@@ -28,6 +28,10 @@ Residential and mobile proxies use **rotating exit IPs** that may change per con
 
 Create a proxy configuration from the types above that can be reused across browser sessions:
 
+<Info>
+KERNEL automatically deletes proxy configurations that haven't been used for 14 days when your organization has more than 100 active configurations. Configurations attached to sessions, pools, instances, or managed auth connections are retained.
+</Info>
+
 <CodeGroup>
 ```typescript Typescript/Javascript
 import Kernel from '@onkernel/sdk';


### PR DESCRIPTION
## summary

- document automatic cleanup of proxy configurations unused for 14 days
- clarify that cleanup applies to organizations with more than 100 active configurations
- note which active references retain a configuration

## validation

- `git diff --check`
- Mintlify preview and broken-link checks run in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to proxies/overview.mdx with no runtime or API behavior changes.
> 
> **Overview**
> Adds an **Info** callout under **Create a proxy** on the proxies overview describing KERNEL’s automatic cleanup of proxy configurations.
> 
> The new text states that unused configs are deleted after **14 days** when the org has **more than 100** active configurations, and that configs still referenced by **sessions, pools, instances, or managed auth connections** are kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d1d7209b0996c94b03d24ccd95a0ea8105c778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->