### PR TITLE
Document organization entitlements command

### DIFF
--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -61,8 +61,8 @@ kernel --version
   <Card icon="key" title="API Keys" href="/reference/cli/api-keys">
     Create, inspect, rotate, rename, and delete API keys.
   </Card>
-  <Card icon="building" title="Organization Limits" href="/reference/cli/org">
-    View and configure organization concurrency limits.
+  <Card icon="building" title="Organization" href="/reference/cli/org">
+    Inspect effective entitlements and configure concurrency limits.
   </Card>
   <Card icon="clock-rotate-left" title="Audit Logs" href="/reference/cli/audit-logs">
     Search and download organization audit logs.

--- a/reference/cli/org.mdx
+++ b/reference/cli/org.mdx
@@ -1,8 +1,27 @@
 ---
-title: "Organization Limits"
+title: "Organization"
 ---
 
-Manage organization-wide concurrency limits and the default cap applied to projects without an explicit override.
+Inspect your organization's effective entitlements and manage its configurable concurrency limits.
+
+## `kernel org entitlements`
+
+Show the effective plan, feature access, and limits for the authenticated organization. These values already account for the organization's plan, trial, billing status, and overrides, so use them instead of inferring access from the plan name.
+
+```bash
+kernel org entitlements
+
+# Return the API response for scripts and agents
+kernel org entitlements --output json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--output json`, `-o json` | Output the raw entitlement response. Nullable limits remain `null`, which means unlimited. |
+
+<Info>
+  This command is read-only. Use `kernel org limits set` to change the configurable default project concurrency cap.
+</Info>
 
 ## `kernel org limits get`
 


### PR DESCRIPTION
## What

- broaden the CLI Organization page from concurrency limits to organization controls
- document `kernel org entitlements` and its JSON output
- explain that effective values already include plan, trial, billing-status, and organization-override policy
- clarify that nullable limits remain `null` in JSON and mean unlimited
- update the CLI landing card to include entitlements

## Why

CLI PR [kernel/cli#232](https://github.com/kernel/cli/pull/232) adds the read-only entitlements command. The public CLI reference currently documents only `kernel org limits`, so users and agents would not discover the new command from the docs site.

The generated API reference already documents `GET /org/entitlements`; this PR only adds the missing CLI guidance and does not duplicate the API schema.

## How

The existing `reference/cli/org` page remains the single Organization reference. It now distinguishes the read-only effective entitlement projection from the mutable limits commands. No new navigation entry or page hierarchy is needed.

## Verification

Before:

- the Organization page and CLI landing card mentioned only concurrency limits

After:

- `npx --yes mint broken-links` passes with no broken links
- `mint dev --port 3102` starts successfully
- `/reference/cli/org` renders the entitlements command, unlimited semantics, and existing limits documentation
- `/reference/cli` renders the updated Organization card
- `jq empty docs.json` and `git diff --check` pass

## Dependency

Merge after [kernel/cli#232](https://github.com/kernel/cli/pull/232), so the public docs do not advertise an unreleased command.

KERNEL-1713

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> **Updates the public CLI reference** so the Organization docs match the new read-only `kernel org entitlements` command (CLI PR kernel/cli#232).
> 
> The **`reference/cli/org`** page is retitled from "Organization Limits" to **Organization** and now leads with **`kernel org entitlements`**, including `--output json`, guidance to use effective values (plan, trial, billing, overrides) instead of inferring from plan name, and that **`null` limits mean unlimited**. Existing **`kernel org limits`** get/set content stays, with a note that entitlements are read-only and limits remain mutable via **`kernel org limits set`**.
> 
> The **`reference/cli`** landing card is updated to point at the broader Organization page and mention entitlements plus concurrency limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66da7019a9ae6554b67b67765fbef07c74bc803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->