### PR TITLE
Clean up pricing page and align to marketing pricing page

### DIFF
--- a/info/pricing.mdx
+++ b/info/pricing.mdx
@@ -4,15 +4,24 @@ title: "Pricing & Limits"
 
 With Kernel, you only pay for what you use and nothing more. You don't pay for idle time thanks to [Standby Mode](/browsers/standby), idle browsers in a browser pool incur no usage charges, and you're never charged for proxies.
 
-## Pricing
+## Plan Pricing
+| Plan | Monthly cost | Included Credits / mo
+| --- | --- | --- |
+| Developer | Free + usage | $5 |
+| Hobbyist | $30 + usage | $10 | 
+| Start-Up | $200 + usage | $50 | 
+| Enterprise | Custom | Custom |
+
+## Usage Rates
 
 | Browser type | Price ($/sec) |
 | --- | --- |
-| Headless | 0.0000166667 |
 | Headful | 0.0001333336 |
+| Headless | 0.0000166667 |
 | Headful + GPU acceleration | 0.0008000016 |
 
-> Note: GPU acceleration is only available on headful, on-demand browsers. Standby mode is not supported for GPU-accelerated browsers.
+> Included monthly credits apply to usage costs only.
+
 
 ### Pricing calculator
 
@@ -22,9 +31,8 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 
 ## Managed infrastructure
 
-| Feature | Developer (free + usage) | Hobbyist ($30 / mo + usage) | Start-Up ($200 / mo + usage) | Enterprise |
+| Feature | Developer | Hobbyist | Start-Up | Enterprise |
 | --- | --- | --- | --- | --- |
-| Included credits / mo | $5 | $10 | $50 | Custom |
 | Browser live view | ✅ | ✅ | ✅ | ✅ |
 | Extended browser timeouts | ✅ | ✅ | ✅ | ✅ |
 | Browser telemetry | ✅ | ✅ | ✅ | ✅ |
@@ -33,26 +41,25 @@ import { PricingCalculator } from '/snippets/calculator.jsx';
 | Browser profiles | ✅ | ✅ | ✅ | ✅ |
 | File i/o | ✅ | ✅ | ✅ | ✅ |
 | Computer controls API | ✅ | ✅ | ✅ | ✅ |
+| Browser pools | ✅ | ✅ | ✅ | ✅ |
+| SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
 | Browser replays | 1 day | 7 days | 30 days | Custom |
 | Managed auth connections | 3 | unlimited | unlimited | unlimited |
 | Custom browser extensions | 1 | 1 | unlimited | unlimited |
-| Configurable & BYO proxies | ❌ | ❌ | ✅ | ✅ |
-| Browser pools | ✅ | ✅ | ✅ | ✅ |
-| GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | Projects | 1 | 1 | unlimited | unlimited |
-| Support | Discord | Discord | Email | Shared Slack |
-| SOC2 compliance | ✅ | ✅ | ✅ | ✅ |
+| Support | Discord | Email | Email | Shared Slack |
+| Configurable & BYO proxies | ❌ | ❌ | ✅ | ✅ |
+| GPU acceleration | ❌ | ❌ | ✅ | ✅ |
 | Audit log search & export | ❌ | ❌ | ✅ | ✅ |
 | Continuous audit log export to S3 | ❌ | ❌ | ❌ | ✅ |
 | HIPAA compliance (BAA) | ❌ | ❌ | ❌ | ✅ |
 
-> Note: Included monthly credits apply to usage costs only.
 
 ## Concurrency limits
 
 Kernel enforces a single concurrency limit covering all browsers you run at once—whether created on demand with `browsers.create()` or reserved in a [browser pool](/browsers/pools/overview). Your full limit is available to either API in any mix.
 
-| Feature | Developer (free + usage) | Hobbyist ($30 / mo + usage) | Start-Up ($200 / mo + usage) | Enterprise |
+| Feature | Developer | Hobbyist | Start-Up | Enterprise |
 | --- | --- | --- | --- | --- |
 | Concurrent browsers | 5 | 10 | 150 | Custom |
 | App invocations | 5 | 10 | 50 | Custom |
@@ -62,20 +69,7 @@ Kernel enforces a single concurrency limit covering all browsers you run at once
 #### Notes
 - Reserved capacity in a [browser pool](/browsers/pools/overview) counts toward your concurrency limit whether or not the browsers are currently acquired—a pool sized to 40 browsers uses 40 of your limit.
 - Browsers in [Standby Mode](/browsers/standby) count against your concurrency limit.
