### PR TITLE
Document organization and project spending caps

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -274,6 +274,7 @@
               "browsers/faq",
               "info/concepts",
               "info/pricing",
+              "info/spending-caps",
               "info/support",
               "info/unikernels",
               "info/zero-data-retention"

--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -4,6 +4,8 @@ title: "Pricing & Limits"
 
 With Kernel, you only pay for what you use and nothing more. You don't pay for idle time thanks to [Standby Mode](/browsers/standby), idle browsers in a browser pool incur no usage charges, and you're never charged for proxies.
 
+Use [Spending Caps](/info/spending-caps) to warn at 80% of a monthly usage limit and pause new browser sessions and app invocations at 100%. You can set one cap across your organization or isolate individual workloads with project caps.
+
 ## Pricing
 
 | Browser type | Price ($/sec) |

--- a/info/projects.mdx
+++ b/info/projects.mdx
@@ -317,6 +317,8 @@ A project's effective cap resolves in this order:
 
 A per-project cap never lets a project exceed your organization's concurrency limit.
 
+Concurrency limits control how many browsers can run at once. To control monthly usage cost instead, see [Spending Caps](/info/spending-caps).
+
 | Method | Path | Description |
 | --- | --- | --- |
 | `GET` | `/org/limits` | Get the org concurrency limit and the default per-project cap |

