### PR TITLE
Add print-to-PDF example to Chrome policies doc

### DIFF
--- a/browsers/chrome-policies.mdx
+++ b/browsers/chrome-policies.mdx
@@ -306,7 +306,12 @@ const browser = await kernel.browsers.create({
 
 ### Print to PDF
 
-`PrintingEnabled` must stay `true` (the default) for the browser's print-to-PDF path — including CDP's `Page.printToPDF` and Playwright's `page.pdf()` — to work. Add `PrintPdfAsImageDefault: true` to render each page as an image before conversion, which produces more consistent output on pages with complex CSS or canvas content.
+`PrintingEnabled` must stay `true` (the default) for the browser's print-to-PDF path — including CDP's `Page.printToPDF` and Playwright's `page.pdf()` — to work.
+
+`PrintPdfAsImageDefault` controls whether each page is rasterized to an image before being placed in the PDF, rather than kept as native vector text and graphics:
+
+- `false` (shown explicitly below, and Chrome's default) — keeps text selectable and extractable in the output PDF. Use this if automation will read the PDF's contents afterward (text extraction, parsing, LLM ingestion) — image-based PDFs need OCR to get text back out.
+- `true` — rasterizes every page, which can look more consistent on pages with complex CSS or canvas content, at the cost of searchable text and a larger file.
 
 <CodeGroup>
 ```python Python
@@ -317,7 +322,7 @@ kernel = Kernel()
 browser = kernel.browsers.create(
     chrome_policy={
         "PrintingEnabled": True,
-        "PrintPdfAsImageDefault": True,
+        "PrintPdfAsImageDefault": False,
     }
 )
 ```
@@ -330,7 +335,7 @@ const kernel = new Kernel();
 const browser = await kernel.browsers.create({
   chrome_policy: {
     PrintingEnabled: true,
-    PrintPdfAsImageDefault: true,
+    PrintPdfAsImageDefault: false,
   },
 });
 ```

--- a/browsers/chrome-policies.mdx
+++ b/browsers/chrome-policies.mdx
@@ -304,6 +304,38 @@ const browser = await kernel.browsers.create({
 ```
 </CodeGroup>
 
+### Print to PDF
+
+`PrintingEnabled` must stay `true` (the default) for the browser's print-to-PDF path — including CDP's `Page.printToPDF` and Playwright's `page.pdf()` — to work. Add `PrintPdfAsImageDefault: true` to render each page as an image before conversion, which produces more consistent output on pages with complex CSS or canvas content.
+
+<CodeGroup>
+```python Python
+from kernel import Kernel
+
+kernel = Kernel()
+
+browser = kernel.browsers.create(
+    chrome_policy={
+        "PrintingEnabled": True,
+        "PrintPdfAsImageDefault": True,
+    }
+)
+```
+
+```typescript Typescript/Javascript
+import Kernel from '@onkernel/sdk';
+
+const kernel = new Kernel();
+
+const browser = await kernel.browsers.create({
+  chrome_policy: {
+    PrintingEnabled: true,
+    PrintPdfAsImageDefault: true,
+  },
+});
+```
+</CodeGroup>
+
 ## Available policies
 
 Any policy listed in the [Chrome Enterprise policy documentation](https://chromeenterprise.google/policies/) can be used in the `chrome_policy` object. Refer to the official docs for the full list of supported policy names, types, and values.


### PR DESCRIPTION
## Summary
- Adds a "Print to PDF" example under Common use cases in `browsers/chrome-policies.mdx`, showing `PrintingEnabled` + `PrintPdfAsImageDefault`.

## Verification
Live-tested against a real Kernel browser session:
- Created a browser with `chrome_policy: {"PrintingEnabled": true, "PrintPdfAsImageDefault": true}`.
- Confirmed both policies show as applied on `chrome://policy` (source: Platform, scope: Machine, level: Mandatory, no errors).
- Called `page.pdf()` against `https://example.com` and confirmed a valid PDF was produced (`%PDF-1.4` header, 14,838 bytes).

## Test plan
- [ ] Docs preview renders the new section correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Print to PDF** subsection under **Common use cases** in `browsers/chrome-policies.mdx`.
> 
> It documents that **`PrintingEnabled`** must remain enabled for CDP `Page.printToPDF` and Playwright `page.pdf()`, and explains **`PrintPdfAsImageDefault`** (`false` for selectable text vs `true` for rasterized pages). Includes matching Python and TypeScript `chrome_policy` examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5922bf31a86c421b14435b7de25e0f6617f3e726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->