### PR TITLE
Add Foreman integration guide to Vercel section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -240,8 +240,8 @@
                 "pages": [
                   "integrations/vercel/overview",
                   "integrations/vercel/ai-sdk",
-                  "integrations/vercel/eve-extension",
                   "integrations/vercel/marketplace",
+                  "integrations/vercel/eve-extension",
                   "integrations/vercel/foreman"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -241,7 +241,8 @@
                   "integrations/vercel/overview",
                   "integrations/vercel/ai-sdk",
                   "integrations/vercel/eve-extension",
-                  "integrations/vercel/marketplace"
+                  "integrations/vercel/marketplace",
+                  "integrations/vercel/foreman"
                 ]
               },
               {

--- a/integrations/vercel/foreman.mdx
+++ b/integrations/vercel/foreman.mdx
@@ -11,7 +11,11 @@ Foreman is built on [Vercel Eve](https://vercel.com/eve), so it mounts extension
 
 ### Foreman + Kernel
 
-Mounting Kernel's [Eve extension](/integrations/vercel/eve-extension) gives Foreman's implementation agent a real cloud browser it can sign into, so it can reproduce bugs and verify fixes in flows that only break behind authentication — not just from reading code. Each teammate authenticates through their own Vercel Connect consent, so the browser acts as them rather than a shared credential, and Foreman parks its first browser action per session behind an approval gate for the person driving it.
+Mounting Kernel's [Eve extension](/integrations/vercel/eve-extension) gives Foreman's implementation agent a real cloud browser, so it can go beyond reading code to reproduce bugs and verify fixes in flows that only break behind authentication:
+
+- **Sign-in, not just code review** — the agent drives an authenticated browser session to reproduce the bug the way a signed-in user would hit it.
+- **Per-user identity** — each teammate authenticates through their own Vercel Connect consent, so the browser acts as them rather than a shared credential.
+- **An approval gate** — Foreman parks its first browser action per session for the person driving it, before it acts inside a logged-in session.
 
 Follow [Foreman's guide for adding the Kernel browser](https://ask-foreman.dev/recipes/add-the-kernel-browser) for the full recipe, including the shadowed connection and tool allowlist.
 
@@ -19,7 +23,7 @@ Follow [Foreman's guide for adding the Kernel browser](https://ask-foreman.dev/r
 
 import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
 
-This is the exact prompt from [Foreman's recipe](https://ask-foreman.dev/recipes/add-the-kernel-browser) above, not a paraphrase. Paste it, unedited, into whatever's driving your Foreman repo (Cursor, Claude Code, etc.) and it works through the same steps in order: register the `@onkernel/eve-extension` mount, wire it to Vercel Connect instead of an API key, shadow the browser connection so it carries an approval gate, and hold the tool allowlist to the seven it ships with.
+This is the exact prompt from [Foreman's recipe](https://ask-foreman.dev/recipes/add-the-kernel-browser) above, not a paraphrase. Paste it, unedited, into whatever coding agent is driving your Foreman repo and it works through the same steps in order: register the `@onkernel/eve-extension` mount, wire it to Vercel Connect instead of an API key, shadow the browser connection so it carries an approval gate, and hold the tool allowlist to the seven it ships with.
 
 <CopyPromptButton
   label="copy Foreman's Kernel browser prompt"

--- a/integrations/vercel/foreman.mdx
+++ b/integrations/vercel/foreman.mdx
@@ -1,0 +1,44 @@
+---
+title: "Foreman"
+description: "Give your Foreman agent a Kernel cloud browser"
+---
+
+## Overview
+
+[Foreman](https://ask-foreman.dev) is a free, open-source software factory: specialized AI agents classify, plan, implement, and review work pulled from GitHub issues, Linear, CI failures, and more, then push draft PRs for a human to approve. Nothing ships without you — Foreman stops at the draft PR.
+
+Foreman is built on [Vercel Eve](https://vercel.com/eve), so it mounts extensions the same way any Eve agent does.
+
+### Foreman + Kernel
+
+Mounting Kernel's [Eve extension](/integrations/vercel/eve-extension) gives Foreman's implementation agent a real cloud browser it can sign into, so it can reproduce bugs and verify fixes in flows that only break behind authentication — not just from reading code. Each teammate authenticates through their own Vercel Connect consent, so the browser acts as them rather than a shared credential, and Foreman parks its first browser action per session behind an approval gate for the person driving it.
+
+Follow [Foreman's guide for adding the Kernel browser](https://ask-foreman.dev/recipes/add-the-kernel-browser) for the full recipe, including the shadowed connection and tool allowlist.
+
+## Quick start
+
+import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
+
+<div className="tinker-box">
+  <h3 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600 }}>fast setup</h3>
+  <div className="tinker-box-row">
+    <div style={{ flexShrink: 0 }}>
+      <img src="/images/tinker-bot.svg" alt="" className="block dark:hidden" style={{ width: '146px', height: 'auto' }} />
+      <img src="/images/tinker-bot-dark.svg" alt="" className="hidden dark:block" style={{ width: '146px', height: 'auto' }} />
+    </div>
+    <div className="tinker-box-content">
+      <p style={{ margin: 0, fontSize: '0.9375rem', lineHeight: 1.6, opacity: 0.8 }}>
+        copy and paste this into your AI coding agent (Cursor, Claude, Windsurf, etc.). it installs the Kernel CLI and skills, authenticates you, and opens a live browser session that you or your agent can interact with.
+      </p>
+      <div>
+        <CopyPromptButton />
+      </div>
+    </div>
+  </div>
+</div>
+
+## Related
+
+- [Eve Extension](/integrations/vercel/eve-extension)
+- [Vercel Marketplace Integration](/integrations/vercel/marketplace)
+- [Managed Auth](/auth/overview)

--- a/integrations/vercel/foreman.mdx
+++ b/integrations/vercel/foreman.mdx
@@ -19,14 +19,13 @@ Mounting Kernel's [Eve extension](/integrations/vercel/eve-extension) gives Fore
 
 Follow [Foreman's guide for adding the Kernel browser](https://ask-foreman.dev/recipes/add-the-kernel-browser) for the full recipe, including the shadowed connection and tool allowlist.
 
-## Copy-paste prompt
+## Quickstart prompt
 
 import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
 
-This is the exact prompt from [Foreman's recipe](https://ask-foreman.dev/recipes/add-the-kernel-browser) above, not a paraphrase. Paste it, unedited, into whatever coding agent is driving your Foreman repo and it works through the same steps in order: register the `@onkernel/eve-extension` mount, wire it to Vercel Connect instead of an API key, shadow the browser connection so it carries an approval gate, and hold the tool allowlist to the seven it ships with.
+Paste this into your coding agent to add the Kernel browser to your Foreman repo. It registers the `@onkernel/eve-extension` mount, wires it to Vercel Connect instead of an API key, shadows the browser connection with an approval gate, and holds the tool allowlist to the seven tools it ships with.
 
 <CopyPromptButton
-  label="copy Foreman's Kernel browser prompt"
   prompt={`Help me customize the eve Software Factory template. I want to add KERNEL so the agent can drive a cloud browser, including signing in to sites through KERNEL's managed auth.
 
 Ground truth first: read AGENTS.md in the repository root, read agent/extensions/github.ts as the in-repo example of an extension mount, and read https://www.kernel.sh/docs/integrations/vercel/eve-extension plus node_modules/eve/docs/extensions.md before writing code. Do not hand-write the mount if the registry provides it.

--- a/integrations/vercel/foreman.mdx
+++ b/integrations/vercel/foreman.mdx
@@ -25,6 +25,7 @@ import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
 
 Paste this into your coding agent to add the Kernel browser to your Foreman repo. It registers the `@onkernel/eve-extension` mount, wires it to Vercel Connect instead of an API key, shadows the browser connection with an approval gate, and holds the tool allowlist to the seven tools it ships with.
 
+<div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
 <CopyPromptButton
   prompt={`Help me customize the eve Software Factory template. I want to add KERNEL so the agent can drive a cloud browser, including signing in to sites through KERNEL's managed auth.
 
@@ -46,6 +47,29 @@ Finish by running pnpm validate and confirming 0 errors and 0 warnings, then run
 
 Full recipe, with the reasoning behind each step: https://ask-foreman.dev/recipes/add-the-kernel-browser`}
 />
+<a
+  href="https://ask-foreman.dev/recipes/add-the-kernel-browser"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    height: '56px',
+    padding: '0 24px',
+    fontSize: '0.9375rem',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    color: 'inherit',
+    border: '1px solid currentColor',
+    opacity: 0.7,
+    textDecoration: 'none',
+    fontFamily: 'inherit',
+  }}
+>
+  view the recipe ↗
+</a>
+</div>
 
 ## Related
 

--- a/integrations/vercel/foreman.mdx
+++ b/integrations/vercel/foreman.mdx
@@ -15,27 +15,34 @@ Mounting Kernel's [Eve extension](/integrations/vercel/eve-extension) gives Fore
 
 Follow [Foreman's guide for adding the Kernel browser](https://ask-foreman.dev/recipes/add-the-kernel-browser) for the full recipe, including the shadowed connection and tool allowlist.
 
-## Quick start
+## Copy-paste prompt
 
 import { CopyPromptButton } from '/snippets/copy-prompt-button.jsx';
 
-<div className="tinker-box">
-  <h3 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600 }}>fast setup</h3>
-  <div className="tinker-box-row">
-    <div style={{ flexShrink: 0 }}>
-      <img src="/images/tinker-bot.svg" alt="" className="block dark:hidden" style={{ width: '146px', height: 'auto' }} />
-      <img src="/images/tinker-bot-dark.svg" alt="" className="hidden dark:block" style={{ width: '146px', height: 'auto' }} />
-    </div>
-    <div className="tinker-box-content">
-      <p style={{ margin: 0, fontSize: '0.9375rem', lineHeight: 1.6, opacity: 0.8 }}>
-        copy and paste this into your AI coding agent (Cursor, Claude, Windsurf, etc.). it installs the Kernel CLI and skills, authenticates you, and opens a live browser session that you or your agent can interact with.
-      </p>
-      <div>
-        <CopyPromptButton />
-      </div>
-    </div>
-  </div>
-</div>
+This is the exact prompt from [Foreman's recipe](https://ask-foreman.dev/recipes/add-the-kernel-browser) above, not a paraphrase. Paste it, unedited, into whatever's driving your Foreman repo (Cursor, Claude Code, etc.) and it works through the same steps in order: register the `@onkernel/eve-extension` mount, wire it to Vercel Connect instead of an API key, shadow the browser connection so it carries an approval gate, and hold the tool allowlist to the seven it ships with.
+
+<CopyPromptButton
+  label="copy Foreman's Kernel browser prompt"
+  prompt={`Help me customize the eve Software Factory template. I want to add KERNEL so the agent can drive a cloud browser, including signing in to sites through KERNEL's managed auth.
+
+Ground truth first: read AGENTS.md in the repository root, read agent/extensions/github.ts as the in-repo example of an extension mount, and read https://www.kernel.sh/docs/integrations/vercel/eve-extension plus node_modules/eve/docs/extensions.md before writing code. Do not hand-write the mount if the registry provides it.
+
+1. Run: eve add extension/kernel
+ This installs @onkernel/eve-extension and writes a mount under agent/extensions/. The extension needs eve 0.25 or later and Node 24; the template ships both, but confirm in package.json rather than assuming. Show me the generated file before changing it.
+2. Configure the mount with Vercel Connect, not an API key: kernel({ connect: "kernel/kernel-mcp" }). Leave KERNEL_API_KEY unset everywhere, and tell me if you find it already set, because the extension falls back to it. If the generated file points at the older domain-based connector (mcp.onkernel.com/eve-extension), prefer the current registry form and say so.
+3. Convert the mount into a directory so the browser connection can carry an approval gate: agent/extensions/kernel/extension.ts holds the mount, and agent/extensions/kernel/connections/browser.ts shadows the extension's built-in browser connection. Use defineMcpClientConnection from eve/connections with url https://mcp.onkernel.com/mcp, auth connect("kernel/kernel-mcp") from @vercel/connect/eve, approval once() from eve/tools/approval, and tools.allow set to exactly the seven tools the extension mounts by default: manage_browsers, execute_playwright_code, computer_action, manage_auth_connections, manage_profiles, manage_proxies, manage_replays. Use allow, not block, so tools the server adds later stay undiscovered too.
+4. Do not add browser_curl, manage_credentials, exec_command, or manage_browser_pools to the allowlist. The extension ships them off to limit an autonomous agent's blast radius, and nothing in this factory needs them.
+5. Tell me the setup commands I need to run myself, and do not run them:
+ vercel link, vercel connect create kernel --name kernel-mcp --connection-method mcp, vercel connect attach kernel/kernel-mcp.
+ Tell me the --connection-method flag needs Vercel CLI 58.8.0 or later.
+6. Important: connect("kernel/kernel-mcp") is per-user consent, so each person authorizes in their own browser before their first tool call. Unattended factory runs (the factory label and the red-CI fix loop) have nobody to complete that flow. Confirm this in the eve connections docs, then tell me plainly which of Foreman's surfaces can and cannot use the browser.
+7. Do not mount this extension under agent/subagents/. Stations run in task mode and cannot park for a consent prompt, an approval card, or a sign-in hand-off. If I ask for it later, explain the failure mode before doing it.
+8. Explain the approval choice back to me instead of copying by reflex. once() parks the first browser action of a session for the person driving it, and agent/connections/linear.ts shows the predicate alternative. Say why a connection whose tools act inside logged-in sessions warrants a gate that this repo's read-oriented connections do not carry.
+
+Finish by running pnpm validate and confirming 0 errors and 0 warnings, then run npx eve info and show me the kernel mount in the discovered surface with only the seven allowed tools. Do not deploy.
+
+Full recipe, with the reasoning behind each step: https://ask-foreman.dev/recipes/add-the-kernel-browser`}
+/>
 
 ## Related
 

--- a/snippets/copy-prompt-button.jsx
+++ b/snippets/copy-prompt-button.jsx
@@ -1,9 +1,6 @@
 const { useState, useCallback } = React;
 
-export const CopyPromptButton = () => {
-  const [copied, setCopied] = useState(false);
-
-  const prompt = `# Setup Kernel
+const DEFAULT_PROMPT = `# Setup Kernel
 
 ## Prerequisites
 - Read the kernel-cli skill at https://github.com/kernel/skills/blob/main/plugins/kernel-cli/skills/kernel-cli/SKILL.md for reference on commands and capabilities.
@@ -29,6 +26,9 @@ export const CopyPromptButton = () => {
    - Open that URL in the user's browser.
    - Tell the user they can use the live view immediately.
    - If browser creation fails, stop and ask the user for help.`;
+
+export const CopyPromptButton = ({ prompt = DEFAULT_PROMPT, label = 'copy prompt' } = {}) => {
+  const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -92,7 +92,7 @@ export const CopyPromptButton = () => {
             <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
             <path d="M10.5 5.5V3.5C10.5 2.67 9.83 2 9 2H3.5C2.67 2 2 2.67 2 3.5V9C2 9.83 2.67 10.5 3.5 10.5H5.5" />
           </svg>
-          copy prompt
+          {label}
         </>
       )}
     </button>


### PR DESCRIPTION
## Summary
- Adds `integrations/vercel/foreman.mdx`: an overview of Foreman, what's possible with Foreman + Kernel (Eve extension gives Foreman's implementation agent a real cloud browser for auth-gated bug repro), and a link out to [Foreman's own recipe](https://ask-foreman.dev/recipes/add-the-kernel-browser) for full setup.
- Reuses the same "fast setup" quick-start prompt block from the docs homepage (`CopyPromptButton`).
- Registers the page as the last entry in the Vercel nav group in `docs.json`.

## Test plan
- [x] Validated `docs.json` is valid JSON
- [x] Confirmed `tinker-box` CSS and `CopyPromptButton` snippet are global (not homepage-scoped), so reuse renders correctly
- [ ] Could not run `mintlify dev` / `mintlify broken-links` end-to-end in this sandbox (network-restricted); page structure mirrors the existing `eve-extension.mdx` and homepage prompt block exactly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change plus a small, backward-compatible snippet API. No product, auth, or data-handling logic.
> 
> **Overview**
> Adds a **Foreman** integration page under Vercel docs: how Kernel’s Eve extension gives Foreman’s implementation agent an authenticated cloud browser, with a copyable coding-agent prompt and a link to Foreman’s full recipe.
> 
> `CopyPromptButton` now takes optional `prompt` and `label` so other pages can reuse it; the homepage default prompt is unchanged. The page is registered last in the Vercel nav group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f222cea00544413af879642b175e97e3dc0554e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->