### PR TITLE
Document fx MCP setup

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -332,6 +332,7 @@
               "reference/mcp-server/clients/claude",
               "reference/mcp-server/clients/cursor",
               "reference/mcp-server/clients/opencode",
+              "reference/mcp-server/clients/fx",
               "reference/mcp-server/clients/goose",
               "reference/mcp-server/clients/vscode",
               "reference/mcp-server/clients/windsurf",

--- a/reference/cli/mcp.mdx
+++ b/reference/cli/mcp.mdx
@@ -19,6 +19,7 @@ Install Kernel MCP server configuration for a supported AI development tool. Thi
 - `vscode` - Visual Studio Code
 - `goose` - Goose AI
 - `zed` - Zed editor
+- `fx` - fx coding agent
 
 ### Examples
 
@@ -31,6 +32,9 @@ kernel mcp install --target claude
 
 # Install for VS Code
 kernel mcp install --target vscode
+
+# Install for fx
+kernel mcp install --target fx
 ```
 
 ### What It Does
@@ -46,7 +50,7 @@ The `mcp install` command:
 
 The command automatically configures the appropriate transport and settings for each tool:
 
-- **Cursor, Claude Code, VS Code**: Uses HTTP transport (`https://mcp.onkernel.com/mcp`)
+- **Cursor, Claude Code, VS Code, fx**: Uses HTTP transport (`https://mcp.onkernel.com/mcp`)
 - **Claude Desktop, Windsurf, Goose, Zed**: Uses stdio transport via `mcp-remote`
 
 ### Next Steps

--- a/reference/mcp-server.mdx
+++ b/reference/mcp-server.mdx
@@ -35,7 +35,7 @@ The server is a centrally hosted, authenticated remote MCP using OAuth 2.1 with 
     OAuth 2.1 and API key authentication.
   </Card>
   <Card icon="rectangle-terminal" title="Connect your client" href="/reference/mcp-server/clients/claude">
-    Setup for Claude, Cursor, VS Code, and more.
+    Setup for Claude, Cursor, fx, VS Code, and more.
   </Card>
   <Card icon="wrench" title="Tools" href="/reference/mcp-server/tools/manage-browsers">
     Browsers, profiles, proxies, apps, and more.

--- a/reference/mcp-server/clients/fx.mdx
+++ b/reference/mcp-server/clients/fx.mdx
@@ -3,7 +3,17 @@ title: "fx"
 description: "Connect fx to the Kernel MCP server"
 ---
 
-Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
+## Install with the Kernel CLI
+
+Run the following command:
+
+```bash
+kernel mcp install --target fx
+```
+
+## Configure manually
+
+Alternatively, add Kernel to the `mcp` map in `~/.fx/mcp.json`:
 
 ```json
 {
@@ -17,10 +27,17 @@ Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
 }
 ```
 
-In an interactive fx session, reload the configuration and authenticate with Kernel:
+## Connect
+
+Start fx, or reload the configuration in an existing session:
 
 ```text
 /mcp reload
+```
+
+Then authenticate with Kernel:
+
+```text
 /mcp auth kernel --open
 ```
 

--- a/reference/mcp-server/clients/fx.mdx
+++ b/reference/mcp-server/clients/fx.mdx
@@ -1,0 +1,27 @@
+---
+title: "fx"
+description: "Connect fx to the Kernel MCP server"
+---
+
+Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
+
+```json
+{
+  "mcp": {
+    "kernel": {
+      "type": "http",
+      "url": "https://mcp.onkernel.com/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+In an interactive fx session, reload the configuration and authenticate with Kernel:
+
+```text
+/mcp reload
+/mcp auth kernel --open
+```
+
+Authorize access in the browser window that opens. You can then run `/mcp list` to verify that Kernel is connected.


### PR DESCRIPTION
## Summary

- add fx to the MCP client navigation
- document `kernel mcp install --target fx`
- document manual Streamable HTTP and OAuth setup in `~/.fx/mcp.json`
- add fx to the CLI target reference

## Testing

- rendered the fx MCP page with Mintlify locally
- validated `docs.json` as JSON
- ran `git diff --check`