-- Limits are org-wide by default unless stated otherwise. `Managed auth connections` refer to profiles with active auth connections that Kernel maintains using your stored [Credentials](/auth/credentials) or [1Password connection](/integrations/1password). A single profile can have multiple auth connections (one per domain)—see [Profiles](/auth/profiles#multiple-auth-connections-per-profile) for details.
-
-## Browser pools
-
-With Browser Pools, you pay the standard usage-based price per GB-second while browsers are running. Idle browsers in a pool incur no disk charges—you only pay when a browser is actively in use.
-
-GPU acceleration is not available for browser pools.
-> Note: A [browser pool](/browsers/pools) counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on Start-Up and Enterprise plans.
-
-## Managed Auth
-
-Managed Auth is included on all plans with no per-connection fees. Under the hood, it uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage and concurrency like any other browser session.
-
-Auth sessions are fast (typically 5-30 seconds each). Kernel monitors session health and re-authenticates automatically when sessions expire—most stay valid for days. For example, keeping 100 auth connections logged in typically costs less than $5/month in browser usage.
+- Limits are org-wide by default unless stated otherwise.
 
 
 ## Rate limiting
@@ -93,3 +87,22 @@ Rate-limited endpoints include these headers on every response:
 All Kernel SDKs automatically retry `429` responses up to 2 times, respecting the `Retry-After` header for delay timing. If retries are exhausted, the SDK throws a typed `RateLimitError` with the response headers accessible for custom backoff logic.
 
 If you need higher rate limits, [contact us](https://calendly.com/d/d3tn-5kp-5yt).
+
+## FAQ
+
+<Accordion title="how can i control my team's usage spending?">
+  see this guide on [spending controls](/info/spending-caps).
+</Accordion>
+<Accordion title="How does billing work across a browser's lifecycle? Am I charged for the full timeout_seconds, or only while it's actively in use?">
+  Only for active runtime. `timeout_seconds` sets an idle auto-delete ceiling, not a billing window. Once a browser goes idle — 5 seconds after the last CDP or Live View activity — it enters Standby Mode and stops accruing usage cost, even if it stays alive until the timeout is reached. Deleting a browser early doesn't lower cost any further (idle time is already free), but it does free up your concurrency slot sooner.
+</Accordion>
+<Accordion title="How are browser pools charged?">
+  you pay the standard usage-based price per GB-second while browsers are running. Idle browsers in a pool incur no disk charges—you only pay when a browser is actively in use.
+
+  Note: A browser pool counts toward your concurrency limit whether or not its browsers are currently acquired — a browser pool sized to 40 browsers uses 40 of your limit. Browser pools are available on Start-Up and Enterprise plans.
+</Accordion>
+<Accordion title="How is Managed Auth charged?">
+Managed Auth is included on all plans with no per-connection fees. Under the hood, it uses browser sessions to log in and keep your sessions fresh—these count toward your browser usage and concurrency like any other browser session.
+
+Auth sessions are fast (typically 5-30 seconds each). Kernel monitors session health and re-authenticates automatically when sessions expire—most stay valid for days. For example, keeping 100 auth connections logged in typically costs less than $5/month in browser usage.
+</Accordion>

--- a/snippets/calculator.jsx
+++ b/snippets/calculator.jsx
@@ -2,7 +2,7 @@ const { useState, useEffect, useRef } = React;
 const { Card, Columns } = MintlifyComponents;
 
 export const PricingCalculator = () => {
-    const defaults = { plan: 'free', browserType: 'headless', avgSessionLength: 30, numSessions: 100 };
+    const defaults = { plan: 'free', browserType: 'headful', avgSessionLength: 30, numSessions: 100 };
     const planPrices = { free: 0, hobbyist: 30, startup: 200 };
     const usagePrices = 0.0000166667;
     const browserMultipliers = { headless: 1, headful: 8, gpu: 48 };
@@ -103,8 +103,8 @@ export const PricingCalculator = () => {
                     <input type="number" style={{...inputStyle}} value={numSessions} onChange={(e) => { hasInteracted.current = true; setNumSessions(parseInt(e.target.value)); }} />
                 </div>
                 <div style={rowStyle}>
-                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headful')} onClick={() => handleBrowserTypeChange('headful')}>Headful</button>
+                    <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'headless')} onClick={() => handleBrowserTypeChange('headless')}>Headless</button>
                     <button class="btn btn-primary dark:text-white" style={btnStyle(browserType === 'gpu')} onClick={() => handleBrowserTypeChange('gpu')}>Headful + GPU</button>
                 </div>
                 <div style={rowStyle}>


### PR DESCRIPTION
Feedback to align pricing page to kernel.sh/pricing. Also default to headful, not headless

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and calculator UI defaults only; no product billing or API behavior changes.
> 
> **Overview**
> Restructures **Pricing & Limits** to match the marketing pricing page: adds a **Plan Pricing** table (monthly fee + included credits), renames the per-second section to **Usage Rates** (headful listed first), and simplifies plan column labels in the feature and concurrency tables.
> 
> Moves pool billing, Managed Auth, spending controls, and browser lifecycle billing out of inline sections into a new **FAQ** with accordions; trims the concurrency notes accordingly. The managed-infrastructure matrix is updated (e.g. **Managed stealth mode**, Hobbyist **Email** support, credits row removed in favor of Plan Pricing).
> 
> In `PricingCalculator`, the default browser type is **headful** and the type toggle order puts Headful first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8478c2129241a7794bd9d5608c77da1593f419ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->