### PR TITLE
Add navigation path recommendation to bot detection guide

### DIFF
--- a/browsers/bot-detection/overview.mdx
+++ b/browsers/bot-detection/overview.mdx
@@ -72,6 +72,7 @@ Once you have a stable baseline, replicate those conditions in your automations.
 | **Headless Mode** | Avoid headless mode. Kernel runs full, rendered browsers by default. |
 | **User Agent Headers** | Don't override headers manually. Let Kernel manage them for minimize mismatches. |
 | **Execution Method** | Prefer our **Playwright Execution API** or **Computer Controls API** over self-hosted Playwright/Puppeteer. |
+| **Navigation Path** | Avoid navigating directly to a deep URL or login page. Start at the site's home page and click through to where you want to go — a real user rarely lands on a deep link with no referrer or prior page views. |
 | **Session Persistence** | Use **Profiles** to retain cookies and local storage between sessions. |
 | **Typing & Scrolling** | Add natural variation to interaction timing. |
 | **Rate Limits** | Many sites monitor request frequency; rapid / concurrent actions can trigger blocking. |


### PR DESCRIPTION
## Summary

Adds a **Navigation Path** row to the Recommended Practices table in the bot detection overview: don't navigate straight to a deep URL or login page — start at the home page and click through, the way a real user would.

Deep-linking with no referrer or prior page views is a signal detection systems weigh, and it's a common pitfall that isn't covered elsewhere in the guide.

Single-row docs change, no code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-row documentation update with no runtime or security impact.
> 
> **Overview**
> Adds a **Navigation Path** row to the Recommended Practices table in the bot detection overview. The guidance tells automations to **start at the site home page and click through** instead of opening deep links or login URLs directly, because missing referrers and prior page views look unlike normal users and can trigger detection.
> 
> No application code changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376e8eb253c0e534c536d995ede9b9e03cea1074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->