### PR TITLE
Show GB-hour billing model on pricing page

### DIFF
--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -6,11 +6,20 @@ With Kernel, you only pay for what you use and nothing more. You don't pay for i
 
 ## Pricing
 
-| Browser type | Price ($/sec) |
+Kernel bills browser usage by the memory a session uses and its compute type—standard or GPU-accelerated—per GB-hour. The rate is the same on the Developer, Hobbyist, and Start-Up plans.
+
+| Compute type | Price |
 | --- | --- |
-| Headless | 0.0000166667 |
-| Headful | 0.0001333336 |
-| Headful + GPU acceleration | 0.0008000016 |
+| Standard | $0.06 / GB-hour ($0.0000166667 / GB-second) |
+| GPU-accelerated | $0.48 / GB-hour ($0.0001333336 / GB-second)—8x the standard rate |
+
+Each browser type has a fixed memory allocation, so you can estimate a session's cost as memory x the rate above:
+
+| Browser type | Memory | Example cost |
+| --- | --- | --- |
+| Headless | 1 GB | ~$0.06 / hour |
+| Headful | 8 GB | ~$0.48 / hour |
+| Headful + GPU acceleration | 6 GB | ~$2.88 / hour |
 
 > Note: GPU acceleration is only available on headful, on-demand browsers. Standby mode is not supported for GPU-accelerated browsers.
 
@@ -66,7 +75,7 @@ Kernel enforces a single concurrency limit covering all browsers you run at once
 
 ## Browser pools
 
-With Browser Pools, you pay the standard usage-based price per GB-second while browsers are running. Idle browsers in a pool incur no disk charges—you only pay when a browser is actively in use.
+With Browser Pools, you pay the standard rate above ($0.06 / GB-hour) while browsers are running. Idle browsers in a pool incur no disk charges—you only pay when a browser is actively in use.
 
 GPU acceleration is not available for browser pools.
 > Note: A [browser pool](/browsers/pools) counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on Start-Up and Enterprise plans.

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -4,8 +4,9 @@ const { Card, Columns } = MintlifyComponents;
 export const PricingCalculator = () => {
     const defaults = { plan: 'free', browserType: 'headless', avgSessionLength: 30, numSessions: 100 };
     const planPrices = { free: 0, hobbyist: 30, startup: 200 };
-    const usagePrices = 0.0000166667;
-    const browserMultipliers = { headless: 1, headful: 8, gpu: 48 };
+    const standardRatePerGBSecond = 0.0000166667; // $0.06/GB-hour
+    const gpuRatePerGBSecond = standardRatePerGBSecond * 8; // $0.48/GB-hour
+    const browserMemoryGiB = { headless: 1, headful: 8, gpu: 6 };
 
     const [plan, setPlan] = useState(defaults.plan);
     const [browserType, setBrowserType] = useState(defaults.browserType);
@@ -43,8 +44,9 @@ export const PricingCalculator = () => {
     };
 
     var price = planPrices[plan];
-    var multiplier = browserMultipliers[browserType];
-    var usageCost = usagePrices * multiplier * numSessions * avgSessionLength;
+    var ratePerGBSecond = browserType === 'gpu' ? gpuRatePerGBSecond : standardRatePerGBSecond;
+    var pricePerSecond = ratePerGBSecond * browserMemoryGiB[browserType];
+    var usageCost = pricePerSecond * numSessions * avgSessionLength;
 
     var includedUsageCredits = 5;
     if (plan === 'hobbyist') {
@@ -109,7 +111,7 @@ export const PricingCalculator = () => {
                 </div>
                 <div style={rowStyle}>
                     <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
-                        ${(usagePrices * multiplier).toFixed(8)}/second
+                        {browserMemoryGiB[browserType]} GB x ${ratePerGBSecond.toFixed(8)}/GB-sec = ${pricePerSecond.toFixed(8)}/second
                         {browserType === 'gpu' && <span style={{ marginLeft: '0.5rem' }}>(Startup tier required)</span>}
                     </span>
                 </div>


### PR DESCRIPTION
## Summary
- Replace the per-browser-type $/sec table with a standard vs. GPU-accelerated $/GB-hour table. Headless/headful/GPU move to a worked-example table underneath instead of looking like separate pricing tiers.
- Point the Browser Pools section at the same $0.06/GB-hour rate instead of a separate "per GB-second" phrasing.
- Rework the pricing calculator to compute cost as memory × rate instead of a hardcoded per-browser-type multiplier (the old GPU multiplier of 48 silently encoded "6 GB × 8x the standard rate").

## Why
Kernel bills browser usage by memory used × a standard-or-GPU rate. Headless/headful aren't separate pricing tiers — they're fixed memory allocations at the same rate. Confirmed live against Metronome: the `browser session uptime (GB-second)` product prices by `gpu`/`overage` only, and Free, Hobbyist, and Start-Up contracts all resolve to the same rate card — $0.06/GB-hour standard, $0.48/GB-hour GPU (8x). Enterprise GPU pricing is a separate open question and stays out of scope here.

## Testing
No test suite for this Mintlify site. Verified the calculator's new derivation against the old hardcoded per-second constants (0.0000166667 / 0.0001333336 / 0.0008000016) — they match exactly. Reviewed the rendered Markdown/JSX by hand; did not run a live `mintlify dev` preview.

Addresses KERNEL-1959.