### PR TITLE
Make CopyPromptButton default prompt self-contained again

### DIFF
--- a/snippets/copy-prompt-button.jsx
+++ b/snippets/copy-prompt-button.jsx
@@ -1,6 +1,10 @@
 const { useState, useCallback } = React;
 
-const DEFAULT_PROMPT = `# Setup Kernel
+export const CopyPromptButton = (props) => {
+  const { label = 'copy prompt' } = props || {};
+  const [copied, setCopied] = useState(false);
+
+  const prompt = (props && props.prompt) || `# Setup Kernel
 
 ## Prerequisites
 - Read the kernel-cli skill at https://github.com/kernel/skills/blob/main/plugins/kernel-cli/skills/kernel-cli/SKILL.md for reference on commands and capabilities.
@@ -26,10 +30,6 @@ const DEFAULT_PROMPT = `# Setup Kernel
    - Open that URL in the user's browser.
    - Tell the user they can use the live view immediately.
    - If browser creation fails, stop and ask the user for help.`;
-
-export const CopyPromptButton = (props) => {
-  const { prompt = DEFAULT_PROMPT, label = 'copy prompt' } = props || {};
-  const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- The homepage's copy-prompt button is broken in production with `ReferenceError: DEFAULT_PROMPT is not defined`, thrown from `CopyPromptButton`'s per-page render.
- #510 hoisted the button's default prompt text out of the function body into a module-level `DEFAULT_PROMPT` const so the new Foreman page could override it via props. That constant isn't resolving wherever this snippet gets evaluated per-page, which breaks the homepage's no-props usage while the Foreman page (which always passes an explicit `prompt`) is unaffected.
- #513 fixed a related but different bug (destructuring a `null` props object) without touching where `DEFAULT_PROMPT` lives, so the `ReferenceError` was still live after that merged.

## Fix
Move the default prompt text back inside `CopyPromptButton`'s function body — the same shape it had before #510 — instead of a module-level constant, while keeping the `prompt`/`label` override the Foreman page relies on. No more identifier needs to resolve outside the function's own scope.

## Test plan
- [x] Read through both call sites (`index.mdx` homepage, `integrations/vercel/foreman.mdx`) to confirm the override path still works with only `props.prompt` set and `label` on its default.
- [ ] Could not run `mintlify dev` in this sandbox to visually confirm; the previous fix (#513) looked correct under local JS semantics but didn't reproduce the actual production error, so this should be spot-checked on preview once deployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small docs-snippet scoping fix with no auth, data, or infrastructure impact. Override behavior for explicit `prompt` props is preserved.
> 
> **Overview**
> Fixes a production `ReferenceError: DEFAULT_PROMPT is not defined` on the homepage copy-prompt button.
> 
> Moves the default prompt string back inside `CopyPromptButton` instead of a module-level `DEFAULT_PROMPT`. Callers can still pass `prompt` (Foreman) or omit it (homepage). `label` still defaults when `props` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0754c2840150b1925f90598c8f58c2d7fcc116fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->