### PR TITLE
Add August 28 changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -13,15 +13,12 @@ For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-n
 ## Product updates
 
 - Launched a [bug bounty program](/security-vulnerability-reporting) covering the Kernel API, dashboard, MCP server, and browser infrastructure. The published scope and policy define eligible targets, severity tiers, and safe-harbor terms for security researchers.
-- Rebranded **Site Configs** to **Config Registry** across the API, SDKs (v0.96.0), and dashboard. The prior route and field names are removed, so move integrations to the `/config-registry` resource path. The API is still pre-release: it requires a paid plan and access is granted per organization.
-- Added country-aware config discovery: config lookups now include the exit country so a cached configuration resolved through one country isn't returned to a customer whose proxy allow-list excludes it, and non-US proxies stop returning localized domains for US-scoped sessions.
 - Split browser telemetry into `control` (agent-driven browser actions) and a new opt-in `platform` category for VM-management calls like recording capture, profile save, and telemetry publish. The default capture set is now cleaner and cheaper, and `executePlaywrightCode` events include the submitted code (clipped to 8 KB).
 - Enabled **WebMCP by default** in Kernel browsers and consolidated the browser feature flags into a single feature list, giving agents Model Context Protocol access out of the box without extra configuration.
 - Improved [MCP server](/reference/mcp-server) support for the OpenAI Apps SDK with the required domain verification challenge, so Kernel MCP can be registered as an OpenAI App connector.
 - Added a `submit_feedback` tool to the [MCP server](/reference/mcp-server) for product, MCP, documentation, and general feedback, so agents can report a problem without leaving the session. Submissions are redacted of emails, URLs, and token-shaped values before capture.
