### PR TITLE
Drop --url param from web-bot-auth extension examples

### DIFF
--- a/browsers/bot-detection/web-bot-auth.mdx
+++ b/browsers/bot-detection/web-bot-auth.mdx
@@ -145,7 +145,6 @@ The directory should contain your public keys in JWKS format:
 kernel extensions build-web-bot-auth \
   --to ./web-bot-auth-ext \
   --key ./my-key.jwk \
-  --url https://yourdomain.com \
   --signature-agent https://yourdomain.com \
   --upload my-web-bot-auth
 ```
@@ -167,7 +166,6 @@ private key (JWK) and upload it under a distinct extension name:
 kernel extensions build-web-bot-auth \
   --to ./web-bot-auth-search-ext \
   --key ./kernel-search.jwk \
-  --url https://www.kernel.sh \
   --signature-agent https://search.bot.kernel.sh \
   --upload web-bot-auth-search
 ```

--- a/browsers/bot-detection/web-bot-auth.mdx
+++ b/browsers/bot-detection/web-bot-auth.mdx
@@ -154,7 +154,7 @@ kernel extensions build-web-bot-auth \
 Kernel's own Web Bot Auth identities are already approved by Cloudflare, Vercel,
 Akamai, and other bot-verification providers. If you want to sign requests with
 one of Kernel's identities rather than your own, [contact Kernel support](https://www.kernel.sh/docs/info/support).
-See [Bots and agents](/docs/bots) for the list of identities and their key
+See [Bots and agents](/bots) for the list of identities and their key
 directories.
 
 ### 5. Register with Vercel and other Web Bot Auth-aware directories (optional)

--- a/browsers/bot-detection/web-bot-auth.mdx
+++ b/browsers/bot-detection/web-bot-auth.mdx
@@ -149,38 +149,13 @@ kernel extensions build-web-bot-auth \
   --upload my-web-bot-auth
 ```
 
-### 4. Kernel Search configuration
+### 4. Using Kernel's bot identities
 
-Kernel Search uses a distinct Web Bot Auth identity from Kernel's user-driven
-agent traffic:
-
-- User-Agent: `KernelSearchBot`
-- Signature-Agent: `https://search.bot.kernel.sh`
-- Key directory:
-  `https://search.bot.kernel.sh/.well-known/http-message-signatures-directory`
-
-To build a browser extension for Kernel Search, use the Kernel Search Ed25519
-private key (JWK) and upload it under a distinct extension name:
-
-```bash
-kernel extensions build-web-bot-auth \
-  --to ./web-bot-auth-search-ext \
-  --key ./kernel-search.jwk \
-  --signature-agent https://search.bot.kernel.sh \
-  --upload web-bot-auth-search
-```
-
-For host-proxy based signing, configure the Search crawler's host-proxy
-environment with:
-
-```bash
-HOST_PROXY_WEB_BOT_AUTH_ENABLED=true
-HOST_PROXY_WEB_BOT_AUTH_KEY_PATH=/path/to/kernel-search-private-key.pem
-HOST_PROXY_WEB_BOT_AUTH_DIRECTORY_URL=https://search.bot.kernel.sh
-```
-
-The signing key must correspond to the public key hosted by
-`search.bot.kernel.sh`.
+Kernel's own Web Bot Auth identities are already approved by Cloudflare, Vercel,
+Akamai, and other bot-verification providers. If you want to sign requests with
+one of Kernel's identities rather than your own, [contact Kernel support](https://www.kernel.sh/docs/info/support).
+See [Bots and agents](/docs/bots) for the list of identities and their key
+directories.
 
 ### 5. Register with Vercel and other Web Bot Auth-aware directories (optional)
 


### PR DESCRIPTION
## Summary

Two cleanups to `browsers/bot-detection/web-bot-auth.mdx`:

1. **Drop `--url` from both `build-web-bot-auth` examples** (section 3 and the old section 4). `--url` sets the base URL for `update.xml`/policy templates and defaults to `127.0.0.1`; pointing it at the customer's domain caused the extension to silently fail to load in browser sessions. The intended domain is already covered by `--signature-agent`.

2. **Replace the "Kernel Search configuration" section** with a short pointer to [`/docs/bots`](https://www.kernel.sh/docs/bots). Kernel's own Web Bot Auth identities (Kernel Agent, Kernel Search) are already approved by Cloudflare, Vercel, Akamai, and other bot-verification providers, so the build/`HOST_PROXY` steps shouldn't be exposed here. The new section tells readers to contact support if they want to sign with Kernel's identities and links to the bots page for the identity list.

## Why

Reported via a customer ticket where the web bot auth extension was silently failing to load — caused by the `--url` example pointing at the customer's domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example CLI flags and internal Kernel identity instructions; no runtime or security behavior changes.
> 
> **Overview**
> Fixes **Web Bot Auth** docs so `build-web-bot-auth` examples no longer include **`--url https://yourdomain.com`**. That flag targets `update.xml`/policy templates (defaults to `127.0.0.1`); using the customer domain could make the extension fail to load in sessions, while identity is already set via **`--signature-agent`**.
> 
> Replaces the long **Kernel Search** build and `HOST_PROXY` walkthrough with **Using Kernel's bot identities**: Kernel-managed identities are already on major bot directories, readers should contact support to sign with them, and identity/key-directory details live on **`/bots`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5fb28386ab8d733d9875f2671be00319351135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->