### PR TITLE
Fix CopyPromptButton crashing when rendered with no props

### DIFF
--- a/snippets/copy-prompt-button.jsx
+++ b/snippets/copy-prompt-button.jsx
@@ -27,7 +27,8 @@ const DEFAULT_PROMPT = `# Setup Kernel
    - Tell the user they can use the live view immediately.
    - If browser creation fails, stop and ask the user for help.`;
 
-export const CopyPromptButton = ({ prompt = DEFAULT_PROMPT, label = 'copy prompt' } = {}) => {
+export const CopyPromptButton = (props) => {
+  const { prompt = DEFAULT_PROMPT, label = 'copy prompt' } = props || {};
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {


### PR DESCRIPTION
## Summary
- The homepage's `fast setup` copy-prompt button disappeared after #510 refactored `CopyPromptButton` to accept optional `prompt`/`label` props for reuse on the new Foreman page.
- `<CopyPromptButton />` with no attributes renders with `null` props under the classic JSX transform. Destructured parameter defaults (`{ prompt = X } = {}`) only apply when the argument is `undefined`, not `null`, so the no-props call throws and the component renders empty.
- `foreman.mdx` always passes an explicit `prompt` object, so that usage was unaffected — only the homepage broke.

Fix: destructure `prompt`/`label` from `props || {}` inside the function body instead of relying on a parameter-level default, so both `null` and `undefined` fall back correctly.

## Test plan
- [x] Reproduced the exact failure in a Node harness: the old signature throws on `Component(null)`; the new one returns the correct defaults for `null`, `undefined`, and a real props object.
- [x] Confirmed via a live browser session against kernel.sh/docs that the homepage button currently renders as an empty `<div>` with no console errors, consistent with a swallowed render-time exception rather than a network/asset failure.
- [ ] Could not run `mintlify dev` in this sandbox to visually confirm the button reappears (matches the constraint noted in #510).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny UI-only defaulting change in a docs snippet; no auth, data, or API impact.
> 
> **Overview**
> Fixes the homepage copy-prompt button disappearing when rendered as `<CopyPromptButton />` with no attributes.
> 
> Classic JSX can pass `null` props, so parameter defaults (`{ prompt = … } = {}`) never ran and destructuring threw. Defaults are now taken from `props || {}` so `null` and `undefined` both fall back to `DEFAULT_PROMPT` and the default label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46d02c1cc096e049d7a8883dbb9b160181b6c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->