-- Added **ap-southeast** as a placement region, served from a new Singapore metro, across the API, dashboard region pickers, and [CLI](https://github.com/kernel/cli). Regional placement is in preview and enabled per organization; contact us to try it.
 - Improved managed auth credential correction: [`@onkernel/managed-auth-react`](https://github.com/kernel/managed-auth-react) surfaces a notice when a field value is rejected, and submitting a corrected value now retries the login instead of failing the flow. Consent prompts are also gated until session initialization completes.
-- Extended the [CLI](https://github.com/kernel/cli) (v0.32.0–v0.33.0) with an `ap-southeast` region option on browser commands and an `fx` MCP install target for one-command setup of the fx MCP.
+- Extended the [CLI](https://github.com/kernel/cli) (v0.32.0–v0.33.0) with an `fx` MCP install target for one-command setup of the fx MCP.
 - Reduced Playwright per-frame overhead by memoizing page target IDs, cutting redundant CDP lookups during multi-step automations.
 - Upgraded [Hypeman](https://docs.hypeman.sh) to Firecracker v1.16.1, picking up upstream snapshot-restore and jailer fixes for the microVM runtime. New instances and snapshots use v1.16.1; existing snapshots keep restoring on the Firecracker version recorded in their metadata.
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,30 @@ import { YouTubeVideo } from '/snippets/youtube-video.mdx';
 For API library updates, see the [Node SDK](https://github.com/onkernel/kernel-node-sdk/blob/main/CHANGELOG.md), [Python SDK](https://github.com/onkernel/kernel-python-sdk/blob/next/CHANGELOG.md), and [Go SDK](https://github.com/onkernel/kernel-go-sdk/blob/main/CHANGELOG.md) changelogs.
 </Note>
 
+<Update label="August 28" tags={["Product", "Docs"]}>
+## Product updates
+
+- Launched a [bug bounty program](/security-vulnerability-reporting) covering the Kernel API, dashboard, MCP server, and browser infrastructure. The published scope and policy define eligible targets, severity tiers, and safe-harbor terms for security researchers.
+- Rebranded **Site Configs** to **Config Registry** across the API, SDKs (v0.96.0), and dashboard. The prior route and field names are removed, so move integrations to the `/config-registry` resource path. The API is still pre-release: it requires a paid plan and access is granted per organization.
+- Added country-aware config discovery: config lookups now include the exit country so a cached configuration resolved through one country isn't returned to a customer whose proxy allow-list excludes it, and non-US proxies stop returning localized domains for US-scoped sessions.
+- Split browser telemetry into `control` (agent-driven browser actions) and a new opt-in `platform` category for VM-management calls like recording capture, profile save, and telemetry publish. The default capture set is now cleaner and cheaper, and `executePlaywrightCode` events include the submitted code (clipped to 8 KB).
+- Enabled **WebMCP by default** in Kernel browsers and consolidated the browser feature flags into a single feature list, giving agents Model Context Protocol access out of the box without extra configuration.
+- Improved [MCP server](/reference/mcp-server) support for the OpenAI Apps SDK with the required domain verification challenge, so Kernel MCP can be registered as an OpenAI App connector.
+- Added a `submit_feedback` tool to the [MCP server](/reference/mcp-server) for product, MCP, documentation, and general feedback, so agents can report a problem without leaving the session. Submissions are redacted of emails, URLs, and token-shaped values before capture.
+- Added **ap-southeast** as a placement region, served from a new Singapore metro, across the API, dashboard region pickers, and [CLI](https://github.com/kernel/cli). Regional placement is in preview and enabled per organization; contact us to try it.
+- Improved managed auth credential correction: [`@onkernel/managed-auth-react`](https://github.com/kernel/managed-auth-react) surfaces a notice when a field value is rejected, and submitting a corrected value now retries the login instead of failing the flow. Consent prompts are also gated until session initialization completes.
+- Extended the [CLI](https://github.com/kernel/cli) (v0.32.0–v0.33.0) with an `ap-southeast` region option on browser commands and an `fx` MCP install target for one-command setup of the fx MCP.
+- Reduced Playwright per-frame overhead by memoizing page target IDs, cutting redundant CDP lookups during multi-step automations.
+- Upgraded [Hypeman](https://docs.hypeman.sh) to Firecracker v1.16.1, picking up upstream snapshot-restore and jailer fixes for the microVM runtime. New instances and snapshots use v1.16.1; existing snapshots keep restoring on the Firecracker version recorded in their metadata.
+
+## Documentation updates
+
+- Documented the new `control` vs `platform` [browser telemetry categories](/browsers/telemetry/categories), including which operations fall into each and how to opt in to platform events.
+- Added a **navigation path recommendation** to the [bot detection guide](/browsers/bot-detection) so agents land on target pages through the flows real users take, rather than deep-linking into gated URLs.
+- Added an [`fx` MCP setup guide](/reference/mcp-server/clients/fx) covering both CLI and MCP installation paths.
+- Made kernel.sh agent-readable: the homepage server-renders with a no-JavaScript fallback, and `llms.txt`, `index.md`, and the OpenAPI, OAuth, and MCP discovery surfaces are published for agents that read the site directly.
+</Update>
+
 <Update label="August 21" tags={["Product", "Docs"]}>
 ## Product updates
 


### PR DESCRIPTION
## Summary

Adds the August 28 changelog entry, covering the week since August 21.

Each line was checked against merged PRs, the deployed API and browser images, published package versions, and live URLs. Three drafted items changed as a result:

- **Dropped the OTLP destination delivery health / circuit breaker item.** Only the storage schema has merged; the PRs that expose `last_export_at`, `last_error_at`, `last_error`, and `consecutive_failures` on destination reads and add the breaker are still open, so nothing is customer-visible yet.
- **Firecracker v1.16.1**: dropped the CVE claim (upstream v1.15.0, v1.16.0, and v1.16.1 release notes list none) and replaced it with the snapshot-restore and jailer fixes that are actually in the range. Added that existing snapshots keep restoring on their recorded version, since there's no in-place migration.
- **WebMCP**: scoped to Kernel browsers generally rather than stealth browsers specifically, matching what shipped.

Other corrections:

- Bug bounty link pointed at a path that doesn't exist; it now points at the published policy page.
- Config Registry linked to a docs page that doesn't exist, so the link is dropped and the paid-plan and per-organization access requirements are stated instead.
- `ap-southeast` was described as a CLI-only addition. It shipped across the API, dashboard, and CLI, and regional placement is enabled per organization, so the item now says both.
- CLI item now cites the version range (v0.32.0-v0.33.0), matching prior entries.
- Telemetry docs link points at the categories page, where the `control` vs `platform` content lives.

Added, having shipped in the window but missing from the draft:

- `submit_feedback` tool on the MCP server.
- Managed auth retries a login when a rejected credential is corrected - the backend half of the rejected-field notice in `@onkernel/managed-auth-react`.
- kernel.sh agent-readable surfaces (`llms.txt`, `index.md`, OpenAPI/OAuth/MCP discovery).

Deliberately left out: project spending caps (internal only), CDP fast extension loading (partial rollout), Config Registry recommendation UI, and bug fixes.

## Testing

Not run locally. All internal links resolve to pages that exist in this repo; the external links were checked live.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds a new **August 28** `<Update>` block at the top of `changelog.mdx`, following the existing Product / Documentation split and `["Product", "Docs"]` tags.
> 
> **Product updates** announce shipped work: a public bug bounty policy, browser telemetry split into default `control` vs opt-in `platform` (with leaner defaults and clipped `executePlaywrightCode` payloads), WebMCP on by default with consolidated feature flags, MCP changes (OpenAI Apps SDK domain verification, new `submit_feedback` with redaction), managed-auth retry on corrected credentials, CLI `fx` MCP install (v0.32.0–v0.33.0), Playwright target-ID memoization, and Hypeman on Firecracker v1.16.1.
> 
> **Documentation updates** link to new or updated guides: telemetry categories, bot-detection navigation guidance, `fx` MCP setup, and kernel.sh agent-readable surfaces (`llms.txt`, `index.md`, discovery endpoints, no-JS homepage fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475d5f3d80bb75e211087eb565bdfadc8b0deae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->