### PR TITLE
Add 16GB headful option to pricing calculator

### DIFF
--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -9,7 +9,8 @@ With Kernel, you only pay for what you use and nothing more. You don't pay for i
 | Browser type | Price ($/sec) |
 | --- | --- |
 | Headless | 0.0000166667 |
-| Headful | 0.0001333336 |
+| Headful (8GB) | 0.0001333336 |
+| Headful (16GB) | 0.0002666672 |
 | Headful + GPU acceleration | 0.0008000016 |
 
 > Note: GPU acceleration is only available on headful, on-demand browsers. Standby mode is not supported for GPU-accelerated browsers.

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -5,10 +5,11 @@ export const PricingCalculator = () => {
     const defaults = { plan: 'free', browserType: 'headless', avgSessionLength: 30, numSessions: 100 };
     const planPrices = { free: 0, hobbyist: 30, startup: 200 };
     const usagePrices = 0.0000166667;
-    const browserMultipliers = { headless: 1, headful: 8, headful16: 16, gpu: 48 };
+    const browserMultipliers = { headless: 1, headful: 8, gpu: 48 };
 
     const [plan, setPlan] = useState(defaults.plan);
     const [browserType, setBrowserType] = useState(defaults.browserType);
+    const [headful16, setHeadful16] = useState(false);
     const [avgSessionLength, setAvgSessionLength] = useState(defaults.avgSessionLength);
     const [numSessions, setNumSessions] = useState(defaults.numSessions);
     const [flash, setFlash] = useState(false);
@@ -20,11 +21,12 @@ export const PricingCalculator = () => {
         var url = new URL(window.location);
         url.searchParams.set('plan', plan);
         url.searchParams.set('browserType', browserType);
+        url.searchParams.set('headful16', headful16);
         url.searchParams.set('duration', avgSessionLength);
         url.searchParams.set('sessions', numSessions);
         url.hash = 'pricing-calculator';
         window.history.replaceState(null, '', url);
-    }, [plan, browserType, avgSessionLength, numSessions]);
+    }, [plan, browserType, headful16, avgSessionLength, numSessions]);
 
     const handleBrowserTypeChange = (type) => {
         hasInteracted.current = true;
@@ -32,6 +34,12 @@ export const PricingCalculator = () => {
         if (type === 'gpu' && plan !== 'startup') {
             setPlan('startup');
         }
+    };
+
+    const handleMemoryChange = (is16) => {
+        hasInteracted.current = true;
+        setHeadful16(is16);
+        setBrowserType('headful');
     };
 
     const handlePlanChange = (newPlan) => {
@@ -43,7 +51,7 @@ export const PricingCalculator = () => {
     };
 
     var price = planPrices[plan];
-    var multiplier = browserMultipliers[browserType];
+    var multiplier = browserType === 'headful' ? 8 * (headful16 ? 2 : 1) : browserMultipliers[browserType];
     var usageCost = usagePrices * multiplier * numSessions * avgSessionLength;
 
     var includedUsageCredits = 5;
@@ -77,12 +85,21 @@ export const PricingCalculator = () => {
         paddingRight: '1.5rem',
     };
     const btnStyle = (active) => ({
-        padding: '0.375rem 0.5rem',
+        padding: '0.375rem 0.75rem',
         borderRadius: '0.375rem',
         border: '1px solid var(--btn-border)',
         fontSize: '0.875rem',
         whiteSpace: 'nowrap',
         background: active ? 'var(--btn-selected-bg)' : undefined,
+        cursor: 'pointer',
+    });
+    const memStyle = (active) => ({
+        padding: '0.2rem 0.5rem',
+        border: 'none',
+        fontSize: '0.75rem',
+        whiteSpace: 'nowrap',
+        background: active ? 'var(--btn-selected-bg)' : 'transparent',
+        cursor: 'pointer',
     });
     return (
         <Columns cols={2}>
@@ -103,15 +120,21 @@ export const PricingCalculator = () => {
                     <label style={labelStyle}>Number of sessions</label>
                     <input type="number" style={{...inputStyle}} value={numSessions} onChange={(e) => { hasInteracted.current = true; setNumSessions(parseInt(e.target.value)); }} />
                 </div>
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
-                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful (8GB, default)</button>
-                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful16')} onClick={() => handleBrowserTypeChange('headful16')}>Headful (16GB)</button>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                        <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
+                        <div style={{ display: 'flex', border: '1px solid var(--btn-border)', borderRadius: '0.375rem', overflow: 'hidden' }}>
+                            <button class="btn btn-primary dark:text-white" style={memStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8GB</button>
+                            <button class="btn btn-primary dark:text-white" style={memStyle(headful16)} onClick={() => handleMemoryChange(true)}>16GB</button>
+                        </div>
+                    </div>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>
                 <div style={rowStyle}>
                     <span style={{ width: '100%', fontSize: '0.8rem', fontStyle: 'italic' }}>
                         ${(usagePrices * multiplier).toFixed(8)}/second
+                        {browserType === 'headful' && <span style={{ marginLeft: '0.5rem' }}>({headful16 ? '16GB' : '8GB'})</span>}
                         {browserType === 'gpu' && <span style={{ marginLeft: '0.5rem' }}>(Startup tier required)</span>}
                     </span>
                 </div>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -92,13 +92,14 @@ export const PricingCalculator = () => {
         whiteSpace: 'nowrap',
         background: active ? 'var(--btn-selected-bg)' : undefined,
         cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.15rem',
     });
     const gbStyle = (active) => ({
-        padding: '0.375rem 0.25rem',
-        border: 'none',
+        padding: '0 0.3rem',
         background: 'transparent',
         fontSize: '0.875rem',
-        whiteSpace: 'nowrap',
         cursor: 'pointer',
         color: active ? 'inherit' : 'rgba(128,128,128,0.55)',
     });
@@ -123,9 +124,11 @@ export const PricingCalculator = () => {
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
-                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
-                    <button class="btn btn-primary dark:text-white" style={gbStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8gb</button>
-                    <button class="btn btn-primary dark:text-white" style={gbStyle(headful16)} onClick={() => handleMemoryChange(true)}>16gb</button>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>
+                        Headful
+                        <span style={gbStyle(!headful16)} onClick={(e) => { e.stopPropagation(); handleMemoryChange(false); }}>8gb</span>
+                        <span style={gbStyle(headful16)} onClick={(e) => { e.stopPropagation(); handleMemoryChange(true); }}>16gb</span>
+                    </button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>
                 <div style={rowStyle}>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -94,9 +94,9 @@ export const PricingCalculator = () => {
         cursor: 'pointer',
     });
     const memStyle = (active) => ({
-        padding: '0.2rem 0.5rem',
-        border: 'none',
-        fontSize: '0.75rem',
+        padding: '0.375rem 0.5rem',
+        borderRadius: '0.25rem',
+        fontSize: '0.875rem',
         whiteSpace: 'nowrap',
         background: active ? 'var(--btn-selected-bg)' : 'transparent',
         cursor: 'pointer',
@@ -122,11 +122,12 @@ export const PricingCalculator = () => {
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', border: '1px solid var(--btn-border)', borderRadius: '0.375rem', overflow: 'hidden' }}>
                         <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
-                        <div style={{ display: 'flex', border: '1px solid var(--btn-border)', borderRadius: '0.375rem', overflow: 'hidden' }}>
-                            <button class="btn btn-primary dark:text-white" style={memStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8GB</button>
-                            <button class="btn btn-primary dark:text-white" style={memStyle(headful16)} onClick={() => handleMemoryChange(true)}>16GB</button>
+                        <span style={{ padding: '0 0.25rem', fontSize: '0.75rem', opacity: 0.6 }}>GB:</span>
+                        <div style={{ display: 'flex' }}>
+                            <button class="btn btn-primary dark:text-white" style={memStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8</button>
+                            <button class="btn btn-primary dark:text-white" style={memStyle(headful16)} onClick={() => handleMemoryChange(true)}>16</button>
                         </div>
                     </div>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -77,10 +77,11 @@ export const PricingCalculator = () => {
         paddingRight: '1.5rem',
     };
     const btnStyle = (active) => ({
-        padding: '0.25rem 0.5rem',
+        padding: '0.375rem 0.5rem',
         borderRadius: '0.375rem',
         border: '1px solid var(--btn-border)',
         fontSize: '0.875rem',
+        whiteSpace: 'nowrap',
         background: active ? 'var(--btn-selected-bg)' : undefined,
     });
     return (
@@ -102,11 +103,9 @@ export const PricingCalculator = () => {
                     <label style={labelStyle}>Number of sessions</label>
                     <input type="number" style={{...inputStyle}} value={numSessions} onChange={(e) => { hasInteracted.current = true; setNumSessions(parseInt(e.target.value)); }} />
                 </div>
-                <div style={rowStyle}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful (8GB, default)</button>
-                </div>
-                <div style={rowStyle}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful16')} onClick={() => handleBrowserTypeChange('headful16')}>Headful (16GB)</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -93,13 +93,14 @@ export const PricingCalculator = () => {
         background: active ? 'var(--btn-selected-bg)' : undefined,
         cursor: 'pointer',
     });
-    const memStyle = (active) => ({
-        padding: '0.375rem 0.5rem',
-        borderRadius: '0.25rem',
+    const gbStyle = (active) => ({
+        padding: '0.375rem 0.25rem',
+        border: 'none',
+        background: 'transparent',
         fontSize: '0.875rem',
         whiteSpace: 'nowrap',
-        background: active ? 'var(--btn-selected-bg)' : 'transparent',
         cursor: 'pointer',
+        color: active ? 'inherit' : 'rgba(128,128,128,0.55)',
     });
     return (
         <Columns cols={2}>
@@ -122,14 +123,9 @@ export const PricingCalculator = () => {
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
-                    <div style={{ display: 'flex', alignItems: 'center', border: '1px solid var(--btn-border)', borderRadius: '0.375rem', overflow: 'hidden' }}>
-                        <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
-                        <span style={{ padding: '0 0.25rem', fontSize: '0.75rem', opacity: 0.6 }}>GB:</span>
-                        <div style={{ display: 'flex' }}>
-                            <button class="btn btn-primary dark:text-white" style={memStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8</button>
-                            <button class="btn btn-primary dark:text-white" style={memStyle(headful16)} onClick={() => handleMemoryChange(true)}>16</button>
-                        </div>
-                    </div>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
+                    <button class="btn btn-primary dark:text-white" style={gbStyle(!headful16)} onClick={() => handleMemoryChange(false)}>8gb</button>
+                    <button class="btn btn-primary dark:text-white" style={gbStyle(headful16)} onClick={() => handleMemoryChange(true)}>16gb</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>
                 <div style={rowStyle}>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -5,7 +5,7 @@ export const PricingCalculator = () => {
     const defaults = { plan: 'free', browserType: 'headless', avgSessionLength: 30, numSessions: 100 };
     const planPrices = { free: 0, hobbyist: 30, startup: 200 };
     const usagePrices = 0.0000166667;
-    const browserMultipliers = { headless: 1, headful: 8, gpu: 48 };
+    const browserMultipliers = { headless: 1, headful: 8, headful16: 16, gpu: 48 };
 
     const [plan, setPlan] = useState(defaults.plan);
     const [browserType, setBrowserType] = useState(defaults.browserType);
@@ -104,7 +104,10 @@ export const PricingCalculator = () => {
                 </div>
                 <div style={rowStyle}>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
-                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful (8GB, default)</button>
+                </div>
+                <div style={rowStyle}>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful16')} onClick={() => handleBrowserTypeChange('headful16')}>Headful (16GB)</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>
                 <div style={rowStyle}>


### PR DESCRIPTION
## Summary

The pricing calculator now exposes a 16GB headful browser option, matching the recently enabled 16GB headful sessions.

## Changes

- **`snippets/calculator.jsx`**: added a `headful16` browser type at 16× the base GB-second rate, and split the browser-type buttons into two rows (Headless | Headful 8GB default, then Headful 16GB | Headful + GPU) so four buttons aren't crowded on one line.
- **`info/pricing.mdx`**: relabeled the existing Headful row as `Headful (8GB)` and added a `Headful (16GB)` row at $0.0002666672/sec.

Prices are linear per-GB-second, so 16GB headful = 16 × $0.0000166667 = $0.0002666672/sec.