### PR TITLE
Document replay iframe embedding

### DIFF
--- a/browsers/replays.mdx
+++ b/browsers/replays.mdx
@@ -240,11 +240,16 @@ func main() {
 
 ## Embedding a replay
 
-Set an iframe's `src` to the `replay_view_url` returned when you start or list a replay. Give the iframe an explicit aspect ratio so the player keeps its shape while loading, and enable fullscreen playback.
+Set an iframe's `src` to the `replay_view_url` returned when you start or list a replay. Give the iframe an explicit aspect ratio so the player keeps its shape while loading, and enable fullscreen playback. Merge the example's `frame-src` sources into your existing Content Security Policy.
 
 Replace `REPLAY_VIEW_URL` with the URL returned by the API:
 
 ```html
+<meta
+  http-equiv="Content-Security-Policy"
+  content="frame-src https://*.kernel.sh:8443 https://*.onkernel.com:8443 https://kernel-api-prod.s3.us-east-1.amazonaws.com;"
+>
+
 <div style="width: 100%; aspect-ratio: 16 / 10;">
   <iframe
     src="REPLAY_VIEW_URL"
@@ -258,4 +263,4 @@ Replace `REPLAY_VIEW_URL` with the URL returned by the API:
 </div>
 ```
 
-Use the recorded browser's viewport ratio if it differs from `16 / 10`. Treat replay URLs as sensitive. If your application enforces a Content Security Policy, configure `frame-src` to permit every origin used to load the replay.
+Use the recorded browser's viewport ratio if it differs from `16 / 10`. Treat replay URLs as sensitive.

--- a/browsers/replays.mdx
+++ b/browsers/replays.mdx
@@ -237,3 +237,25 @@ func main() {
 }
 ```
 </CodeGroup>
+
+## Embedding a replay
+
+Set an iframe's `src` to the `replay_view_url` returned when you start or list a replay. Give the iframe an explicit aspect ratio so the player keeps its shape while loading, and enable fullscreen playback.
+
+Replace `REPLAY_VIEW_URL` with the URL returned by the API:
+
+```html
+<div style="width: 100%; aspect-ratio: 16 / 10;">
+  <iframe
+    src="REPLAY_VIEW_URL"
+    title="Browser session replay"
+    loading="lazy"
+    referrerpolicy="no-referrer"
+    allow="fullscreen"
+    allowfullscreen
+    style="display: block; width: 100%; height: 100%; border: 0;"
+  ></iframe>
+</div>
+```
+
+Use the recorded browser's viewport ratio if it differs from `16 / 10`. Treat replay URLs as sensitive. If your application enforces a Content Security Policy, configure `frame-src` to permit every origin used to load the replay.


### PR DESCRIPTION
## Description

Adds replay iframe guidance to the existing Replays page, including a responsive HTML example, viewport sizing, fullscreen support, URL handling, and CSP guidance.

## Implementation Checklist

- [x] No sample app changes
- [x] No CLI changes

## Testing

- [x] `mintlify dev` renders `/browsers/replays`
- [x] `git diff --check`

## Visual Proof

Docs-only HTML example; no product UI changes.

## Related Issue

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eed24df7266f8f16c5120d4b04be589c051cf539. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->