--- a/info/spending-caps.mdx
+++ b/info/spending-caps.mdx
@@ -1,0 +1,151 @@
+---
+title: "Spending Caps"
+description: "Choose a monthly spending guardrail for your organization, a project, or both"
+---
+
+A retry loop, traffic spike, or long-running agent can raise usage faster than you expect. Spending caps let you decide how much new usage KERNEL can admit each month before it pauses the affected workload.
+
+KERNEL sends a warning when usage reaches 80% of a cap, then pauses new browser sessions and app invocations at 100%. Already-running work continues, and you can still inspect resources, clean them up, or raise the cap.
+
+<Note>
+  Project spending caps are in limited preview. [Contact support](/info/support) if you don't see the project option on your billing page. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
+</Note>
+
+## Choose a cap
+
+<CardGroup cols={2}>
+  <Card title="Organization cap" icon="building">
+    Bound your organization's total out-of-pocket usage spend after monthly credits. When it is reached, new usage pauses across every project.
+
+    Use this as the final guardrail for your KERNEL bill.
+  </Card>
+  <Card title="Project cap" icon="folder">
+    Bound gross usage for one project before organization credits. When it is reached, that project pauses while sibling projects continue.
+
+    Use this to isolate teams, environments, customers, or experiments.
+  </Card>
+</CardGroup>
+
+For most multi-project production setups, use both: an organization cap for the total bill and lower project limits for workloads that need tighter control.
+
+| Behavior | Organization cap | Project cap |
+| --- | --- | --- |
+| Spend measured | Out-of-pocket usage after monthly credits | Gross usage before credits |
+| Scope paused at 100% | Every project in the organization | Only the selected project |
+| Best for | A final billing guardrail | Workload, team, or environment isolation |
+| Quantity | One per organization | One per project |
+
+Subscription fees don't count toward either cap. Spending caps apply to usage charges.
+
+## How spend is counted
+
+### Organization caps
+
+An organization cap measures usage after KERNEL applies your included monthly credits:
+
+```text
+out-of-pocket usage = gross usage - included monthly credits
+```
+
+For example, an organization with \$50 in monthly usage credits sets a \$100 organization cap:
+
+- KERNEL sends the 80% warning at \$130 in gross usage: \$50 in credits plus \$80 in out-of-pocket usage.
+- KERNEL pauses new usage at \$150 in gross usage: \$50 in credits plus the \$100 cap.
+- The plan's subscription fee remains separate.
+
+Choose an organization cap when your main requirement is a predictable maximum for monthly usage charges, regardless of which project creates the spend.
+
+### Project caps
+
+A project cap measures that project's gross usage. Organization credits aren't divided or assigned to individual projects.
+
+For example, a \$25 project cap warns at \$20 and pauses new usage for that project at \$25. Other projects can continue until they reach their own caps or the organization cap is reached.
+
+Requests without an explicit project resolve to your [default project](/info/projects#the-default-project) and count toward that project's cap.
+
+Choose project caps when one workload must not consume an open-ended share of the organization's budget. Common examples include staging, customer-specific automations, and experiments with uncertain retry behavior.
+
+## How enforcement works
+
+<Steps>
+  <Step title="Usage starts a new monthly period">
+    KERNEL evaluates each cap from the first day of the month at 00:00 utc. Organization and project usage accumulate independently.
+  </Step>
+  <Step title="KERNEL warns at 80%">
+    KERNEL sends a warning email for the cap that entered the warning range. Existing and new work continue.
+  </Step>
+  <Step title="New work pauses at 100%">
+    New browser sessions and app invocations return a `403` for the affected scope. An organization cap pauses every project; a project cap pauses only that project.
+  </Step>
+  <Step title="The cap resets next month">
+    New work resumes when the next monthly period starts. An organization admin can also increase or remove the cap from the billing page.
+  </Step>
+</Steps>
+
+When a cap is reached:
+
+- Already-running browser sessions and app invocations continue until they end.
+- Read and delete requests remain available, along with selected non-billable administrative operations such as managing projects, limits, and api keys.
+- Browser pools can maintain idle capacity, but you can't acquire a new browser for a capped scope.
+- Organization members can view cap status. Only organization admins can set, edit, or remove caps.
+
+<Warning>
+  A spending cap is an admission guardrail, not a transactional hard ceiling. Usage is evaluated through billing events, and already-running work can continue adding usage after the threshold is reached. Leave headroom below any budget that must not be exceeded.
+</Warning>
+
+## Layer organization and project caps
+
+Organization and project caps are independent. KERNEL doesn't allocate the organization cap among projects, and project caps don't have to add up to the organization cap.
+
+<Columns cols={3}>
+  <Card title="A project reaches its cap" icon="folder-closed">
+    KERNEL pauses new work for that project. Other projects continue.
+  </Card>
+  <Card title="The organization reaches its cap" icon="building-circle-xmark">
+    KERNEL pauses new work across every project, even if their individual caps have room left.
+  </Card>
+  <Card title="Both thresholds are reached" icon="layer-group">
+    The organization cap takes precedence because it applies to the full organization.
+  </Card>
+</Columns>
+
+If a project cap is higher than the organization cap plus monthly credits, the organization cap can trigger first. The dashboard warns you when you enter that configuration, but it still lets you save it because a later change to credits or the organization cap can change which threshold comes first.
+
+## Recommended setups
+
+### One production workload
+
+Set an organization cap above your normal monthly usage and below the point where an unexpected retry loop becomes expensive. Add a project cap only if you need a tighter boundary for a separate test or staging project.
+
+### Multiple teams or environments
+
+Set one organization cap for the total bill, then give staging, experiments, and each team their own project caps. A noisy project pauses without taking production down with it.
+
+### Customer-specific workloads
+
+Place each customer's resources in a [project](/info/projects), then set project caps according to the workload's expected usage. Keep an organization cap as the final boundary across all customers.
+
+### High-volume production
+
+Use a spending cap for cost and [concurrency limits](/info/pricing#concurrency-limits) for simultaneous capacity. A spending cap doesn't reserve throughput, and a concurrency limit doesn't bound monthly spend.
+
+## Set or update a cap
+
+<Steps>
+  <Step title="Open billing">
+    Go to the [KERNEL billing page](https://dashboard.onkernel.com/billing) as an organization admin.
+  </Step>
+  <Step title="Choose the scope">
+    In **Spending Cap**, select **Organization** or **Project**. For a project cap, select the project you want to control.
+  </Step>
+  <Step title="Set the monthly amount">
+    Enter the usage amount in usd and save. If current month-to-date usage already exceeds a new or reduced cap, the scope can enter the reached state as soon as billing data finishes evaluating.
+  </Step>
+  <Step title="Monitor or adjust it">
+    The card shows month-to-date progress and reached state. Increase, lower, or remove the cap at any time.
+  </Step>
+</Steps>
+
+<Card title="Open billing" icon="credit-card" href="https://dashboard.onkernel.com/billing">
+  Set an organization spending cap or manage the project caps available to your organization.
+</Card>

--- a/info/spending-caps.mdx
+++ b/info/spending-caps.mdx
@@ -41,7 +41,7 @@ Subscription fees don't count toward either cap. Spending caps apply to usage ch
 </Steps>
 
 <Note>
-  Project spending caps are in limited preview. [Contact support](/info/support) if you don't see the project option. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
+  Project spending caps are in limited preview. [Email support@kernel.sh](mailto:support@kernel.sh?subject=Project%20spending%20cap%20access) to request access if you don't see the project option. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
 </Note>
 
 <Card title="Open billing" icon="credit-card" href="https://dashboard.onkernel.com/billing">

--- a/info/spending-caps.mdx
+++ b/info/spending-caps.mdx
@@ -3,133 +3,30 @@ title: "Spending Caps"
 description: "Choose a monthly spending guardrail for your organization, a project, or both"
 ---
 
-A retry loop, traffic spike, or long-running agent can raise usage faster than you expect. Spending caps let you decide how much new usage KERNEL can admit each month before it pauses the affected workload.
+A retry loop, traffic spike, or long-running agent can raise usage faster than you expect. Spending caps warn you before that usage reaches the amount you choose, then pause new work for the affected scope.
 
-KERNEL sends a warning when usage reaches 80% of a cap, then pauses new browser sessions and app invocations at 100%. Already-running work continues, and you can still inspect resources, clean them up, or raise the cap.
+If you only set one cap, start with an organization cap. It protects the total bill. Add project caps when a team, environment, customer, or experiment needs a tighter boundary.
 
-<Note>
-  Project spending caps are in limited preview. [Contact support](/info/support) if you don't see the project option on your billing page. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
-</Note>
-
-## Choose a cap
+## Which cap should you use?
 
 <CardGroup cols={2}>
   <Card title="Organization cap" icon="building">
-    Bound your organization's total out-of-pocket usage spend after monthly credits. When it is reached, new usage pauses across every project.
+    Counts out-of-pocket usage after monthly credits. At 100%, new usage pauses across every project.
 
-    Use this as the final guardrail for your KERNEL bill.
+    Use it as the final guardrail for your KERNEL bill.
   </Card>
   <Card title="Project cap" icon="folder">
-    Bound gross usage for one project before organization credits. When it is reached, that project pauses while sibling projects continue.
+    Counts one project's gross usage before organization credits. At 100%, only that project pauses.
 
-    Use this to isolate teams, environments, customers, or experiments.
+    Use it to isolate a workload, team, environment, or customer.
   </Card>
 </CardGroup>
 
-For most multi-project production setups, use both: an organization cap for the total bill and lower project limits for workloads that need tighter control.
-
-| Behavior | Organization cap | Project cap |
-| --- | --- | --- |
-| Spend measured | Out-of-pocket usage after monthly credits | Gross usage before credits |
-| Scope paused at 100% | Every project in the organization | Only the selected project |
-| Best for | A final billing guardrail | Workload, team, or environment isolation |
-| Quantity | One per organization | One per project |
+Use both for a multi-project production setup: one organization cap for the total bill, plus lower project caps where a single workload needs tighter control.
 
 Subscription fees don't count toward either cap. Spending caps apply to usage charges.
 
-## How spend is counted
-
-### Organization caps
-
-An organization cap measures usage after KERNEL applies your included monthly credits:
-
-```text
-out-of-pocket usage = gross usage - included monthly credits
-```
-
-For example, an organization with \$50 in monthly usage credits sets a \$100 organization cap:
-
-- KERNEL sends the 80% warning at \$130 in gross usage: \$50 in credits plus \$80 in out-of-pocket usage.
-- KERNEL pauses new usage at \$150 in gross usage: \$50 in credits plus the \$100 cap.
-- The plan's subscription fee remains separate.
-
-Choose an organization cap when your main requirement is a predictable maximum for monthly usage charges, regardless of which project creates the spend.
-
-### Project caps
-
-A project cap measures that project's gross usage. Organization credits aren't divided or assigned to individual projects.
-
-For example, a \$25 project cap warns at \$20 and pauses new usage for that project at \$25. Other projects can continue until they reach their own caps or the organization cap is reached.
-
-Requests without an explicit project resolve to your [default project](/info/projects#the-default-project) and count toward that project's cap.
-
-Choose project caps when one workload must not consume an open-ended share of the organization's budget. Common examples include staging, customer-specific automations, and experiments with uncertain retry behavior.
-
-## How enforcement works
-
-<Steps>
-  <Step title="Usage starts a new monthly period">
-    KERNEL evaluates each cap from the first day of the month at 00:00 utc. Organization and project usage accumulate independently.
-  </Step>
-  <Step title="KERNEL warns at 80%">
-    KERNEL sends a warning email for the cap that entered the warning range. Existing and new work continue.
-  </Step>
-  <Step title="New work pauses at 100%">
-    New browser sessions and app invocations return a `403` for the affected scope. An organization cap pauses every project; a project cap pauses only that project.
-  </Step>
-  <Step title="The cap resets next month">
-    New work resumes when the next monthly period starts. An organization admin can also increase or remove the cap from the billing page.
-  </Step>
-</Steps>
-
-When a cap is reached:
-
-- Already-running browser sessions and app invocations continue until they end.
-- Read and delete requests remain available, along with selected non-billable administrative operations such as managing projects, limits, and api keys.
-- Browser pools can maintain idle capacity, but you can't acquire a new browser for a capped scope.
-- Organization members can view cap status. Only organization admins can set, edit, or remove caps.
-
-<Warning>
-  A spending cap is an admission guardrail, not a transactional hard ceiling. Usage is evaluated through billing events, and already-running work can continue adding usage after the threshold is reached. Leave headroom below any budget that must not be exceeded.
-</Warning>
-
-## Layer organization and project caps
-
-Organization and project caps are independent. KERNEL doesn't allocate the organization cap among projects, and project caps don't have to add up to the organization cap.
-
-<Columns cols={3}>
-  <Card title="A project reaches its cap" icon="folder-closed">
-    KERNEL pauses new work for that project. Other projects continue.
-  </Card>
-  <Card title="The organization reaches its cap" icon="building-circle-xmark">
-    KERNEL pauses new work across every project, even if their individual caps have room left.
-  </Card>
-  <Card title="Both thresholds are reached" icon="layer-group">
-    The organization cap takes precedence because it applies to the full organization.
-  </Card>
-</Columns>
-
-If a project cap is higher than the organization cap plus monthly credits, the organization cap can trigger first. The dashboard warns you when you enter that configuration, but it still lets you save it because a later change to credits or the organization cap can change which threshold comes first.
-
-## Recommended setups
-
-### One production workload
-
-Set an organization cap above your normal monthly usage and below the point where an unexpected retry loop becomes expensive. Add a project cap only if you need a tighter boundary for a separate test or staging project.
-
-### Multiple teams or environments
-
-Set one organization cap for the total bill, then give staging, experiments, and each team their own project caps. A noisy project pauses without taking production down with it.
-
-### Customer-specific workloads
-
-Place each customer's resources in a [project](/info/projects), then set project caps according to the workload's expected usage. Keep an organization cap as the final boundary across all customers.
-
-### High-volume production
-
-Use a spending cap for cost and [concurrency limits](/info/pricing#concurrency-limits) for simultaneous capacity. A spending cap doesn't reserve throughput, and a concurrency limit doesn't bound monthly spend.
-
-## Set or update a cap
+## Set a cap
 
 <Steps>
   <Step title="Open billing">
@@ -139,13 +36,111 @@ Use a spending cap for cost and [concurrency limits](/info/pricing#concurrency-l
     In **Spending Cap**, select **Organization** or **Project**. For a project cap, select the project you want to control.
   </Step>
   <Step title="Set the monthly amount">
-    Enter the usage amount in usd and save. If current month-to-date usage already exceeds a new or reduced cap, the scope can enter the reached state as soon as billing data finishes evaluating.
-  </Step>
-  <Step title="Monitor or adjust it">
-    The card shows month-to-date progress and reached state. Increase, lower, or remove the cap at any time.
+    Enter the usage amount in usd and save. The card shows month-to-date progress against the limit.
   </Step>
 </Steps>
+
+<Note>
+  Project spending caps are in limited preview. [Contact support](/info/support) if you don't see the project option. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
+</Note>
 
 <Card title="Open billing" icon="credit-card" href="https://dashboard.onkernel.com/billing">
   Set an organization spending cap or manage the project caps available to your organization.
 </Card>
+
+## What happens during the month
+
+<Steps>
+  <Step title="Usage starts a new period">
+    KERNEL evaluates each cap from the first day of the month at 00:00 utc. Organization and project usage accumulate independently.
+  </Step>
+  <Step title="KERNEL warns at 80%">
+    KERNEL sends a warning email. Existing and new work continue.
+  </Step>
+  <Step title="New work pauses at 100%">
+    New browser sessions and app invocations return a `403` for the affected scope. Running work continues until it ends.
+  </Step>
+  <Step title="The cap resets next month">
+    New work resumes when the next monthly period starts. An organization admin can also increase or remove the cap at any time.
+  </Step>
+</Steps>
+
+<Warning>
+  A spending cap is an admission guardrail, not a transactional hard ceiling. Billing events take time to evaluate, and already-running work can continue adding usage after the threshold is reached. Leave headroom below any budget that must not be exceeded.
+</Warning>
+
+## How spend is counted
+
+<Tabs>
+  <Tab title="Organization cap">
+    An organization cap measures usage after KERNEL applies your included monthly credits:
+
+    ```text
+    out-of-pocket usage = gross usage - included monthly credits
+    ```
+
+    For example, an organization with \$50 in monthly usage credits sets a \$100 cap:
+
+    - KERNEL sends the 80% warning at \$130 in gross usage: \$50 in credits plus \$80 in out-of-pocket usage.
+    - KERNEL pauses new usage at \$150 in gross usage: \$50 in credits plus the \$100 cap.
+    - The plan's subscription fee remains separate.
+
+    Choose this cap when your main requirement is a predictable maximum for monthly usage charges, regardless of which project creates the spend.
+  </Tab>
+  <Tab title="Project cap">
+    A project cap measures that project's gross usage. Organization credits aren't divided or assigned to individual projects.
+
+    For example, a \$25 project cap warns at \$20 and pauses new usage for that project at \$25. Other projects continue until they reach their own caps or the organization cap.
+
+    Requests without an explicit project resolve to your [default project](/info/projects#the-default-project) and count toward that project's cap.
+
+    Choose this cap when one workload must not consume an open-ended share of the organization's budget.
+  </Tab>
+</Tabs>
+
+## Layer organization and project caps
+
+Organization and project caps are independent. KERNEL doesn't allocate the organization cap among projects, and project caps don't have to add up to it.
+
+<Columns cols={3}>
+  <Card title="A project reaches its cap" icon="folder-closed">
+    KERNEL pauses new work for that project. Other projects continue.
+  </Card>
+  <Card title="The organization reaches its cap" icon="building-circle-xmark">
+    KERNEL pauses new work across every project, even if individual project caps have room left.
+  </Card>
+  <Card title="Both thresholds are reached" icon="layer-group">
+    The organization cap takes precedence because it applies to the full organization.
+  </Card>
+</Columns>
+
+If a project cap is higher than the organization cap plus monthly credits, the organization cap can trigger first. The dashboard warns you about this configuration but still lets you save it because later changes to credits or either cap can change which threshold comes first.
+
+## Common setups
+
+| Your setup | Recommended caps |
+| --- | --- |
+| One production workload | Start with an organization cap above normal monthly usage. |
+| Production plus staging or experiments | Use an organization cap, then lower project caps for non-production work. |
+| Multiple teams | Use an organization cap, then project caps to isolate each team's usage. |
+| Customer-specific workloads | Put each customer in a [project](/info/projects), cap each project, and keep an organization cap as the final boundary. |
+
+## Operational details
+
+<Accordion title="What remains available after a cap is reached?">
+  Already-running browser sessions and app invocations continue until they end. Read and delete requests remain available, along with selected non-billable administrative operations such as managing projects, limits, and api keys.
+
+  Browser pools can maintain idle capacity, but you can't acquire a new browser for a capped scope.
+</Accordion>
+
+<Accordion title="What happens if I lower a cap below current usage?">
+  The scope can enter the reached state as soon as billing data finishes evaluating. Raise or remove the cap if you need to resume new work before the next monthly period.
+</Accordion>
+
+<Accordion title="Who can manage caps?">
+  Organization members can view cap status. Only organization admins can set, edit, or remove caps.
+</Accordion>
+
+<Accordion title="How are spending caps different from concurrency limits?">
+  Spending caps bound monthly usage cost. [Concurrency limits](/info/pricing#concurrency-limits) bound simultaneous browser capacity. A spending cap doesn't reserve throughput, and a concurrency limit doesn't bound monthly spend.
+</Accordion>

--- a/info/spending-caps.mdx
+++ b/info/spending-caps.mdx
@@ -41,7 +41,12 @@ Subscription fees don't count toward either cap. Spending caps apply to usage ch
 </Steps>
 
 <Note>
-  Project spending caps are in limited preview. [Email support@kernel.sh](mailto:support@kernel.sh?subject=Project%20spending%20cap%20access) to request access if you don't see the project option. Organization caps are available to self-serve organizations with a payment method. Enterprise availability is limited.
+  Availability varies by scope:
+
+  - **Organization caps:** Available to eligible self-serve organizations. Enterprise access is in limited preview.
+  - **Project caps:** In limited preview for all organizations.
+
+  [Email support@kernel.sh](mailto:support@kernel.sh?subject=Spending%20cap%20preview%20access) to request preview access.
 </Note>
 
 <Card title="Open billing" icon="credit-card" href="https://dashboard.onkernel.com/billing">

--- a/info/spending-caps.mdx
+++ b/info/spending-caps.mdx
@@ -10,12 +10,33 @@ If you only set one cap, start with an organization cap. It protects the total b
 ## Which cap should you use?
 
 <CardGroup cols={2}>
-  <Card title="Organization cap" icon="building">
+  <Card
+    title="Organization cap"
+    icon={
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M10 12h4" />
+        <path d="M10 8h4" />
+        <path d="M14 21v-3a2 2 0 0 0-4 0v3" />
+        <path d="M6 10H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-2" />
+        <path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
+      </svg>
+    }
+  >
     Counts out-of-pocket usage after monthly credits. At 100%, new usage pauses across every project.
 
     Use it as the final guardrail for your KERNEL bill.
   </Card>
-  <Card title="Project cap" icon="folder">
+  <Card
+    title="Project cap"
+    icon={
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+        <path d="M8 10v4" />
+        <path d="M12 10v2" />
+        <path d="M16 10v6" />
+      </svg>
+    }
+  >
     Counts one project's gross usage before organization credits. At 100%, only that project pauses.
 
     Use it to isolate a workload, team, environment, or customer.


### PR DESCRIPTION
## summary

- add a dedicated spending caps guide under info
- compare organization and project cap accounting, scope, and use cases
- document the 80% warning, 100% pause, monthly reset, layered behavior, and enforcement caveats
- use native cards, comparison tables, and step flows instead of a dashboard screenshot that can drift
- link the guide from pricing, projects, and the docs navigation

## testing

- `mint validate`
- `mint broken-links`
- rendered `/info/spending-caps` locally in chromium
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no product code or API behavior modifications.
> 
> **Overview**
> Adds a new **Spending Caps** guide under Info and wires it into the docs nav, **Pricing & Limits**, and **Projects**.
> 
> The guide explains organization vs project caps (out-of-pocket after credits vs per-project gross usage), how to set limits on the billing dashboard, and monthly behavior: **80%** warning email, **100%** pause of new browser sessions and app invocations (`403`), UTC month reset, and layered org/project enforcement. It also covers admission-guardrail caveats, preview availability, recommended setups, and how caps differ from concurrency limits—using Mintlify cards, steps, and tabs instead of dashboard screenshots.
> 
> **Pricing** and **Projects** each gain a short pointer so readers can find cost guardrails without conflating them with simultaneous-browser limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba79803e5c0d0237b942b5cf0dc310942f1b7908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->