### PR TITLE
Add August 21 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,27 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="August 21" tags={["Product", "Docs"]}>
+## Product updates
+
+- Added **org entitlements**: a read-only `GET /org/entitlements` endpoint returning your organization's effective feature access and constraints after applying its plan, active trial treatment, plan status, and any organization-specific overrides. Null constraint values mean unlimited.
+- Added a **`memory` option** when creating a browser: request `16GiB` instead of the default `8GiB` for headful, non-GPU sessions. Every browser now reports its allocation on create, read, list, and pool acquire.
+- Added **customer-configurable OTLP export** for on-demand browser sessions. Create, list, update, and delete project-scoped OTLP/HTTP destinations through the API or [CLI](https://github.com/kernel/cli), then point a session at one with `telemetry.export.otlp.destination` when creating a browser. Destination headers are encrypted at rest and returned redacted. Browser pools do not support export.
+- Expanded [browser telemetry](/browsers/telemetry/overview) with two event types: proxy failures now arrive as first-class `proxy_error` events carrying a typed code instead of being buried in the raw network stream, and the CDP commands that drive the browser — input gestures, navigation, dialogs, file selection, screenshots — are reported as `cdp_command` under the `control` category.
+- [Proxy](/proxies/overview) configurations are now cleaned up automatically. Once an organization has more than 100 active configurations, those unused for 14 days are deleted; anything attached to a session, browser pool, instance, or managed auth connection is retained.
+- Extended the [CLI](https://github.com/kernel/cli) (v0.30.0–v0.31.0) with the `kernel telemetry destinations` command group, `--memory` on `browsers create`, `--proxy-name` / `--proxy-mode` and `--telemetry-export-otlp` across browser and managed auth commands, a new `kernel auth context` for inspecting the principal and scope behind your credentials, `--name` and `--query` filters on the list commands, and a Stagehand v4 project template. Note that `kernel browsers list` changed its column order, so scripts parsing that table positionally need updating.
+
+## Documentation updates
+
+- Added a [Foreman integration guide](/integrations/vercel/foreman) to the Vercel section.
+- Documented [replay iframe embedding](/browsers/replays) for embedding session replays inside your own dashboards.
+- Documented the 30-day retention window for browser telemetry events.
+- Documented automatic [proxy](/proxies/overview) cleanup behavior.
+- Added a print-to-PDF example to the Chrome policies doc.
+- Documented deployment API key lifecycle and the list of reserved env vars that cannot be overridden at deploy time.
+- Updated [Stagehand integration](/integrations/stagehand) docs to v4.
+</Update>
+
 <Update label="August 14" tags={["Product", "Docs"]}>
 ## Product updates
 


### PR DESCRIPTION
## Summary

Adds the August 21 changelog entry, verified line by line against the merged PRs and shipped code rather than the draft list.

Six product bullets and seven documentation bullets. Relative to the draft, four items were dropped and two were adjusted:

**Dropped — not shipped**

- *Humanized computer-use interaction endpoints.* The only merged humanization (Bezier mouse movement, smooth typing, Gaussian jitter) landed in February–April and was announced then. The broader work is still an unmerged planning document, and the current implementation issues multiple `xdotool` calls per request, so the "single call, no added latency" claim does not hold either.
- *Browser Loop release.* The publishable package is `@onkernel/browser-loop`, not `@onkernel/loop`, and nothing is on npm yet — no releases cut, repository not yet renamed. The most recent published package is still `@onkernel/cua-agent` 0.10.0. Worth announcing once the first publish lands, including the CLI retirement, which is a larger breaking change than the agent-class retirement.
- *Chromium 152.0.7977.42.* That is the Chrome for Testing build in the open-source browser images. Production images pin our Chromium fork at `v150.0.7871.114-r3`, which overrides that install, so no customer-visible version changed this week.
- *Fast extension upload endpoint.* Merged and present in the current image, but no control-plane path reaches it — the customer-facing upload endpoint still restarts Chromium. Internal only for now.

**Adjusted**

- *Org entitlements* now covers the API only. The matching CLI command is merged but not in a released build (latest tag is v0.31.0, cut before it merged). Happy to add the CLI half back if v0.32.0 ships before this publishes.
- *Browser telemetry* keeps `proxy_error` and `cdp_command`, both fully wired through to the events API. The captcha task-start and challenge-result events are dropped: only the schema merged, and the producer that emits them is still open, so no session emits them today.
- *Browser sizes* became an accurate `memory` bullet. The shipped API takes `8GiB` (default) or `16GiB` on create, headful and non-GPU only — there is no M/L/XL naming and no storage dimension.

**Added**

- Automatic proxy cleanup on the product side, which is what the new documentation describes.
- A CLI bullet for v0.30.0–v0.31.0, including the `browsers list` column reorder, which breaks scripts that parse that table positionally.

Two link fixes carried over from the draft: the Foreman guide lives at `/integrations/vercel/foreman`, and the telemetry bullet points at `/browsers/telemetry/overview` rather than the stealth page.

## Test plan

- [x] Verified every link in the new entry resolves to a page in this repo
- [x] Confirmed `GET /org/entitlements` and `/telemetry/destinations` return 401 rather than 404 in production, so both are live
- [ ] Did not run `mintlify dev` (network-restricted here); the entry reuses the exact structure of the existing entries and changes no other file

## Follow-ups, not in this PR

- Browser memory is undocumented — no page mentions `8GiB` or `16GiB`, so the feature ships without docs.
- The telemetry categories table is missing `proxy_error` and `cdp_command`.
- The fingerprint-coherence improvements announced on August 14 were reverted in the browser fork. Images still pin the revision that has them, so behavior is unchanged today, but this will need a correction once the fleet picks up the newer revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog text; no product, API, or security code is changed.
> 
> **Overview**
> Adds an **August 21** changelog entry at the top of `changelog.mdx`.
> 
> Product notes cover org entitlements (`GET /org/entitlements`), optional `16GiB` browser memory, customer-configurable OTLP export, `proxy_error` / `cdp_command` telemetry, automatic unused-proxy cleanup, and CLI v0.30.0–v0.31.0 (including a `browsers list` column-order break). Docs notes cover Foreman, replay iframe embedding, telemetry retention, proxy cleanup, Chrome PDF, deploy keys, and Stagehand v4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5a1e285104d27166cf473f251140f1bae3711e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->